### PR TITLE
Install

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,6 @@
 .DS_Store
 build
 playground
-dependencies
 .vscode
 dump
 *.msh

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,21 +38,46 @@ endif(CMAKE_BUILD_TYPE STREQUAL "Debug")
 option(BUILD_SKETCHES "Build sketch files" OFF)
 
 # # Define variables for use in generating a configure file
-# if(GTEST_FOUND)
-#   set(CAROM_HAS_GTEST 1)
-# endif(GTEST_FOUND)
+set(LIB_DIR "" CACHE PATH "User-defined path to the directory that contains all the prerequisites.")
+set(MFEM_DIR "" CACHE PATH "User-defined path to mfem build.")
+set(HYPRE_DIR "" CACHE PATH "User-defined path to hypre.")
+set(METIS_DIR "" CACHE PATH "User-defined path to metis installation.")
+set(PARMETIS_DIR "" CACHE PATH "User-defined path to parmetis installtion.")
+set(MUMPS_DIR "" CACHE PATH "User-defined path to mumps.")
+set(YAML_DIR "" CACHE PATH "User-defined path to yaml-cpp installation.")
+set(LIBROM_DIR "" CACHE PATH "User-defined path to libROM source.")
 
-# if(BLAS_FOUND)
-#   set(CAROM_HAVE_BLAS 1)
-# endif(BLAS_FOUND)
+# If LIB_DIR is specified and prerequisite path is not specified,
+# then set a default path within LIB_DIR.
+if (NOT (LIB_DIR STREQUAL ""))
+  if (MFEM_DIR STREQUAL "")
+    set(MFEM_DIR "${LIB_DIR}/mfem/build")
+  endif()
 
-# if(LAPACK_FOUND)
-#   set(CAROM_HAVE_LAPACK 1)
-# endif(LAPACK_FOUND)
+  if (HYPRE_DIR STREQUAL "")
+    set(HYPRE_DIR "${LIB_DIR}/hypre")
+  endif()
 
-# if(HDF5_FOUND)
-#   set(CAROM_HAVE_HDF5 1)
-# endif(HDF5_FOUND)
+  if (METIS_DIR STREQUAL "")
+    set(METIS_DIR "${LIB_DIR}/metis-install")
+  endif()
+
+  if (PARMETIS_DIR STREQUAL "")
+    set(PARMETIS_DIR "${LIB_DIR}/parmetis-install")
+  endif()
+
+  if (MUMPS_DIR STREQUAL "")
+    set(MUMPS_DIR "${LIB_DIR}/mumps")
+  endif()
+
+  if (YAML_DIR STREQUAL "")
+    set(YAML_DIR "${LIB_DIR}/yaml-cpp-install")
+  endif()
+
+  if (LIBROM_DIR STREQUAL "")
+    set(LIBROM_DIR "${LIB_DIR}/libROM")
+  endif()
+endif()
 
 # List minimum version requirements for dependencies where possible to make
 # packaging easier later.
@@ -68,7 +93,7 @@ find_package(ZLIB 1.2.3 REQUIRED)
 
 find_package(Doxygen 1.8.5)
 
-find_package(GTest 1.6.0 REQUIRED)
+find_package(GTest 1.6.0)
 
 find_program(GMSH gmsh)
 
