### PR TITLE
Multi-component steady Navier-Stokes flow solver

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,6 +65,10 @@ jobs:
         run: |
             cd ${GITHUB_WORKSPACE}/build/test
             ./stokes_dd_mms
+      - name: Test SteadyNS DD solver
+        run: |
+            cd ${GITHUB_WORKSPACE}/build/test
+            ./steady_ns_dd_mms
       - name: Test parametrized problem
         run: |
             cd ${GITHUB_WORKSPACE}/build/test

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -179,6 +179,9 @@ set(scaleupROMObj_SOURCES
   include/stokes_solver.hpp
   src/stokes_solver.cpp
 
+  include/steady_ns_solver.hpp
+  src/steady_ns_solver.cpp
+
   include/input_parser.hpp
   src/input_parser.cpp
 

--- a/include/hyperreduction_integ.hpp
+++ b/include/hyperreduction_integ.hpp
@@ -25,8 +25,8 @@ public:
    const bool precomputable;
 
 protected:
-   HyperReductionIntegrator(const bool precomputable_ = false)
-      : precomputable(precomputable_), NonlinearFormIntegrator() {}
+   HyperReductionIntegrator(const bool precomputable_ = false, const IntegrationRule *ir = NULL)
+      : precomputable(precomputable_), NonlinearFormIntegrator(ir) {}
 
    // removed const qualifier for basis in order to use its column view vector.
    void GetBasisElement(DenseMatrix &basis, const int col,

--- a/include/interfaceinteg.hpp
+++ b/include/interfaceinteg.hpp
@@ -5,17 +5,17 @@
 #ifndef SCALEUPROM_INTERFACE_INTEGRATOR_HPP
 #define SCALEUPROM_INTERFACE_INTEGRATOR_HPP
 
-// #include <fem/bilininteg.hpp>
 #include "mfem.hpp"
+#include "hyperreduction_integ.hpp"
 
 namespace mfem
 {
 
-class InterfaceNonlinearFormIntegrator : public NonlinearFormIntegrator
+class InterfaceNonlinearFormIntegrator : virtual public HyperReductionIntegrator
 {
 protected:
-  InterfaceNonlinearFormIntegrator(const IntegrationRule *ir = NULL)
-      : NonlinearFormIntegrator(ir) {}
+  InterfaceNonlinearFormIntegrator(const bool precomputable_ = false, const IntegrationRule *ir = NULL)
+      : HyperReductionIntegrator(precomputable_, ir) {}
 public:
    // FaceElementTransformations belongs to one mesh (having mesh pointer).
    // In order to extract element/transformation from each mesh,

--- a/include/multiblock_solver.hpp
+++ b/include/multiblock_solver.hpp
@@ -92,6 +92,8 @@ protected:
    // boundary condition is enforced via forcing term.
    Array<Array<SparseMatrix *> *> bdr_mats;
    Array<Array2D<SparseMatrix *> *> port_mats;   // reference ports.
+   // DenseTensor objects from nonlinear operators
+   // will be defined per each derived MultiBlockSolver.
 
 public:
    MultiBlockSolver();
@@ -185,14 +187,14 @@ public:
    void SaveROMElements(const std::string &filename);
    // Save ROM Elements in a hdf5-format file specified with file_id.
    // TODO: add more arguments to support more general data structures of ROM Elements.
-   void SaveCompBdrROMElement(hid_t &file_id);
+   virtual void SaveCompBdrROMElement(hid_t &file_id);
    void SaveBdrROMElement(hid_t &comp_grp_id, const int &comp_idx);
    void SaveInterfaceROMElement(hid_t &file_id);
 
    void LoadROMElements(const std::string &filename);
    // Load ROM Elements in a hdf5-format file specified with file_id.
    // TODO: add more arguments to support more general data structures of ROM Elements.
-   void LoadCompBdrROMElement(hid_t &file_id);
+   virtual void LoadCompBdrROMElement(hid_t &file_id);
    void LoadBdrROMElement(hid_t &comp_grp_id, const int &comp_idx);
    void LoadInterfaceROMElement(hid_t &file_id);
 

--- a/include/multiblock_solver.hpp
+++ b/include/multiblock_solver.hpp
@@ -175,6 +175,10 @@ public:
       InterfaceNonlinearFormIntegrator *interface_integ,
       Array<InterfaceInfo> *interface_infos, Array2D<SparseMatrix*> &mats);
 
+   // Global ROM operator Loading.
+   virtual void LoadROMOperatorFromFile(const std::string input_prefix="")
+   { rom_handler->LoadOperatorFromFile(input_prefix); }
+
    // Component-wise assembly
    void GetComponentFESpaces(Array<FiniteElementSpace *> &comp_fes);
    void AllocateROMElements();

--- a/include/rom_handler.hpp
+++ b/include/rom_handler.hpp
@@ -113,7 +113,7 @@ public:
    void GetBasis(const int &basis_index, const CAROM::Matrix* &basis);
    virtual void GetBasisOnSubdomain(const int &subdomain_index, const CAROM::Matrix* &basis);
    virtual Vector* GetBasisVector(const int &basis_index, const int &column_idx, const int size=-1, const int offset=0)
-   { mfem_error("ROMHandler::GetBasisVector is not supported! Use MFEMROMHandler.\n"); }
+   { mfem_error("ROMHandler::GetBasisVector is not supported! Use MFEMROMHandler.\n"); return NULL; }
    virtual void SetBlockSizes();
    virtual void AllocROMMat();  // allocate matrixes for rom.
    // TODO: extension to nonlinear operators.

--- a/include/rom_handler.hpp
+++ b/include/rom_handler.hpp
@@ -117,8 +117,10 @@ public:
    int GetBasisIndexForSubdomain(const int &subdomain_index);
    void GetBasis(const int &basis_index, const CAROM::Matrix* &basis);
    virtual void GetBasisOnSubdomain(const int &subdomain_index, const CAROM::Matrix* &basis);
-   virtual Vector* GetBasisVector(const int &basis_index, const int &column_idx, const int size=-1, const int offset=0)
-   { mfem_error("ROMHandler::GetBasisVector is not supported! Use MFEMROMHandler.\n"); return NULL; }
+   virtual void GetBasis(const int &basis_index, DenseMatrix* &basis)
+   { mfem_error("ROMHandler::GetBasis only supports CAROM::Matrix! Use MFEMROMHandler.\n"); }
+   virtual void GetBasisOnSubdomain(const int &subdomain_index, DenseMatrix* &basis)
+   { mfem_error("ROMHandler::GetBasis only supports CAROM::Matrix! Use MFEMROMHandler.\n"); }
    virtual void SetBlockSizes();
    virtual void AllocROMMat();  // allocate matrixes for rom.
    // TODO: extension to nonlinear operators.
@@ -196,9 +198,8 @@ public:
    // cannot do const GridFunction* due to librom function definitions.
    // virtual void FormReducedBasis(const int &total_samples);
    virtual void LoadReducedBasis();
-   void GetBasis(const int &basis_index, DenseMatrix* &basis);
-   void GetBasisOnSubdomain(const int &subdomain_index, DenseMatrix* &basis);
-   virtual Vector* GetBasisVector(const int &basis_index, const int &column_idx, const int size=-1, const int offset=0) override;
+   virtual void GetBasis(const int &basis_index, DenseMatrix* &basis) override;
+   virtual void GetBasisOnSubdomain(const int &subdomain_index, DenseMatrix* &basis) override;
    // virtual void AllocROMMat();  // allocate matrixes for rom.
    // TODO: extension to nonlinear operators.
    virtual void ProjectOperatorOnReducedBasis(const Array2D<Operator*> &mats);

--- a/include/rom_handler.hpp
+++ b/include/rom_handler.hpp
@@ -112,6 +112,8 @@ public:
    int GetBasisIndexForSubdomain(const int &subdomain_index);
    void GetBasis(const int &basis_index, const CAROM::Matrix* &basis);
    virtual void GetBasisOnSubdomain(const int &subdomain_index, const CAROM::Matrix* &basis);
+   virtual Vector* GetBasisVector(const int &basis_index, const int &column_idx, const int size=-1, const int offset=0)
+   { mfem_error("ROMHandler::GetBasisVector is not supported! Use MFEMROMHandler.\n"); }
    virtual void SetBlockSizes();
    virtual void AllocROMMat();  // allocate matrixes for rom.
    // TODO: extension to nonlinear operators.
@@ -185,6 +187,7 @@ public:
    virtual void LoadReducedBasis();
    void GetBasis(const int &basis_index, DenseMatrix* &basis);
    void GetBasisOnSubdomain(const int &subdomain_index, DenseMatrix* &basis);
+   virtual Vector* GetBasisVector(const int &basis_index, const int &column_idx, const int size=-1, const int offset=0) override;
    // virtual void AllocROMMat();  // allocate matrixes for rom.
    // TODO: extension to nonlinear operators.
    virtual void ProjectOperatorOnReducedBasis(const Array2D<Operator*> &mats);

--- a/include/steady_ns_solver.hpp
+++ b/include/steady_ns_solver.hpp
@@ -42,7 +42,7 @@ public:
    virtual Operator &GetGradient(const Vector &x) const;
 };
 
-class SteadyNSSolver : virtual public StokesSolver, virtual public Operator
+class SteadyNSSolver : public StokesSolver
 {
 
 friend class ParameterizedProblem;

--- a/include/steady_ns_solver.hpp
+++ b/include/steady_ns_solver.hpp
@@ -1,0 +1,115 @@
+// Copyright 2023 Lawrence Livermore National Security, LLC. See the top-level LICENSE file for details.
+//
+// SPDX-License-Identifier: MIT
+
+#ifndef SCALEUPROM_STEADY_NS_SOLVER_HPP
+#define SCALEUPROM_STEADY_NS_SOLVER_HPP
+
+#include "stokes_solver.hpp"
+
+// By convention we only use mfem namespace as default, not CAROM.
+using namespace mfem;
+
+// A proxy Operator used for Newton Solver.
+class SteadyNSOperator : public Operator
+{
+protected:
+   bool direct_solve;
+
+   Array<int> u_offsets, vblock_offsets;
+   Array<NonlinearForm *> hs;
+   BlockOperator *Hop = NULL;
+
+   BlockMatrix *linearOp = NULL;
+   SparseMatrix *M = NULL, *B = NULL, *Bt = NULL;
+
+   // Jacobian matrix objects
+   mutable BlockMatrix *system_jac = NULL;
+   mutable Array<SparseMatrix *> hs_mats;
+   mutable BlockMatrix *hs_jac = NULL;
+   mutable SparseMatrix *uu_mono = NULL;
+   mutable SparseMatrix *mono_jac = NULL;
+   mutable HypreParMatrix *jac_hypre = NULL;
+
+   HYPRE_BigInt sys_glob_size;
+   mutable HYPRE_BigInt sys_row_starts[2];
+public:
+   SteadyNSOperator(BlockMatrix *linearOp_, Array<NonlinearForm *> &hs_, Array<int> &u_offsets_, const bool direct_solve_=true);
+
+   virtual ~SteadyNSOperator();
+
+   virtual void Mult(const Vector &x, Vector &y) const;
+   virtual Operator &GetGradient(const Vector &x) const;
+};
+
+class SteadyNSSolver : virtual public StokesSolver, virtual public Operator
+{
+
+friend class ParameterizedProblem;
+
+protected:
+   double zeta = 1.0;
+   ConstantCoefficient zeta_coeff;
+
+   // operator for nonlinear convection.
+   Array<NonlinearForm *> hs;
+   
+   // integration rule for nonliear operator.
+   const IntegrationRule *ir_nl = NULL;
+
+   // component ROM element for nonlinear convection.
+   Array<DenseTensor *> comp_tensors;
+
+   Solver *J_solver = NULL;
+   GMRESSolver *J_gmres = NULL;
+   NewtonSolver *newton_solver = NULL;
+
+public:
+   SteadyNSSolver();
+
+   virtual ~SteadyNSSolver();
+
+   // virtual void SetupBCVariables() override;
+   // virtual void AddBCFunction(std::function<void(const Vector &, Vector &)> F, const int battr = -1);
+   // virtual void AddBCFunction(const Vector &F, const int battr = -1);
+   // virtual void InitVariables();
+
+   // void DeterminePressureDirichlet();
+
+   virtual void BuildOperators() override;
+   // virtual void BuildRHSOperators();
+   virtual void BuildDomainOperators();
+   
+   // virtual bool BCExistsOnBdr(const int &global_battr_idx);
+   // virtual void SetupBCOperators() override;
+   // virtual void SetupRHSBCOperators();
+   // virtual void SetupDomainBCOperators();
+
+   virtual void Assemble();
+   // virtual void AssembleRHS();
+   // virtual void AssembleOperator();
+   // // For bilinear case.
+   // // system-specific.
+   // virtual void AssembleInterfaceMatrixes();
+
+   // Component-wise assembly
+   virtual void BuildCompROMElement(Array<FiniteElementSpace *> &fes_comp);
+   // virtual void BuildBdrROMElement(Array<FiniteElementSpace *> &fes_comp);
+   // virtual void BuildInterfaceROMElement(Array<FiniteElementSpace *> &fes_comp);
+   virtual void SaveCompBdrROMElement(hid_t &file_id);
+   virtual void LoadCompBdrROMElement(hid_t &file_id);
+
+   virtual void Solve();
+
+   virtual void ProjectOperatorOnReducedBasis();
+
+   // void SanityCheckOnCoeffs();
+
+   // virtual void SetParameterizedProblem(ParameterizedProblem *problem) override;
+
+   // // to ensure incompressibility for the problems with all velocity dirichlet bc.
+   // void SetComplementaryFlux(const Array<bool> nz_dbcs);
+
+};
+
+#endif

--- a/include/steady_ns_solver.hpp
+++ b/include/steady_ns_solver.hpp
@@ -86,7 +86,7 @@ protected:
    const IntegrationRule *ir_nl = NULL;
 
    // component ROM element for nonlinear convection.
-   Array<DenseTensor *> comp_tensors;
+   Array<DenseTensor *> comp_tensors, subdomain_tensors;
 
    Solver *J_solver = NULL;
    GMRESSolver *J_gmres = NULL;
@@ -104,18 +104,23 @@ public:
 
    virtual void Assemble();
 
+   virtual void LoadROMOperatorFromFile(const std::string input_prefix="");
+
    // Component-wise assembly
    virtual void BuildCompROMElement(Array<FiniteElementSpace *> &fes_comp);
    // virtual void BuildBdrROMElement(Array<FiniteElementSpace *> &fes_comp);
    // virtual void BuildInterfaceROMElement(Array<FiniteElementSpace *> &fes_comp);
-   virtual void SaveCompBdrROMElement(hid_t &file_id);
-   virtual void LoadCompBdrROMElement(hid_t &file_id);
+   virtual void SaveCompBdrROMElement(hid_t &file_id) override;
+   virtual void LoadCompBdrROMElement(hid_t &file_id) override;
 
    virtual void Solve();
 
    virtual void ProjectOperatorOnReducedBasis();
 
    virtual void SolveROM() override;
+
+private:
+   DenseTensor* GetReducedTensor(DenseMatrix *basis, FiniteElementSpace *fespace);
 };
 
 #endif

--- a/include/stokes_solver.hpp
+++ b/include/stokes_solver.hpp
@@ -175,6 +175,8 @@ public:
    // For bilinear case.
    // system-specific.
    virtual void AssembleInterfaceMatrixes();
+   virtual void SetupMUMPSSolver();
+   virtual void SetupPressureMassMatrix();
 
    // Component-wise assembly
    virtual void BuildCompROMElement(Array<FiniteElementSpace *> &fes_comp);

--- a/include/stokes_solver.hpp
+++ b/include/stokes_solver.hpp
@@ -172,6 +172,7 @@ public:
    virtual void Assemble();
    virtual void AssembleRHS();
    virtual void AssembleOperator();
+   virtual void AssembleOperatorBase();   // base function that NS solver inherits.
    // For bilinear case.
    // system-specific.
    virtual void AssembleInterfaceMatrixes();

--- a/src/main_workflow.cpp
+++ b/src/main_workflow.cpp
@@ -6,6 +6,7 @@
 #include "multiblock_solver.hpp"
 #include "poisson_solver.hpp"
 #include "stokes_solver.hpp"
+#include "steady_ns_solver.hpp"
 #include "etc.hpp"
 #include <fstream>
 #include <iostream>
@@ -50,6 +51,7 @@ MultiBlockSolver* InitSolver()
    MultiBlockSolver *solver = NULL;
    if (solver_type == "poisson")       { solver = new PoissonSolver; }
    else if (solver_type == "stokes")   { solver = new StokesSolver; }
+   else if (solver_type == "steady-ns")   { solver = new SteadyNSSolver; }
    else
    {
       printf("Unknown MultiBlockSolver %s!\n", solver_type.c_str());

--- a/src/main_workflow.cpp
+++ b/src/main_workflow.cpp
@@ -301,7 +301,7 @@ double SingleRun(MPI_Comm comm, const std::string output_file)
                case ROMBuildingLevel::GLOBAL:
                {
                   printf("loading operator file.. ");
-                  rom->LoadOperatorFromFile();
+                  test->LoadROMOperatorFromFile();
                   break;
                }
                case ROMBuildingLevel::NONE:
@@ -339,7 +339,7 @@ double SingleRun(MPI_Comm comm, const std::string output_file)
                case ROMBuildingLevel::GLOBAL:
                {
                   printf("loading global operator file.. ");
-                  rom->LoadOperatorFromFile();
+                  test->LoadROMOperatorFromFile();
                   break;
                }
                case ROMBuildingLevel::NONE:

--- a/src/rom_handler.cpp
+++ b/src/rom_handler.cpp
@@ -547,6 +547,18 @@ void MFEMROMHandler::GetBasisOnSubdomain(const int &subdomain_index, DenseMatrix
    GetBasis(idx, basis);
 }
 
+const Vector* MFEMROMHandler::GetBasisVector(
+   const int &basis_index, const int &column_idx, const int size, const int offset)
+{
+   assert(num_basis_sets > 0);
+   assert((basis_index >= 0) && (basis_index < num_basis_sets));
+   assert((column_idx >= 0) && (column_idx < num_basis[basis_index]));
+
+   // This vector does not assume ownership of the basis data.
+   const int vec_size = (size > 0) ? size : spatialbasis[basis_index]->NumRows();
+   return new Vector(spatialbasis[basis_index]->GetColumn(column_idx) + offset, vec_size);
+}
+
 void MFEMROMHandler::ProjectOperatorOnReducedBasis(const Array2D<Operator*> &mats)
 {
    assert(mats.NumRows() == numSub);

--- a/src/rom_handler.cpp
+++ b/src/rom_handler.cpp
@@ -728,6 +728,67 @@ void MFEMROMHandler::Solve(BlockVector* U)
    }
 }
 
+void MFEMROMHandler::NonlinearSolve(Operator &oper, BlockVector* U, Solver *prec)
+{
+   assert(U->NumBlocks() == numSub);
+
+   printf("Solve ROM.\n");
+   reduced_sol = new BlockVector(rom_block_offsets);
+   (*reduced_sol) = 0.0;
+
+   int maxIter = config.GetOption<int>("solver/max_iter", 100);
+   double rtol = config.GetOption<double>("solver/relative_tolerance", 1.e-10);
+   double atol = config.GetOption<double>("solver/absolute_tolerance", 1.e-10);
+   int print_level = config.GetOption<int>("solver/print_level", 0);   
+
+   int jac_maxIter = config.GetOption<int>("solver/jacobian/max_iter", 10000);
+   double jac_rtol = config.GetOption<double>("solver/jacobian/relative_tolerance", 1.e-10);
+   double jac_atol = config.GetOption<double>("solver/jacobian/absolute_tolerance", 1.e-10);
+   int jac_print_level = config.GetOption<int>("solver/jacobian/print_level", -1);
+   std::string prec_str = config.GetOption<std::string>("model_reduction/preconditioner", "none");
+   if (prec_str != "none") assert(prec);
+
+   Solver *J_solver = NULL;
+   if (linsol_type == SolverType::DIRECT)
+   {
+      mumps = new MUMPSSolver();
+      mumps->SetMatrixSymType(mat_type);
+      mumps->SetPrintLevel(jac_print_level);
+      J_solver = mumps;
+   }
+   else
+   {
+      IterativeSolver *iter_solver = SetIterativeSolver(linsol_type, prec_str);
+      iter_solver->SetAbsTol(jac_atol);
+      iter_solver->SetRelTol(jac_rtol);
+      iter_solver->SetMaxIter(jac_maxIter);
+      iter_solver->SetPrintLevel(jac_print_level);
+      if (prec) iter_solver->SetPreconditioner(*prec);
+      J_solver = iter_solver;
+   }
+
+   NewtonSolver newton_solver;
+   newton_solver.SetSolver(*J_solver);
+   newton_solver.SetOperator(oper);
+   newton_solver.SetPrintLevel(print_level); // print Newton iterations
+   newton_solver.SetRelTol(rtol);
+   newton_solver.SetAbsTol(atol);
+   newton_solver.SetMaxIter(maxIter);
+
+   newton_solver.Mult(*reduced_rhs, *reduced_sol);
+
+   for (int i = 0; i < numSub; i++)
+   {
+      assert(U->GetBlock(i).Size() == fom_num_vdofs[i]);
+
+      DenseMatrix* basis_i;
+      GetBasisOnSubdomain(i, basis_i);
+
+      // 23. reconstruct FOM state
+      basis_i->Mult(reduced_sol->GetBlock(i).GetData(), U->GetBlock(i).GetData());
+   }
+}
+
 SparseMatrix* MFEMROMHandler::ProjectOperatorOnReducedBasis(const int &i, const int &j, const Operator *mat)
 {
    assert((i >= 0) && (i < num_basis_sets));
@@ -866,6 +927,12 @@ IterativeSolver* MFEMROMHandler::SetIterativeSolver(const MFEMROMHandler::Solver
          else                    solver = new MINRESSolver();
          break;
       }
+      case (SolverType::GMRES):
+      {
+         if (prec_type == "amg") solver = new GMRESSolver(MPI_COMM_WORLD);
+         else                    solver = new GMRESSolver();
+         break;
+      }
       default:
       {
          mfem_error("Unknown ROM iterative linear solver type!\n");
@@ -878,7 +945,10 @@ IterativeSolver* MFEMROMHandler::SetIterativeSolver(const MFEMROMHandler::Solver
 
 void MFEMROMHandler::SetupDirectSolver()
 {
-   if (linsol_type != MFEMROMHandler::SolverType::DIRECT) return;
+   // If nonlinear mode, Jacobian will keep changing within Solve, thus no need of initial LU factorization.
+   if ((linsol_type != MFEMROMHandler::SolverType::DIRECT) || nonlinear_mode)
+      return;
+
    assert(romMat_mono);
    delete romMat_hypre, mumps;
 

--- a/src/rom_handler.cpp
+++ b/src/rom_handler.cpp
@@ -547,18 +547,6 @@ void MFEMROMHandler::GetBasisOnSubdomain(const int &subdomain_index, DenseMatrix
    GetBasis(idx, basis);
 }
 
-Vector* MFEMROMHandler::GetBasisVector(
-   const int &basis_index, const int &column_idx, const int size, const int offset)
-{
-   assert(num_basis_sets > 0);
-   assert((basis_index >= 0) && (basis_index < num_basis_sets));
-   assert((column_idx >= 0) && (column_idx < num_basis[basis_index]));
-
-   // This vector does not assume ownership of the basis data.
-   const int vec_size = (size > 0) ? size : spatialbasis[basis_index]->NumRows();
-   return new Vector(spatialbasis[basis_index]->GetColumn(column_idx) + offset, vec_size);
-}
-
 void MFEMROMHandler::ProjectOperatorOnReducedBasis(const Array2D<Operator*> &mats)
 {
    assert(mats.NumRows() == numSub);

--- a/src/rom_handler.cpp
+++ b/src/rom_handler.cpp
@@ -547,7 +547,7 @@ void MFEMROMHandler::GetBasisOnSubdomain(const int &subdomain_index, DenseMatrix
    GetBasis(idx, basis);
 }
 
-const Vector* MFEMROMHandler::GetBasisVector(
+Vector* MFEMROMHandler::GetBasisVector(
    const int &basis_index, const int &column_idx, const int size, const int offset)
 {
    assert(num_basis_sets > 0);

--- a/src/steady_ns_solver.cpp
+++ b/src/steady_ns_solver.cpp
@@ -1,0 +1,293 @@
+// Copyright 2023 Lawrence Livermore National Security, LLC. See the top-level LICENSE file for details.
+//
+// SPDX-License-Identifier: MIT
+
+#include "steady_ns_solver.hpp"
+#include "hyperreduction_integ.hpp"
+// #include "input_parser.hpp"
+// #include "hdf5_utils.hpp"
+// #include "linalg_utils.hpp"
+// #include "dg_bilinear.hpp"
+// #include "dg_linear.hpp"
+#include "etc.hpp"
+
+using namespace std;
+using namespace mfem;
+
+/*
+   SteadyNSOperator
+*/
+
+SteadyNSOperator::SteadyNSOperator(BlockMatrix *linearOp_, Array<NonlinearForm *> &hs_, Array<int> &u_offsets_, const bool direct_solve_)
+   : Operator(linearOp_->Height(), linearOp_->Width()), linearOp(linearOp_), hs(hs_), u_offsets(u_offsets_), direct_solve(direct_solve_),
+     M(&(linearOp_->GetBlock(0, 0))), Bt(&(linearOp_->GetBlock(0, 1))), B(&(linearOp_->GetBlock(1, 0)))
+{
+   vblock_offsets.SetSize(3);
+   vblock_offsets[0] = 0;
+   vblock_offsets[1] = u_offsets.Last();
+   vblock_offsets[2] = height;
+
+   // TODO: this needs to be changed for parallel implementation.
+   sys_glob_size = height;
+   sys_row_starts[0] = 0;
+   sys_row_starts[1] = height;
+
+   Hop = new BlockOperator(u_offsets);
+   for (int m = 0; m < hs_.Size(); m++)
+   {
+      assert(hs_[m]);
+      Hop->SetDiagonalBlock(m, hs_[m]);
+   }
+}
+
+SteadyNSOperator::~SteadyNSOperator()
+{
+   delete Hop;
+   delete system_jac;
+   DeletePointers(hs_mats);
+   delete hs_jac;
+   delete uu_mono;
+   delete mono_jac;
+   delete jac_hypre;
+}
+
+void SteadyNSOperator::Mult(const Vector &x, Vector &y) const
+{
+   assert(linearOp);
+   Vector x_u(x.GetData(), u_offsets.Last()), y_u(y.GetData(), u_offsets.Last());
+
+   y = 0.0;
+
+   Hop->Mult(x_u, y_u);
+   linearOp->AddMult(x, y);
+}
+
+Operator& SteadyNSOperator::GetGradient(const Vector &x) const
+{
+   DeletePointers(hs_mats);
+   delete hs_jac;
+   delete uu_mono;
+   delete system_jac;
+   delete mono_jac;
+   delete jac_hypre;
+   
+   const Vector x_u(x.GetData(), u_offsets.Last());
+
+   hs_jac = new BlockMatrix(u_offsets);
+   hs_mats.SetSize(hs.Size());
+   for (int i = 0; i < hs.Size(); i++)
+   {
+      hs_mats[i] = dynamic_cast<SparseMatrix *>(&hs[i]->GetGradient(x_u));
+
+      hs_jac->SetBlock(i, i, hs_mats[i]);
+   }
+   SparseMatrix *hs_jac_mono = hs_jac->CreateMonolithic();
+   uu_mono = Add(*M, *hs_jac_mono);
+   delete hs_jac_mono;
+
+   assert(B && Bt);
+
+   system_jac = new BlockMatrix(vblock_offsets);
+   system_jac->SetBlock(0,0, uu_mono);
+   system_jac->SetBlock(0,1, Bt);
+   system_jac->SetBlock(1,0, B);
+
+   mono_jac = system_jac->CreateMonolithic();
+   if (direct_solve)
+   {
+      jac_hypre = new HypreParMatrix(MPI_COMM_WORLD, sys_glob_size, sys_row_starts, mono_jac);
+      return *jac_hypre;
+   }  
+   else
+      return *mono_jac;
+}
+
+/*
+   SteadyNSSolver
+*/
+
+SteadyNSSolver::SteadyNSSolver()
+   : StokesSolver(), zeta_coeff(zeta)
+{
+   // StokesSolver reads viscosity from stokes/nu.
+   nu = config.GetOption<double>("navier-stokes/nu", 1.0);
+   delete nu_coeff;
+   nu_coeff = new ConstantCoefficient(nu);
+
+   ir_nl = &(IntRules.Get(ufes[0]->GetFE(0)->GetGeomType(), (int)(ceil(1.5 * (2 * ufes[0]->GetMaxElementOrder() - 1)))));
+}
+
+SteadyNSSolver::~SteadyNSSolver()
+{
+   DeletePointers(hs);
+   delete mumps;
+   delete J_gmres;
+   delete newton_solver;
+}
+
+void SteadyNSSolver::BuildOperators()
+{
+   BuildRHSOperators();
+
+   BuildDomainOperators();
+}
+
+void SteadyNSSolver::BuildDomainOperators()
+{
+   StokesSolver::BuildDomainOperators();
+
+   hs.SetSize(numSub);
+   for (int m = 0; m < numSub; m++)
+   {
+      hs[m] = new NonlinearForm(ufes[m]);
+
+      auto nl_integ = new VectorConvectionTrilinearFormIntegrator(zeta_coeff);
+      nl_integ->SetIntRule(ir_nl);
+      hs[m]->AddDomainIntegrator(nl_integ);
+      // if (full_dg)
+      //    hs[m]->AddInteriorFaceIntegrator(new DGVectorDiffusionIntegrator(*nu_coeff, sigma, kappa));
+   }
+}
+
+void SteadyNSSolver::Assemble()
+{
+   StokesSolver::AssembleRHS();
+
+   StokesSolver::AssembleOperator();
+
+   // nonlinear operator?
+}
+
+void SteadyNSSolver::BuildCompROMElement(Array<FiniteElementSpace *> &fes_comp)
+{
+   StokesSolver::BuildCompROMElement(fes_comp);
+
+   const int num_comp = topol_handler->GetNumComponents();
+   comp_tensors.SetSize(num_comp);
+   comp_tensors = NULL;
+
+   for (int c = 0; c < num_comp; c++)
+   {
+      const int fidx = c * num_var;
+      const int nvdofs = fes_comp[fidx]->GetVSize();
+
+      const int num_basis_c = rom_handler->GetNumBasis(c);
+      comp_tensors[c] = new DenseTensor(num_basis_c, num_basis_c, num_basis_c);
+      Vector tmp(nvdofs);
+      DenseMatrix tmp_jk(num_basis_c, num_basis_c);
+
+      // DenseTensor is column major and i is the fastest index. 
+      // For fast iteration, we set k to be the test function index.
+      for (int i = 0; i < num_basis_c; i++)
+      {
+         Vector *u_i = rom_handler->GetBasisVector(c, i, nvdofs);
+         GridFunction ui_gf(fes_comp[fidx], u_i->GetData());
+         VectorGridFunctionCoefficient ui_coeff(&ui_gf);
+
+         NonlinearForm h_comp(fes_comp[fidx]);
+         auto nl_integ_tmp = new VectorConvectionTrilinearFormIntegrator(zeta_coeff, &ui_coeff);
+         nl_integ_tmp->SetIntRule(ir_nl);
+         h_comp.AddDomainIntegrator(nl_integ_tmp);
+         // if (full_dg)
+         //    h_comp.AddInteriorFaceIntegrator(new DGVectorDiffusionIntegrator(*nu_coeff, sigma, kappa));
+
+         for (int j = 0; j < num_basis_c; j++)
+         {
+            Vector *u_j = rom_handler->GetBasisVector(c, j, nvdofs);
+            tmp = 0.0;
+            h_comp.Mult(*u_j, tmp);
+            
+            for (int k = 0; k < num_basis_c; k++)
+            {
+               Vector *u_k = rom_handler->GetBasisVector(c, k, nvdofs);
+               (*comp_tensors[c])(i, j, k) = (*u_k) * tmp;
+            }  // for (int k = 0; k < num_basis_c; k++)
+         }  // for (int j = 0; j < num_basis_c; j++)
+      }  // for (int i = 0; i < num_basis_c; i++)
+   }  // for (int c = 0; c < num_comp; c++)
+}
+
+void SteadyNSSolver::SaveCompBdrROMElement(hid_t &file_id)
+{
+
+}
+
+void SteadyNSSolver::LoadCompBdrROMElement(hid_t &file_id)
+{
+
+}
+
+void SteadyNSSolver::Solve()
+{
+   int maxIter = config.GetOption<int>("solver/max_iter", 100);
+   double rtol = config.GetOption<double>("solver/relative_tolerance", 1.e-15);
+   double atol = config.GetOption<double>("solver/absolute_tolerance", 1.e-15);
+   int print_level = config.GetOption<int>("solver/print_level", 0);
+
+   int jac_maxIter = config.GetOption<int>("solver/jacobian/max_iter", 10000);
+   double jac_rtol = config.GetOption<double>("solver/jacobian/relative_tolerance", 1.e-15);
+   double jac_atol = config.GetOption<double>("solver/jacobian/absolute_tolerance", 1.e-15);
+   int jac_print_level = config.GetOption<int>("solver/jacobian/print_level", -1);
+
+   // same size as var_offsets, but sorted by variables first (then by subdomain).
+   Array<int> offsets_byvar(num_var * numSub + 1);
+   offsets_byvar = 0;
+   for (int k = 0; k < numSub; k++)
+   {
+      offsets_byvar[k+1] = u_offsets[k+1];
+      offsets_byvar[k+1 + numSub] = p_offsets[k+1] + u_offsets.Last();
+   }
+
+   // sort out solution/rhs by variables.
+   BlockVector rhs_byvar(offsets_byvar);
+   BlockVector sol_byvar(offsets_byvar);
+   SortByVariables(*RHS, rhs_byvar);
+   sol_byvar = 0.0;
+
+   SteadyNSOperator oper(systemOp, hs, u_offsets, direct_solve);
+
+   if (direct_solve)
+   {
+      mumps = new MUMPSSolver();
+      mumps->SetMatrixSymType(MUMPSSolver::MatType::UNSYMMETRIC);
+      mumps->SetPrintLevel(jac_print_level);
+      J_solver = mumps;
+   }
+   else
+   {
+      J_gmres = new GMRESSolver;
+      J_gmres->SetAbsTol(jac_atol);
+      J_gmres->SetRelTol(jac_rtol);
+      J_gmres->SetMaxIter(jac_maxIter);
+      J_gmres->SetPrintLevel(jac_print_level);
+      J_solver = J_gmres;
+   }
+
+   newton_solver = new NewtonSolver;
+   newton_solver->SetSolver(*J_solver);
+   newton_solver->SetOperator(oper);
+   newton_solver->SetPrintLevel(print_level); // print Newton iterations
+   newton_solver->SetRelTol(rtol);
+   newton_solver->SetAbsTol(atol);
+   newton_solver->SetMaxIter(maxIter);
+
+   newton_solver->Mult(rhs_byvar, sol_byvar);
+
+   // orthogonalize the pressure.
+   if (!pres_dbc)
+   {
+      Vector pres_view(sol_byvar, vblock_offsets[1], vblock_offsets[2] - vblock_offsets[1]);
+
+      // TODO(kevin): parallelization.
+      double tmp = pres_view.Sum() / pres_view.Size();
+      pres_view -= tmp;
+   }
+
+   SortBySubdomains(sol_byvar, *U);
+}
+
+void SteadyNSSolver::ProjectOperatorOnReducedBasis()
+{
+   StokesSolver::ProjectOperatorOnReducedBasis();
+
+}

--- a/src/stokes_solver.cpp
+++ b/src/stokes_solver.cpp
@@ -367,12 +367,6 @@ void StokesSolver::Assemble()
    AssembleRHS();
 
    AssembleOperator();
-
-   if (direct_solve)
-      SetupMUMPSSolver();
-   else
-      // pressure mass matrix for preconditioner.
-      SetupPressureMassMatrix();
 }
 
 void StokesSolver::AssembleRHS()
@@ -394,6 +388,17 @@ void StokesSolver::AssembleRHS()
 }
 
 void StokesSolver::AssembleOperator()
+{
+   AssembleOperatorBase();
+
+   if (direct_solve)
+      SetupMUMPSSolver();
+   else
+      // pressure mass matrix for preconditioner.
+      SetupPressureMassMatrix();
+}
+
+void StokesSolver::AssembleOperatorBase()
 {
    SanityCheckOnCoeffs();
 
@@ -489,6 +494,7 @@ void StokesSolver::SetupPressureMassMatrix()
 {
    assert(pms.Size() == numSub);
    delete pmMat;
+   delete pM;
 
    pmMat = new BlockMatrix(p_offsets);
    for (int m = 0; m < numSub; m++)
@@ -764,6 +770,7 @@ void StokesSolver::Solve()
          amg_prec->SetSystemsOptions(vdim[0], true);
 
          // pressure mass preconditioner
+         assert(pM);
          p_prec = new GSSmoother(*pM);
          if (!pres_dbc)
          {

--- a/src/stokes_solver.cpp
+++ b/src/stokes_solver.cpp
@@ -367,6 +367,12 @@ void StokesSolver::Assemble()
    AssembleRHS();
 
    AssembleOperator();
+
+   if (direct_solve)
+      SetupMUMPSSolver();
+   else
+      // pressure mass matrix for preconditioner.
+      SetupPressureMassMatrix();
 }
 
 void StokesSolver::AssembleRHS()
@@ -457,34 +463,43 @@ void StokesSolver::AssembleOperator()
    systemOp->SetBlock(0,0, M);
    systemOp->SetBlock(0,1, Bt);
    systemOp->SetBlock(1,0, B);
+}
 
-   if (direct_solve)
+void StokesSolver::SetupMUMPSSolver()
+{
+   assert(systemOp);
+   delete systemOp_mono;
+   delete systemOp_hypre;
+   delete mumps;
+
+   systemOp_mono = systemOp->CreateMonolithic();
+
+   // TODO: need to change when the actual parallelization is implemented.
+   sys_glob_size = systemOp_mono->NumRows();
+   sys_row_starts[0] = 0;
+   sys_row_starts[1] = systemOp_mono->NumRows();
+   systemOp_hypre = new HypreParMatrix(MPI_COMM_WORLD, sys_glob_size, sys_row_starts, systemOp_mono);
+
+   mumps = new MUMPSSolver();
+   mumps->SetMatrixSymType(MUMPSSolver::MatType::SYMMETRIC_POSITIVE_DEFINITE);
+   mumps->SetOperator(*systemOp_hypre);
+}
+
+void StokesSolver::SetupPressureMassMatrix()
+{
+   assert(pms.Size() == numSub);
+   delete pmMat;
+
+   pmMat = new BlockMatrix(p_offsets);
+   for (int m = 0; m < numSub; m++)
    {
-      systemOp_mono = systemOp->CreateMonolithic();
+      assert(pms[m]);
+      pms[m]->Assemble();
+      pms[m]->Finalize();
 
-      // TODO: need to change when the actual parallelization is implemented.
-      sys_glob_size = systemOp_mono->NumRows();
-      sys_row_starts[0] = 0;
-      sys_row_starts[1] = systemOp_mono->NumRows();
-      systemOp_hypre = new HypreParMatrix(MPI_COMM_WORLD, sys_glob_size, sys_row_starts, systemOp_mono);
-
-      mumps = new MUMPSSolver();
-      mumps->SetMatrixSymType(MUMPSSolver::MatType::SYMMETRIC_POSITIVE_DEFINITE);
-      mumps->SetOperator(*systemOp_hypre);
+      pmMat->SetBlock(m, m, &(pms[m]->SpMat()));
    }
-   else
-   {
-      // pressure mass matrix for preconditioner.
-      pmMat = new BlockMatrix(p_offsets);
-      for (int m = 0; m < numSub; m++)
-      {
-         pms[m]->Assemble();
-         pms[m]->Finalize();
-
-         pmMat->SetBlock(m, m, &(pms[m]->SpMat()));
-      }
-      pM = pmMat->CreateMonolithic();
-   }
+   pM = pmMat->CreateMonolithic();
 }
 
 void StokesSolver::AssembleInterfaceMatrixes()

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -30,6 +30,7 @@ file(COPY inputs/test_param_prob.yml DESTINATION ${CMAKE_BINARY_DIR}/test/inputs
 add_executable(test_workflow test_workflow.cpp $<TARGET_OBJECTS:scaleupROMObj>)
 file(COPY inputs/test.base.yml DESTINATION ${CMAKE_BINARY_DIR}/test/inputs)
 file(COPY inputs/stokes.base.yml DESTINATION ${CMAKE_BINARY_DIR}/test/inputs)
+file(COPY inputs/steady_ns.base.yml DESTINATION ${CMAKE_BINARY_DIR}/test/inputs)
 file(COPY meshes/test.2x2.mesh DESTINATION ${CMAKE_BINARY_DIR}/test/meshes)
 
 file(COPY inputs/test.component.yml DESTINATION ${CMAKE_BINARY_DIR}/test/inputs)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -35,6 +35,7 @@ file(COPY meshes/test.2x2.mesh DESTINATION ${CMAKE_BINARY_DIR}/test/meshes)
 
 file(COPY inputs/test.component.yml DESTINATION ${CMAKE_BINARY_DIR}/test/inputs)
 file(COPY inputs/stokes.component.yml DESTINATION ${CMAKE_BINARY_DIR}/test/inputs)
+file(COPY inputs/steady_ns.component.yml DESTINATION ${CMAKE_BINARY_DIR}/test/inputs)
 file(COPY meshes/test.1x1.mesh DESTINATION ${CMAKE_BINARY_DIR}/test/meshes)
 file(COPY meshes/test.global.h5 DESTINATION ${CMAKE_BINARY_DIR}/test/meshes)
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -12,6 +12,7 @@ file(COPY inputs/test.parser.yml DESTINATION ${CMAKE_BINARY_DIR}/test/inputs)
 
 add_executable(poisson_dd_mms poisson_dd_mms.cpp $<TARGET_OBJECTS:scaleupROMObj> $<TARGET_OBJECTS:mmsSuiteObj>)
 add_executable(stokes_dd_mms stokes_dd_mms.cpp $<TARGET_OBJECTS:scaleupROMObj> $<TARGET_OBJECTS:mmsSuiteObj>)
+add_executable(steady_ns_dd_mms steady_ns_dd_mms.cpp $<TARGET_OBJECTS:scaleupROMObj> $<TARGET_OBJECTS:mmsSuiteObj>)
 add_executable(dg_integ_mms dg_integ_mms.cpp $<TARGET_OBJECTS:scaleupROMObj> $<TARGET_OBJECTS:mmsSuiteObj>)
 file(COPY inputs/dd_mms.yml DESTINATION ${CMAKE_BINARY_DIR}/test/inputs)
 file(COPY meshes/dd_mms.mesh DESTINATION ${CMAKE_BINARY_DIR}/test/meshes)

--- a/test/inputs/steady_ns.base.yml
+++ b/test/inputs/steady_ns.base.yml
@@ -1,0 +1,70 @@
+main:
+#mode: run_example/sample_generation/build_rom/single_run
+  solver: steady-ns
+  mode: single_run
+  use_rom: true
+
+mesh:
+  filename: meshes/test.2x2.mesh
+  uniform_refinement: 0
+
+domain-decomposition:
+  type: interior_penalty
+
+discretization:
+  order: 2
+  full-discrete-galerkin: false
+
+solver:
+  relative_tolerance: 1.0e-15
+  absolute_tolerance: 1.0e-15
+  jacobian:
+    relative_tolerance: 1.0e-15
+    absolute_tolerance: 1.0e-15
+
+visualization:
+  enabled: false
+  unified_paraview: true
+  file_path:
+    prefix: sample_gen_output
+
+parameterized_problem:
+  name: stokes_channel
+
+single_run:
+  stokes_channel:
+    nu: 2.5
+
+sample_generation:
+  maximum_number_of_snapshots: 400
+  component_sampling: false
+  file_path:
+    prefix: "ns_channel"
+  parameters:
+    - key: single_run/stokes_channel/nu
+      type: double
+      sample_size: 3
+      minimum: 2.0
+      maximum: 3.0
+
+basis:
+  prefix: "ns0"
+  number_of_basis: 3
+  tags:
+    - name: comp0
+  svd:
+    save_spectrum: true
+    update_right_sv: false
+  visualization:
+    enabled: false
+
+model_reduction:
+  rom_handler_type: mfem
+  # individual/universal
+  subdomain_training: individual
+  save_operator:
+    level: global
+    prefix: "proj_inv"
+  compare_solution:
+    enabled: true
+  solver_type: direct

--- a/test/inputs/steady_ns.component.yml
+++ b/test/inputs/steady_ns.component.yml
@@ -5,8 +5,32 @@ main:
   use_rom: true
 
 mesh:
-  filename: meshes/test.2x2.mesh
-  uniform_refinement: 0
+  type: component-wise
+  uniform_refinement: 2
+  component-wise:
+    global_config: "meshes/test.global.h5"
+    components:
+      - name: "square"
+        file: "meshes/test.1x1.mesh"
+    ports:
+      - name: "port1"
+        file: "meshes/test.port1.h5"
+        comp1:
+          name: "square"
+          attr: 3
+        comp2:
+          name: "square"
+          attr: 1
+        comp2_configuration: [0., 1., 0., 0., 0., 0.]
+      - name: "port2"
+        file: "meshes/test.port2.h5"
+        comp1:
+          name: "square"
+          attr: 2
+        comp2:
+          name: "square"
+          attr: 4
+        comp2_configuration: [1., 0., 0., 0., 0., 0.]
 
 domain-decomposition:
   type: interior_penalty
@@ -34,25 +58,25 @@ parameterized_problem:
 
 single_run:
   stokes_channel:
-    nu: 2.5
+    nu: 2.0
 
 sample_generation:
   maximum_number_of_snapshots: 400
   component_sampling: false
   file_path:
-    prefix: "ns_channel"
+    prefix: "stokes"
   parameters:
     - key: single_run/stokes_channel/nu
       type: double
-      sample_size: 3
+      sample_size: 1
       minimum: 2.0
-      maximum: 3.0
+      maximum: 2.0
 
 basis:
   prefix: "ns0"
-  number_of_basis: 3
+  number_of_basis: 4
   tags:
-    - name: comp0
+    - name: square
   svd:
     save_spectrum: true
     update_right_sv: false
@@ -62,10 +86,10 @@ basis:
 model_reduction:
   rom_handler_type: mfem
   # individual/universal
-  subdomain_training: individual
+  subdomain_training: universal
   save_operator:
-    level: global
-    prefix: "proj_inv"
+    level: component
+    prefix: "test.rom_elem"
   compare_solution:
     enabled: true
-  solver_type: direct
+  solver_type: gmres

--- a/test/mms_suite.cpp
+++ b/test/mms_suite.cpp
@@ -377,7 +377,7 @@ SteadyNSSolver *SolveWithRefinement(const int num_refinement)
 
 void CheckConvergence(const double &threshold)
 {
-   nu = config.GetOption<double>("navier-stokes/nu", 1.0);
+   nu = config.GetOption<double>("stokes/nu", 1.0);
 
    int num_refine = config.GetOption<int>("manufactured_solution/number_of_refinement", 3);
    int base_refine = config.GetOption<int>("manufactured_solution/baseline_refinement", 0);

--- a/test/mms_suite.cpp
+++ b/test/mms_suite.cpp
@@ -302,6 +302,185 @@ void CheckConvergence(const double &threshold)
 
 }  // namespace stokes
 
+namespace steady_ns
+{
+
+void uFun_ex(const Vector & x, Vector & u)
+{
+   double xi(x(0));
+   double yi(x(1));
+   assert(x.Size() == 2);
+
+   u(0) = cos(xi)*sin(yi);
+   u(1) = - sin(xi)*cos(yi);
+}
+
+// Change if needed
+double pFun_ex(const Vector & x)
+{
+   double xi(x(0));
+   double yi(x(1));
+
+   assert(x.Size() == 2);
+
+   return 2.0 * nu * sin(xi)*sin(yi);
+}
+
+void fFun(const Vector & x, Vector & f)
+{
+   assert(x.Size() == 2);
+   f.SetSize(x.Size());
+
+   double xi(x(0));
+   double yi(x(1));
+
+   f(0) = 4.0 * nu * cos(xi) * sin(yi);
+   f(1) = 0.0;
+
+   f(0) += - zeta * sin(xi) * cos(xi);
+   f(1) += - zeta * sin(yi) * cos(yi);
+}
+
+double gFun(const Vector & x)
+{
+   assert(x.Size() == 2);
+
+   return 0.0;
+}
+
+SteadyNSSolver *SolveWithRefinement(const int num_refinement)
+{
+   config.dict_["mesh"]["uniform_refinement"] = num_refinement;
+   SteadyNSSolver *test = new SteadyNSSolver();
+
+   test->InitVariables();
+   test->InitVisualization();
+
+   test->AddBCFunction(uFun_ex);
+   test->AddRHSFunction(fFun);
+   // NOTE(kevin): uFun_ex already satisfies zero divergence.
+   //              no need to set complementary flux.
+   // Array<bool> nz_dbcs(test->GetNumBdr());
+   // nz_dbcs = true;
+   // test->SetComplementaryFlux(nz_dbcs);
+
+   test->BuildOperators();
+
+   test->SetupBCOperators();
+
+   test->Assemble();
+
+   test->Solve();
+
+   return test;
+}
+
+void CheckConvergence(const double &threshold)
+{
+   nu = config.GetOption<double>("navier-stokes/nu", 1.0);
+
+   int num_refine = config.GetOption<int>("manufactured_solution/number_of_refinement", 3);
+   int base_refine = config.GetOption<int>("manufactured_solution/baseline_refinement", 0);
+
+   //printf("Num. Elem.\tRel. v err.\tConv Rate\tNorm\tRel. p err.\tConv Rate\tNorm\n");
+   printf("%10s\t%10s\t%10s\t%10s\t%10s\t%10s\t%10s\n",
+          "Num. Elem.", "Rel v err", "Conv Rate", "Norm", "Rel p err", "Conv Rate", "Norm");
+
+   Vector uconv_rate(num_refine), pconv_rate(num_refine);
+   uconv_rate = 0.0;
+   pconv_rate = 0.0;
+   double uerror1 = 0.0, perror1 = 0.0;
+   for (int r = base_refine; r < num_refine; r++)
+   {
+      SteadyNSSolver *test = SolveWithRefinement(r);
+
+      // Compare with exact solution
+      int dim = test->GetDim();
+      VectorFunctionCoefficient exact_usol(dim, uFun_ex);
+      FunctionCoefficient exact_psol(pFun_ex);
+
+      // For all velocity dirichlet bc, pressure does not have the absolute value.
+      // specify the constant scalar for the reference value.
+      double p_const = 0.0;
+      int ps = 0;
+      for (int k = 0; k < test->GetNumSubdomains(); k++)
+      {
+         GridFunction *pk = test->GetPresGridFunction(k);
+         GridFunction p_ex(*pk);
+         p_ex.ProjectCoefficient(exact_psol);
+         ps += p_ex.Size();
+         p_const += p_ex.Sum();
+         // If p_ex is the view vector of pk, then this will prevent false negative test result.
+         p_ex += 1.0;
+      }
+      p_const /= static_cast<double>(ps);
+
+      for (int k = 0; k < test->GetNumSubdomains(); k++)
+      {
+         GridFunction *pk = test->GetPresGridFunction(k);
+         (*pk) += p_const;
+      }
+
+      int uorder = test->GetVelFEOrder();
+      int porder = test->GetPresFEOrder();
+      int order_quad = max(2, 2*uorder+1);
+      const IntegrationRule *irs[Geometry::NumGeom];
+      for (int i=0; i < Geometry::NumGeom; ++i)
+      {
+         irs[i] = &(IntRules.Get(i, order_quad));
+      }
+
+      int numEl = 0;
+      double unorm = 0.0, pnorm = 0.0;
+      for (int k = 0; k < test->GetNumSubdomains(); k++)
+      {
+         Mesh *mk = test->GetMesh(k);
+         unorm += pow(ComputeLpNorm(2.0, exact_usol, *mk, irs), 2);
+         pnorm += pow(ComputeLpNorm(2.0, exact_psol, *mk, irs), 2);
+         numEl += mk->GetNE();
+      }
+      unorm = sqrt(unorm);
+      pnorm = sqrt(pnorm);
+
+      double uerror = 0.0, perror = 0.0;
+      for (int k = 0; k < test->GetNumSubdomains(); k++)
+      {
+         GridFunction *uk = test->GetVelGridFunction(k);
+         GridFunction *pk = test->GetPresGridFunction(k);
+         uerror += pow(uk->ComputeLpError(2, exact_usol), 2);
+         perror += pow(pk->ComputeLpError(2, exact_psol), 2);
+      }
+      uerror = sqrt(uerror);
+      perror = sqrt(perror);
+
+      uerror /= unorm;
+      perror /= pnorm;
+      
+      if (r > base_refine)
+      {
+         uconv_rate(r) = uerror1 / uerror;
+         pconv_rate(r) = perror1 / perror;
+      }
+      printf("%10d\t%10.5E\t%10.5E\t%10.5E\t%10.5E\t%10.5E\t%10.5E\n", numEl, uerror, uconv_rate(r), unorm, perror, pconv_rate(r), pnorm);
+
+      // reported convergence rate
+      if (r > base_refine)
+      {
+         EXPECT_TRUE(uconv_rate(r) > pow(2.0, uorder+1) - threshold);
+         EXPECT_TRUE(pconv_rate(r) > pow(2.0, porder+1) - threshold);
+      }
+
+      uerror1 = uerror;
+      perror1 = perror;
+
+      delete test;
+   }
+
+   return;
+}
+
+}  // namespace steady_ns
+
 namespace fem
 {
 

--- a/test/mms_suite.hpp
+++ b/test/mms_suite.hpp
@@ -8,6 +8,7 @@
 #include "mfem.hpp"
 #include "poisson_solver.hpp"
 #include "stokes_solver.hpp"
+#include "steady_ns_solver.hpp"
 #include <fstream>
 #include <iostream>
 #include <cmath>
@@ -57,6 +58,22 @@ StokesSolver *SolveWithRefinement(const int num_refinement);
 void CheckConvergence(const double &threshold = 0.1);
 
 }   // namespace stokes
+
+namespace steady_ns
+{
+
+static double nu;
+static const double zeta = 1.0;
+
+void uFun_ex(const Vector & x, Vector & u);
+double pFun_ex(const Vector & x);
+void fFun(const Vector & x, Vector & f);
+double gFun(const Vector & x);
+
+SteadyNSSolver *SolveWithRefinement(const int num_refinement);
+void CheckConvergence(const double &threshold = 1.0);
+
+}   // namespace steady_ns
 
 namespace fem
 {

--- a/test/steady_ns_dd_mms.cpp
+++ b/test/steady_ns_dd_mms.cpp
@@ -1,0 +1,105 @@
+// Copyright 2023 Lawrence Livermore National Security, LLC. See the top-level LICENSE file for details.
+//
+// SPDX-License-Identifier: MIT
+
+#include<gtest/gtest.h>
+#include "mms_suite.hpp"
+
+using namespace std;
+using namespace mfem;
+using namespace mms::steady_ns;
+
+/**
+ * Simple smoke test to make sure Google Test is properly linked
+ */
+TEST(GoogleTestFramework, GoogleTestFrameworkFound) {
+   SUCCEED();
+}
+
+TEST(DDSerialTest, Test_convergence)
+{
+   config = InputParser("inputs/dd_mms.yml");
+   config.dict_["discretization"]["order"] = 1;
+   config.dict_["manufactured_solution"]["number_of_refinement"] = 3;
+   config.dict_["solver"]["jacobian"]["max_iter"] = 20000;
+   CheckConvergence();
+
+   return;
+}
+
+TEST(DDSerialTest, Test_direct_solve)
+{
+   config = InputParser("inputs/dd_mms.yml");
+   config.dict_["discretization"]["order"] = 1;
+   config.dict_["manufactured_solution"]["number_of_refinement"] = 3;
+   config.dict_["solver"]["jacobian"]["max_iter"] = 20000;
+   config.dict_["solver"]["direct_solve"] = true;
+   CheckConvergence();
+
+   return;
+}
+
+TEST(DDSerialTest, Test_componentwise)
+{
+   config = InputParser("inputs/dd_mms.component.yml");
+   config.dict_["discretization"]["order"] = 1;
+   config.dict_["manufactured_solution"]["number_of_refinement"] = 3;
+   config.dict_["solver"]["direct_solve"] = true;
+   CheckConvergence();
+
+   return;
+}
+
+TEST(DDSerialTest, Test_triangle)
+{
+   config = InputParser("inputs/dd_mms.yml");
+   config.dict_["discretization"]["order"] = 1;
+   config.dict_["manufactured_solution"]["number_of_refinement"] = 3;
+   config.dict_["solver"]["max_iter"] = 20000;
+   config.dict_["mesh"]["filename"] = "meshes/square.tri.mesh";
+   config.dict_["solver"]["direct_solve"] = true;
+   CheckConvergence();
+
+   return;
+}
+
+TEST(DDSerialTest, Test_full_dg)
+{
+   config = InputParser("inputs/dd_mms.yml");
+   config.dict_["discretization"]["order"] = 1;
+   config.dict_["manufactured_solution"]["number_of_refinement"] = 3;
+   config.dict_["solver"]["jacobian"]["max_iter"] = 20000;
+   config.dict_["mesh"]["filename"] = "meshes/square.tri.mesh";
+   config.dict_["discretization"]["full-discrete-galerkin"] = true;
+   config.dict_["solver"]["direct_solve"] = true;
+   CheckConvergence(1.0);
+
+   return;
+}
+
+// TODO: Devise 3d incompressible manufactured solution.
+// TEST(DDSerial_component_3D_hex_test, Test_convergence)
+// {
+//    config = InputParser("inputs/dd_mms.comp.3d.yml");
+//    CheckConvergence();
+
+//    return;
+// }
+
+// TEST(DDSerial_component_3D_tet_test, Test_convergence)
+// {
+//    config = InputParser("inputs/dd_mms.comp.3d.yml");
+//    config.dict_["mesh"]["component-wise"]["components"][0]["file"] = "meshes/dd_mms.3d.tet.mesh";
+//    CheckConvergence();
+
+//    return;
+// }
+
+int main(int argc, char* argv[])
+{
+   MPI_Init(&argc, &argv);
+   ::testing::InitGoogleTest(&argc, argv);
+   int result = RUN_ALL_TESTS();
+   MPI_Finalize();
+   return result;
+}

--- a/test/test_workflow.cpp
+++ b/test/test_workflow.cpp
@@ -385,6 +385,35 @@ TEST(Stokes_Workflow, ComponentWiseWithDirectSolve)
    return;
 }
 
+TEST(SteadyNS_Workflow, MFEMIndividualTest)
+{
+   config = InputParser("inputs/steady_ns.base.yml");
+   for (int k = 0; k < 4; k++)
+      config.dict_["basis"]["tags"][k]["name"] = "dom" + std::to_string(k);
+
+   config.dict_["model_reduction"]["rom_handler_type"] = "mfem";
+   config.dict_["model_reduction"]["visualization"]["enabled"] = true;
+   config.dict_["model_reduction"]["visualization"]["prefix"] = "basis_paraview";
+
+   config.dict_["main"]["mode"] = "sample_generation";
+   GenerateSamples(MPI_COMM_WORLD);
+
+   config.dict_["main"]["mode"] = "train_rom";
+   TrainROM(MPI_COMM_WORLD);
+
+   config.dict_["main"]["mode"] = "build_rom";
+   BuildROM(MPI_COMM_WORLD);
+
+   config.dict_["main"]["mode"] = "single_run";
+   double error = SingleRun(MPI_COMM_WORLD);
+
+   // This reproductive case must have a very small error at the level of finite-precision.
+   printf("Error: %.15E\n", error);
+   EXPECT_TRUE(error < stokes_threshold);
+
+   return;
+}
+
 int main(int argc, char* argv[])
 {
    ::testing::InitGoogleTest(&argc, argv);

--- a/test/test_workflow.cpp
+++ b/test/test_workflow.cpp
@@ -414,6 +414,104 @@ TEST(SteadyNS_Workflow, MFEMIndividualTest)
    return;
 }
 
+TEST(SteadyNS_Workflow, MFEMUniversalTest)
+{
+   config = InputParser("inputs/steady_ns.base.yml");
+
+   config.dict_["mesh"]["uniform_refinement"] = 2;
+   config.dict_["discretization"]["order"] = 2;
+   config.dict_["visualization"]["enabled"] = true;
+
+   config.dict_["model_reduction"]["rom_handler_type"] = "mfem";
+   config.dict_["model_reduction"]["visualization"]["enabled"] = true;
+   config.dict_["model_reduction"]["visualization"]["prefix"] = "basis_paraview";
+
+   config.dict_["single_run"]["stokes_channel"]["nu"] = 2.0;
+   config.dict_["sample_generation"]["parameters"][0]["sample_size"] = 1;
+   config.dict_["model_reduction"]["subdomain_training"] = "universal";
+   config.dict_["basis"]["number_of_basis"] = 4;
+
+   // Test save/loadSolution as well.
+   config.dict_["save_solution"]["enabled"] = true;
+   config.dict_["model_reduction"]["compare_solution"]["load_solution"] = true;
+   config.dict_["model_reduction"]["compare_solution"]["fom_solution_file"] = "./sample0_solution.h5";
+   
+   config.dict_["main"]["mode"] = "sample_generation";
+   GenerateSamples(MPI_COMM_WORLD);
+
+   config.dict_["main"]["mode"] = "train_rom";
+   TrainROM(MPI_COMM_WORLD);
+
+   config.dict_["main"]["mode"] = "build_rom";
+   BuildROM(MPI_COMM_WORLD);
+
+   config.dict_["save_solution"]["enabled"] = false;
+   config.dict_["main"]["mode"] = "single_run";
+   double error = SingleRun(MPI_COMM_WORLD);
+
+   // This reproductive case must have a very small error at the level of finite-precision.
+   printf("Error: %.15E\n", error);
+   EXPECT_TRUE(error < stokes_threshold);
+
+   return;
+}
+
+TEST(SteadyNS_Workflow, ComponentWiseTest)
+{
+   config = InputParser("inputs/steady_ns.component.yml");
+
+   printf("\nSample Generation \n\n");
+   
+   config.dict_["main"]["mode"] = "sample_generation";
+   GenerateSamples(MPI_COMM_WORLD);
+
+   config.dict_["main"]["mode"] = "train_rom";
+   TrainROM(MPI_COMM_WORLD);
+
+   printf("\nBuild ROM \n\n");
+
+   config.dict_["main"]["mode"] = "build_rom";
+   BuildROM(MPI_COMM_WORLD);
+
+   config.dict_["main"]["mode"] = "single_run";
+   double error = SingleRun(MPI_COMM_WORLD);
+
+   // This reproductive case must have a very small error at the level of finite-precision.
+   printf("Error: %.15E\n", error);
+   EXPECT_TRUE(error < stokes_threshold);
+
+   return;
+}
+
+TEST(SteadyNS_Workflow, ComponentWiseWithDirectSolve)
+{
+   config = InputParser("inputs/stokes.component.yml");
+   config.dict_["model_reduction"]["linear_solver_type"] = "direct";
+   config.dict_["model_reduction"]["linear_system_type"] = "us";
+
+   printf("\nSample Generation \n\n");
+   
+   config.dict_["main"]["mode"] = "sample_generation";
+   GenerateSamples(MPI_COMM_WORLD);
+
+   config.dict_["main"]["mode"] = "train_rom";
+   TrainROM(MPI_COMM_WORLD);
+
+   printf("\nBuild ROM \n\n");
+
+   config.dict_["main"]["mode"] = "build_rom";
+   BuildROM(MPI_COMM_WORLD);
+
+   config.dict_["main"]["mode"] = "single_run";
+   double error = SingleRun(MPI_COMM_WORLD);
+
+   // This reproductive case must have a very small error at the level of finite-precision.
+   printf("Error: %.15E\n", error);
+   EXPECT_TRUE(error < stokes_threshold);
+
+   return;
+}
+
 int main(int argc, char* argv[])
 {
    ::testing::InitGoogleTest(&argc, argv);

--- a/utils/paraview/comp_system_load.py
+++ b/utils/paraview/comp_system_load.py
@@ -1,3 +1,7 @@
+# Copyright 2023 Lawrence Livermore National Security, LLC. See the top-level LICENSE file for details.
+#
+# SPDX-License-Identifier: MIT
+
 # trace generated using paraview version 5.11.0
 #import paraview
 #paraview.compatibility.major = 5


### PR DESCRIPTION
`SteadyNSSolver` is implemented as a child class of `StokesSolver` that solves for steady Navier-Stokes flow equation.

- As for all other `MultiblockSolver`s, all the necessary steps to solve the nonlinear equation is encapsulated in `SteadyNSSolver::Solve`.


`SteadyNSSolver` currently only supports tensorial ROM.
- Aside from the usual projected matrix, `SteadyNSSolver` also saves/loads the 3rd-order tensors for nonlinear convection operator.
- `MFEMROMHandler::NonlinearSolve` provides a generic solving routine for a nonlinear ROM operator provided by `SteadyNSSolver` (and any other future nonliner `MultiblockSolver`).
- In case of using other nonlinear ROM approaches, developers can define their own nonlinear ROM operator to feed `MFEMROMHandler::NonlinearSolve`.
- `ROMHandler` only keeps the projected linear operator, and any nonlinear ROM operators will be owned by `MultiblockSolver`.