### PR TITLE
multiple snapshots can be read using FilenameParam.

### DIFF
--- a/include/parameter.hpp
+++ b/include/parameter.hpp
@@ -76,6 +76,7 @@ public:
 
    virtual void SetParam(const int &param_index, InputParser &parser) override;
    virtual void SetRandomParam(InputParser &parser) override;
+   void ParseFilenames(std::vector<std::string> &filenames);
 };
 
 #endif

--- a/src/main_workflow.cpp
+++ b/src/main_workflow.cpp
@@ -157,6 +157,13 @@ void TrainROM(MPI_Comm comm)
       std::vector<std::string> file_list =
          config.GetOptionFromDict<std::vector<std::string>>(
             "snapshot_files", std::vector<std::string>(0), basis_list[p]);
+      YAML::Node snapshot_format = config.FindNodeFromDict("snapshot_format", basis_list[p]);
+      if (snapshot_format)
+      {
+         FilenameParam snapshot_param("", snapshot_format);
+         snapshot_param.ParseFilenames(file_list);
+      }
+
       if (file_list.size() == 0)
       {
          std::string filename = sample_generator->GetBaseFilename(sample_generator->GetSamplePrefix(), basis_tag);

--- a/src/parameter.cpp
+++ b/src/parameter.cpp
@@ -137,3 +137,10 @@ void FilenameParam::SetRandomParam(InputParser &parser)
 
    parser.SetOption<std::string>(key, filename);
 }
+
+void FilenameParam::ParseFilenames(std::vector<std::string> &filenames)
+{
+   for (int k = minval; k <= maxval; k++)
+      filenames.push_back(string_format(format, k));
+   return;
+}


### PR DESCRIPTION
Inputs for `FilenameParam` can be specified as `basis/tags/../snapshot_format`. `TrainROM` will parse all filenames from the `FilenameParam` and add to the list of snapshots.