@@ -84,7 +109,7 @@ find_path(PARMETIS_INCLUDES metis.h "${METIS_DIR}/include" "${PARMETIS_DIR}/meti
 find_path(MUMPS_INCLUDES dmumps_c.h "${MUMPS_DIR}/include" "${MUMPS_DIR}/build/local/include" "$ENV{MUMPS_DIR}/include" "$ENV{MUMPS_DIR}/build/local/include")
 
 # yaml-cpp library
-find_package(yaml-cpp REQUIRED)
+find_package(yaml-cpp REQUIRED HINTS "${YAML_DIR}" "$ENV{YAML_DIR}")
 # find_library(YAML yaml-cpp HINTS "$ENV{YAML_DIR}/lib")
 # find_path(YAML_INCLUDES yaml.h HINTS "$ENV{YAML_DIR}/include/yaml-cpp")
 
@@ -119,7 +144,6 @@ link_libraries(
   ${METIS}
   ${MUMPS}
   yaml-cpp::yaml-cpp
-  GTest::GTest
   ${LIBROM}
 )
 
@@ -217,7 +241,10 @@ add_library(scaleupROMObj OBJECT ${scaleupROMObj_SOURCES})
 
 add_subdirectory(bin)
 add_subdirectory(utils)
-add_subdirectory(test)
+if (GTEST_FOUND)
+  link_libraries(GTest::GTest)
+  add_subdirectory(test)
+endif()
 add_subdirectory(examples)
 if(BUILD_SKETCHES)
   add_subdirectory(sketches)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,15 +73,15 @@ find_package(GTest 1.6.0 REQUIRED)
 find_program(GMSH gmsh)
 
 # MFEM is required.
-find_library(MFEM mfem "$ENV{MFEM_DIR}/lib")
-find_library(HYPRE HYPRE "$ENV{HYPRE_DIR}/lib")
-find_library(PARMETIS parmetis "$ENV{PARMETIS_DIR}/lib")
-find_library(METIS metis "$ENV{METIS_DIR}/lib")
-find_library(MUMPS dmumps "$ENV{MUMPS_DIR}/lib")
-find_path(MFEM_INCLUDES mfem.hpp "$ENV{MFEM_DIR}/include")
-find_path(HYPRE_INCLUDES HYPRE.h "$ENV{HYPRE_DIR}/include")
-find_path(PARMETIS_INCLUDES metis.h "$ENV{PARMETIS_DIR}/metis/include")
-find_path(MUMPS_INCLUDES dmumps_c.h "$ENV{MUMPS_DIR}/include")
+find_library(MFEM mfem "${MFEM_DIR}" "${MFEM_DIR}/build" "${MFEM_DIR}/lib" "${MFEM_DIR}/build/lib" "$ENV{MFEM_DIR}" "$ENV{MFEM_DIR}/build" "$ENV{MFEM_DIR}/lib" "$ENV{MFEM_DIR}/build/lib")
+find_library(HYPRE HYPRE "${HYPRE_DIR}/lib" "${HYPRE_DIR}/src/hypre/lib" "$ENV{HYPRE_DIR}/lib" "$ENV{HYPRE_DIR}/src/hypre/lib")
+find_library(PARMETIS parmetis "${PARMETIS_DIR}/lib" "$ENV{PARMETIS_DIR}/lib")
+find_library(METIS metis "${METIS_DIR}/lib" "$ENV{METIS_DIR}/lib")
+find_library(MUMPS dmumps "${MUMPS_DIR}/lib" "${MUMPS_DIR}/build/local/lib" "$ENV{MUMPS_DIR}/lib" "$ENV{MUMPS_DIR}/build/local/lib")
+find_path(MFEM_INCLUDES mfem.hpp "${MFEM_DIR}" "${MFEM_DIR}/build" "${MFEM_DIR}/include" "${MFEM_DIR}/build/include" "$ENV{MFEM_DIR}" "$ENV{MFEM_DIR}/build" "$ENV{MFEM_DIR}/include" "$ENV{MFEM_DIR}/build/include")
+find_path(HYPRE_INCLUDES HYPRE.h "${HYPRE_DIR}/include" "${HYPRE_DIR}/src/hypre/include" "$ENV{HYPRE_DIR}/include" "$ENV{HYPRE_DIR}/src/hypre/include")
+find_path(PARMETIS_INCLUDES metis.h "${METIS_DIR}/include" "${PARMETIS_DIR}/metis/include" "$ENV{METIS_DIR}/include"  "$ENV{PARMETIS_DIR}/metis/include")
+find_path(MUMPS_INCLUDES dmumps_c.h "${MUMPS_DIR}/include" "${MUMPS_DIR}/build/local/include" "$ENV{MUMPS_DIR}/include" "$ENV{MUMPS_DIR}/build/local/include")
 
 # yaml-cpp library
 find_package(yaml-cpp REQUIRED)
@@ -89,8 +89,8 @@ find_package(yaml-cpp REQUIRED)
 # find_path(YAML_INCLUDES yaml.h HINTS "$ENV{YAML_DIR}/include/yaml-cpp")
 
 # libROM
-find_library(LIBROM libROM.so HINTS "$ENV{LIBROM_DIR}/build/lib")
-find_path(LIBROM_INCLUDES librom.h HINTS "$ENV{LIBROM_DIR}/lib")
+find_library(LIBROM libROM.so HINTS "${LIBROM_DIR}/build/lib" "$ENV{LIBROM_DIR}/build/lib")
+find_path(LIBROM_INCLUDES librom.h HINTS "${LIBROM_DIR}/lib" "$ENV{LIBROM_DIR}/lib")
 
 include_directories(
   include

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -84,8 +84,9 @@ find_path(PARMETIS_INCLUDES metis.h "$ENV{PARMETIS_DIR}/metis/include")
 find_path(MUMPS_INCLUDES dmumps_c.h "$ENV{MUMPS_DIR}/include")
 
 # yaml-cpp library
-find_library(YAML yaml-cpp HINTS "$ENV{YAML_DIR}/lib")
-find_path(YAML_INCLUDES yaml.h HINTS "$ENV{YAML_DIR}/include/yaml-cpp")
+find_package(yaml-cpp REQUIRED)
+# find_library(YAML yaml-cpp HINTS "$ENV{YAML_DIR}/lib")
+# find_path(YAML_INCLUDES yaml.h HINTS "$ENV{YAML_DIR}/include/yaml-cpp")
 
 # libROM
 find_library(LIBROM libROM.so HINTS "$ENV{LIBROM_DIR}/build/lib")
@@ -100,7 +101,6 @@ include_directories(
   ${HDF5_C_INCLUDE_DIRS}
   ${MPI_C_INCLUDE_DIRS}
   ${MFEM_C_INCLUDE_DIRS}
-  ${YAML_INCLUDES}
   ${LIBROM_INCLUDES}
 )
 link_libraries(
@@ -118,7 +118,7 @@ link_libraries(
   ${PARMETIS}
   ${METIS}
   ${MUMPS}
-  ${YAML}
+  yaml-cpp::yaml-cpp
   GTest::GTest
   ${LIBROM}
 )

--- a/dependencies/FindMETIS.cmake
+++ b/dependencies/FindMETIS.cmake
@@ -1,0 +1,79 @@
+# Distributed under the OSI-approved BSD 3-Clause License.  See accompanying
+# file Copyright.txt or https://cmake.org/licensing for details.
+
+#[=======================================================================[.rst:
+FindMETIS
+-------
+Michael Hirsch, Ph.D.
+
+Finds the METIS library.
+NOTE: If libparmetis used, libmetis must also be linked.
+
+Imported Targets
+^^^^^^^^^^^^^^^^
+
+METIS::METIS
+
+Result Variables
+^^^^^^^^^^^^^^^^
+
+METIS_LIBRARIES
+  libraries to be linked
+
+METIS_INCLUDE_DIRS
+  dirs to be included
+
+#]=======================================================================]
+
+
+if("parallel" IN_LIST METIS_FIND_COMPONENTS)
+  find_library(PARMETIS_LIBRARY
+    NAMES parmetis
+    PATH_SUFFIXES METIS libmetis
+    DOC "ParMETIS library"
+    )
+  if(PARMETIS_LIBRARY)
+    set(METIS_parallel_FOUND true)
+  endif()
+endif()
+
+find_library(METIS_LIBRARY
+  NAMES metis
+  PATH_SUFFIXES METIS libmetis
+  DOC "METIS library"
+  )
+
+if(parallel IN_LIST METIS_FIND_COMPONENTS)
+  set(metis_inc parmetis.h)
+else()
+  set(metis_inc metis.h)
+endif()
+
+find_path(METIS_INCLUDE_DIR
+NAMES ${metis_inc}
+PATH_SUFFIXES METIS openmpi-x86_64 mpich-x86_64
+DOC "METIS include directory"
+)
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(METIS
+REQUIRED_VARS METIS_LIBRARY METIS_INCLUDE_DIR
+HANDLE_COMPONENTS
+)
+
+if(METIS_FOUND)
+
+set(METIS_LIBRARIES ${PARMETIS_LIBRARY} ${METIS_LIBRARY})
+set(METIS_INCLUDE_DIRS ${METIS_INCLUDE_DIR})
+
+message(VERBOSE "METIS libraries: ${METIS_LIBRARIES}
+METIS include directories: ${METIS_INCLUDE_DIRS}")
+
+if(NOT TARGET METIS::METIS)
+  add_library(METIS::METIS INTERFACE IMPORTED)
+  set_property(TARGET METIS::METIS PROPERTY INTERFACE_LINK_LIBRARIES "${METIS_LIBRARIES}")
+  set_property(TARGET METIS::METIS PROPERTY INTERFACE_INCLUDE_DIRECTORIES "${METIS_INCLUDE_DIR}")
+endif()
+endif(METIS_FOUND)
+
+mark_as_advanced(METIS_INCLUDE_DIR METIS_LIBRARY PARMETIS_LIBRARY)

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -13,8 +13,10 @@ WORKDIR $LIB_DIR
 RUN sudo git clone https://github.com/scivision/mumps.git
 WORKDIR ./mumps
 RUN sudo git checkout v5.6.2.1
+RUN sudo wget -O cmake/FindMETIS.cmake https://github.com/LLNL/scaleupROM/raw/install/dependencies/FindMETIS.cmake
+# RUN sudo sed -i 's/if(parallel IN_LIST METIS_FIND_COMPONENTS)/if("parallel" IN_LIST METIS_FIND_COMPONENTS)/g' cmake/FindMETIS.cmake
+
 # RUN sudo sed -i 's/option(CMAKE_TLS_VERIFY "Verify TLS certificates" ON)/option(CMAKE_TLS_VERIFY "Verify TLS certificates" OFF)/g' options.cmake
-RUN sudo sed -i 's/if(parallel IN_LIST METIS_FIND_COMPONENTS)/if("parallel" IN_LIST METIS_FIND_COMPONENTS)/g' cmake/FindMETIS.cmake
 # # RUN sudo sed -i 's/TLS_VERIFY true/TLS_VERIFY false/g' cmake/mumps_src.cmake
 # RUN sudo sed -i '/NAMES parmetis/a PATHS "$ENV{PARMETIS_DIR}/lib"' cmake/FindMETIS.cmake
 # RUN sudo sed -i '/NAMES metis/a PATHS "$ENV{METIS_DIR}/lib"' cmake/FindMETIS.cmake

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -22,9 +22,7 @@ RUN sudo wget -O cmake/FindMETIS.cmake https://github.com/LLNL/scaleupROM/raw/in
 # RUN sudo sed -i '/NAMES metis/a PATHS "$ENV{METIS_DIR}/lib"' cmake/FindMETIS.cmake
 # RUN sudo sed -i 's/set(metis_inc parmetis.h)/set(metis_inc metis.h)/g' cmake/FindMETIS.cmake
 # RUN sudo sed -i '/NAMES ${metis_inc}/a PATHS "$ENV{PARMETIS_DIR}/metis/include"' cmake/FindMETIS.cmake
-RUN sudo -E cmake -B build -Dparmetis=YES -Dparallel=YES -DCMAKE_TLS_VERIFY=OFF && sudo -E cmake --build build
-WORKDIR $LIB_DIR/MUMPS_5.2.0
-RUN sudo ln -s $LIB_DIR/mumps/build/_deps/mumps-src/include ./include && sudo ln -s $LIB_DIR/mumps/build ./lib
+RUN sudo -E cmake -B build -Dparmetis=YES -Dparallel=YES -DCMAKE_TLS_VERIFY=OFF && sudo -E cmake --build build && sudo -E cmake --install build
 
 # make a link to scalapack for mfem cmake-build with mumps
 WORKDIR /usr/lib
@@ -32,7 +30,7 @@ RUN arch=$(uname -m) && sudo ln -s /usr/lib/${arch}-linux-gnu/libscalapack-openm
 
 # re-install mfem with mumps, with cmake
 WORKDIR $LIB_DIR/mfem/build
-RUN sudo -E cmake .. -DBUILD_SHARED_LIBS=YES -DMFEM_USE_MPI=YES -DMFEM_USE_GSLIB=${MG} -DMFEM_USE_METIS=YES -DMFEM_USE_METIS_5=YES -DMFEM_USE_MUMPS=YES -DMETIS_DIR="$PARMETIS_DIR/metis/include" -DGSLIB_DIR="$LIB_DIR/gslib/build" -DMUMPS_DIR="$LIB_DIR/MUMPS_5.2.0"
+RUN sudo -E cmake .. -DBUILD_SHARED_LIBS=YES -DMFEM_USE_MPI=YES -DMFEM_USE_GSLIB=${MG} -DMFEM_USE_METIS=YES -DMFEM_USE_METIS_5=YES -DMFEM_USE_MUMPS=YES -DGSLIB_DIR="$LIB_DIR/gslib/build" -DMUMPS_DIR="$LIB_DIR/mumps/build/local"
 RUN sudo -E make -j 16
 RUN sudo ln -s . include && sudo ln -s . lib
 
@@ -72,4 +70,4 @@ RUN sudo apt-get install -yq hdf5-tools gmsh
 # create and switch to a user
 WORKDIR /home/$USERNAME
 
-ENV MUMPS_DIR=$LIB_DIR/MUMPS_5.2.0
+ENV MUMPS_DIR=$LIB_DIR/mumps/build/local

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -39,9 +39,9 @@ ENV MFEM_INCLUDES=${MFEM_DIR}
 WORKDIR $LIB_DIR
 RUN sudo git clone https://github.com/jbeder/yaml-cpp.git
 WORKDIR ./yaml-cpp/lib
-RUN cmake .. -DYAML_BUILD_SHARED_LIBS=on && make
-WORKDIR $LIB_DIR/yaml-cpp/include/yaml-cpp
-RUN sudo ln -s ./ yaml-cpp
+RUN cmake .. -DYAML_BUILD_SHARED_LIBS=on && make && sudo make install
+# WORKDIR $LIB_DIR/yaml-cpp/include/yaml-cpp
+# RUN sudo ln -s ./ yaml-cpp
 
 # flags for libROM cmake
 ENV YAML_DIR=$LIB_DIR/yaml-cpp

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -5,20 +5,22 @@ FROM ghcr.io/llnl/librom/librom_env:latest
 WORKDIR $LIB_DIR
 WORKDIR parmetis-4.0.3
 RUN sudo make install
+WORKDIR metis
+RUN sudo make config && sudo make && sudo make install
 
 # install mumps
 WORKDIR $LIB_DIR
 RUN sudo git clone https://github.com/scivision/mumps.git
 WORKDIR ./mumps
 RUN sudo git checkout v5.6.2.1
-RUN sudo sed -i 's/option(CMAKE_TLS_VERIFY "Verify TLS certificates" ON)/option(CMAKE_TLS_VERIFY "Verify TLS certificates" OFF)/g' options.cmake
-# RUN sudo sed -i 's/TLS_VERIFY true/TLS_VERIFY false/g' cmake/mumps_src.cmake
+# RUN sudo sed -i 's/option(CMAKE_TLS_VERIFY "Verify TLS certificates" ON)/option(CMAKE_TLS_VERIFY "Verify TLS certificates" OFF)/g' options.cmake
 RUN sudo sed -i 's/if(parallel IN_LIST METIS_FIND_COMPONENTS)/if("parallel" IN_LIST METIS_FIND_COMPONENTS)/g' cmake/FindMETIS.cmake
-RUN sudo sed -i '/NAMES parmetis/a PATHS "$ENV{PARMETIS_DIR}/lib"' cmake/FindMETIS.cmake
-RUN sudo sed -i '/NAMES metis/a PATHS "$ENV{METIS_DIR}/lib"' cmake/FindMETIS.cmake
-RUN sudo sed -i 's/set(metis_inc parmetis.h)/set(metis_inc metis.h)/g' cmake/FindMETIS.cmake
-RUN sudo sed -i '/NAMES ${metis_inc}/a PATHS "$ENV{PARMETIS_DIR}/metis/include"' cmake/FindMETIS.cmake
-RUN sudo -E cmake -B build -Dparmetis=YES -Dparallel=YES && sudo -E cmake --build build
+# # RUN sudo sed -i 's/TLS_VERIFY true/TLS_VERIFY false/g' cmake/mumps_src.cmake
+# RUN sudo sed -i '/NAMES parmetis/a PATHS "$ENV{PARMETIS_DIR}/lib"' cmake/FindMETIS.cmake
+# RUN sudo sed -i '/NAMES metis/a PATHS "$ENV{METIS_DIR}/lib"' cmake/FindMETIS.cmake
+# RUN sudo sed -i 's/set(metis_inc parmetis.h)/set(metis_inc metis.h)/g' cmake/FindMETIS.cmake
+# RUN sudo sed -i '/NAMES ${metis_inc}/a PATHS "$ENV{PARMETIS_DIR}/metis/include"' cmake/FindMETIS.cmake
+RUN sudo -E cmake -B build -Dparmetis=YES -Dparallel=YES -DCMAKE_TLS_VERIFY=OFF && sudo -E cmake --build build
 WORKDIR $LIB_DIR/MUMPS_5.2.0
 RUN sudo ln -s $LIB_DIR/mumps/build/_deps/mumps-src/include ./include && sudo ln -s $LIB_DIR/mumps/build ./lib
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -35,7 +35,6 @@ RUN sudo -E make -j 16
 RUN sudo ln -s . include && sudo ln -s . lib
 
 ENV MFEM_DIR=$LIB_DIR/mfem/build
-ENV MFEM_INCLUDES=${MFEM_DIR}
 
 # install yaml-cpp
 WORKDIR $LIB_DIR
@@ -51,10 +50,8 @@ ENV YAML_DIR=$LIB_DIR/yaml-cpp
 # install libROM for scaleupROM
 WORKDIR $LIB_DIR
 RUN sudo git clone https://github.com/LLNL/libROM.git
-WORKDIR ./libROM
-# some minor revisions needed for scaleupROM, not merged yet into master branch.
-RUN sudo git pull
-WORKDIR ./build
+WORKDIR ./libROM/build
+# libROM is using the MFEM without MUMPS right now.
 RUN sudo cmake .. -DCMAKE_TOOLCHAIN_FILE=${TOOLCHAIN_FILE} -DCMAKE_BUILD_TYPE=${BUILD_TYPE} -DUSE_MFEM=${USE_MFEM} -DMFEM_USE_GSLIB=${MFEM_USE_GSLIB}
 RUN sudo make -j 16
 

--- a/include/input_parser.hpp
+++ b/include/input_parser.hpp
@@ -5,7 +5,7 @@
 #ifndef INPUT_PARSER_HPP
 #define INPUT_PARSER_HPP
 
-#include "yaml.h"
+#include "yaml-cpp/yaml.h"
 #include "mfem.hpp"
 
 using namespace mfem;

--- a/include/parameter.hpp
+++ b/include/parameter.hpp
@@ -47,24 +47,35 @@ public:
    virtual void SetRandomParam(InputParser &parser);
 };
 
-// TODO(kevin): technically we can extract IntegerParam from FilenameParam,
-//              and let FilenameParam inherit from it.
-class FilenameParam : public Parameter
+class IntegerParam : public Parameter
 {
 protected:
    int minval = -1;
    int maxval = -1;
+
+   const int GetInteger(const int &param_index);
+   const int GetRandomInteger();
+public:
+   IntegerParam(const std::string &input_key, YAML::Node option);
+   virtual ~IntegerParam() {}
+
+   virtual void SetParam(const int &param_index, InputParser &parser);
+   virtual void SetRandomParam(InputParser &parser);
+
+   virtual void SetMaximumSize() { SetSize(maxval - minval); }
+};
+
+class FilenameParam : public IntegerParam
+{
+protected:
    std::string format = "";
 
 public:
    FilenameParam(const std::string &input_key, YAML::Node option);
    virtual ~FilenameParam() {}
 
-   virtual void SetParam(const int &param_index, InputParser &parser);
-   virtual void SetRandomParam(InputParser &parser);
-
-   virtual const std::string GetFilename(const int &param_index);
-   virtual void SetMaximumSize() { SetSize(maxval - minval); }
+   virtual void SetParam(const int &param_index, InputParser &parser) override;
+   virtual void SetRandomParam(InputParser &parser) override;
 };
 
 #endif

--- a/src/main_workflow.cpp
+++ b/src/main_workflow.cpp
@@ -164,7 +164,7 @@ void TrainROM(MPI_Comm comm)
          file_list.push_back(filename);
       }
       if (file_list.size() > 1)
-         mfem_error("TrainROM - CAROM::BasisGenerator cannot take multiple snapshot files, shamefully.\n");
+         mfem_warning("TrainROM - CAROM::BasisGenerator may not take multiple snapshot files.\n");
 
       sample_generator->FormReducedBasis(basis_prefix, basis_tag, file_list, num_basis);
    }  // for (int p = 0; p < basis_list.size(); p++)

--- a/src/parameter.cpp
+++ b/src/parameter.cpp
@@ -70,37 +70,30 @@ void DoubleParam::SetRandomParam(InputParser &parser)
 }
 
 /*
-   FilenameParam
+   IntegerParam
 */
 
-FilenameParam::FilenameParam(const std::string &input_key, YAML::Node option)
+IntegerParam::IntegerParam(const std::string &input_key, YAML::Node option)
    : Parameter(input_key),
-     format(config.GetRequiredOptionFromDict<std::string>("format", option)),
      minval(config.GetRequiredOptionFromDict<int>("minimum", option)),
      maxval(config.GetRequiredOptionFromDict<int>("maximum", option))
-   //   zero_pad(config.GetOptionFromDict<int>("zero_pad", 8, option))
 {}
 
-void FilenameParam::SetParam(const int &param_index, InputParser &parser)
+void IntegerParam::SetParam(const int &param_index, InputParser &parser)
 {
-   std::string filename = GetFilename(param_index);
+   int val = GetInteger(param_index);
 
-   parser.SetOption<std::string>(key, filename);
+   parser.SetOption<int>(key, val);
 }
 
-void FilenameParam::SetRandomParam(InputParser &parser)
+void IntegerParam::SetRandomParam(InputParser &parser)
 {
-   double range = static_cast<double>(maxval - minval + 1);
-   double realval = static_cast<double>(minval) + range * UniformRandom();
-   int val = std::floor(realval);
-   if (val > maxval) val = maxval;
+   int val = GetRandomInteger();
 
-   std::string filename = string_format(format, val);
-
-   parser.SetOption<std::string>(key, filename);
+   parser.SetOption<int>(key, val);
 }
 
-const std::string FilenameParam::GetFilename(const int &param_index)
+const int IntegerParam::GetInteger(const int &param_index)
 {
    assert(size > 0);
    assert((param_index >= 0) && (param_index < size));
@@ -110,5 +103,37 @@ const std::string FilenameParam::GetFilename(const int &param_index)
    int dp = (maxval - minval) / Np;
    val = minval + param_index * dp;
 
-   return string_format(format, val);
+   return val;
+}
+
+const int IntegerParam::GetRandomInteger()
+{
+   int val = UniformRandom(minval, maxval);
+
+   return val;
+}
+
+/*
+   FilenameParam
+*/
+
+FilenameParam::FilenameParam(const std::string &input_key, YAML::Node option)
+   : IntegerParam(input_key, option),
+     format(config.GetRequiredOptionFromDict<std::string>("format", option))
+{}
+
+void FilenameParam::SetParam(const int &param_index, InputParser &parser)
+{
+   int val = GetInteger(param_index);
+   std::string filename = string_format(format, val);
+
+   parser.SetOption<std::string>(key, filename);
+}
+
+void FilenameParam::SetRandomParam(InputParser &parser)
+{
+   int val = GetRandomInteger();
+   std::string filename = string_format(format, val);
+
+   parser.SetOption<std::string>(key, filename);
 }

--- a/src/sample_generator.cpp
+++ b/src/sample_generator.cpp
@@ -32,6 +32,7 @@ SampleGenerator::SampleGenerator(MPI_Comm comm)
       std::string param_type = config.GetRequiredOptionFromDict<std::string>("type", param_list[p]);
 
       if (param_type == "double")         params[p] = new DoubleParam(param_key, param_list[p]);
+      else if (param_type == "integer")   params[p] = new IntegerParam(param_key, param_list[p]);
       else if (param_type == "filename")  params[p] = new FilenameParam(param_key, param_list[p]);
       else mfem_error("SampleGenerator: Unknown parameter type!\n");
    }  // for (int p = 0; p < num_sampling_params; p++)


### PR DESCRIPTION
# Changes in installation procedure
- Some prerequisites are now further **install**ed via `make install` command, which simplifies the installation procedure:
  - yaml-cpp
  - parmetis/metis
  - mumps
- googletest package becomes optional. If googletest is not found, then the test routines will not be compiled.
- users can specify the paths to prerequisites on `cmake` command, not only as environment variables.

# Documentation of installation procedure
The installation procedure for all the prerequisites and scaleupROM is documented in the [wiki page](https://github.com/LLNL/scaleupROM/wiki/Installation).

# Minor changes
- `IntegerParam` is extracted from `FilenameParam`. This can be used for sample generation.