### PR TITLE
Various ROM projections for steady NS toy model

### DIFF
--- a/include/linalg_utils.hpp
+++ b/include/linalg_utils.hpp
@@ -93,6 +93,42 @@ void TensorAddMultTranspose(const DenseTensor &tensor, const Vector &x, const in
 // axis 1: M_{ki} += w * T_{ijk} * x_j
 void TensorAddScaledMultTranspose(const DenseTensor &tensor, const double w, const Vector &x, const int axis, DenseMatrix &M);
 
+class CGOptimizer : public OptimizationSolver
+{
+protected:
+   const double golden_ratio = 0.5 * (1.0 + sqrt(5.0));
+   const double Cr = 1.0 - 1. / golden_ratio;
+   const double ib = 0.1;
+   const double eps = 1.0e-14;
+
+   const int N_mnbrak = 1e4;
+   const int N_para = 1e4;
+
+public:
+   CGOptimizer() : OptimizationSolver() {}
+   virtual ~CGOptimizer() {}
+
+   virtual void SetOperator(const Operator &op) override
+   {
+      oper = &op;
+      height = op.Height();
+      width = op.Width();
+
+      res.SetSize(height);
+   }
+
+   virtual void Mult(const Vector &rhs, Vector &sol) const;
+
+private:
+   mutable Vector res;
+   mutable Vector sol1, g, xi, xi1, h;
+
+   double Objective(const Vector &rhs, const Vector &sol) const;
+   void Gradient(const Vector &rhs, const Vector &sol, Vector &grad) const;
+
+   double Brent(const Vector &rhs, const Vector &xi, Vector &sol, double b0 = 1e-1, double lin_tol = 1e-2) const;
+};
+
 }
 
 #endif

--- a/include/linalg_utils.hpp
+++ b/include/linalg_utils.hpp
@@ -114,13 +114,13 @@ public:
       height = op.Height();
       width = op.Width();
 
-      res.SetSize(height);
+      resvec.SetSize(height);
    }
 
    virtual void Mult(const Vector &rhs, Vector &sol) const;
 
 private:
-   mutable Vector res;
+   mutable Vector resvec;
    mutable Vector sol1, g, xi, xi1, h;
 
    double Objective(const Vector &rhs, const Vector &sol) const;

--- a/include/linalg_utils.hpp
+++ b/include/linalg_utils.hpp
@@ -44,6 +44,9 @@ void PrintVector(const CAROM::Vector &vec,
 
 namespace mfem
 {
+
+void GramSchmidt(DenseMatrix& mat);
+
 // Compute Rt * A * P
 void RtAP(DenseMatrix& R,
         const Operator& A,

--- a/include/multiblock_solver.hpp
+++ b/include/multiblock_solver.hpp
@@ -195,7 +195,7 @@ public:
 
    void AssembleROM();
 
-   virtual void Solve() = 0;
+   virtual bool Solve() = 0;
 
    virtual void InitVisualization(const std::string& output_dir = "");
    virtual void InitUnifiedParaview(const std::string &file_prefix);

--- a/include/poisson_solver.hpp
+++ b/include/poisson_solver.hpp
@@ -85,7 +85,7 @@ public:
    virtual void BuildBdrROMElement(Array<FiniteElementSpace *> &fes_comp);
    virtual void BuildInterfaceROMElement(Array<FiniteElementSpace *> &fes_comp);
 
-   virtual void Solve();
+   virtual bool Solve();
 
    virtual void ProjectOperatorOnReducedBasis();
 

--- a/include/random_sample_generator.hpp
+++ b/include/random_sample_generator.hpp
@@ -16,6 +16,8 @@ public:
 
    virtual ~RandomSampleGenerator() {}
 
+   virtual SampleGeneratorType GetType() override { return RANDOM; }
+
    // RandomSampleGenerator has the same sampling size for all parameters, equal to total samples.
    // const Array<int> GetSampleSizes() { return sampling_sizes; }
 

--- a/include/sample_generator.hpp
+++ b/include/sample_generator.hpp
@@ -12,6 +12,13 @@
 
 using namespace mfem;
 
+enum SampleGeneratorType
+{
+   BASE,
+   RANDOM,
+   NUM_SAMPLE_GEN_TYPE
+};
+
 class SampleGenerator
 {
 protected:
@@ -50,6 +57,8 @@ public:
    SampleGenerator(MPI_Comm comm);
 
    virtual ~SampleGenerator();
+
+   virtual SampleGeneratorType GetType() { return BASE; }
 
    const int GetNumSampleParams() { return num_sampling_params; }
    const Array<int> GetSampleSizes() { return sampling_sizes; }

--- a/include/steady_ns_solver.hpp
+++ b/include/steady_ns_solver.hpp
@@ -131,7 +131,7 @@ public:
    virtual void SaveCompBdrROMElement(hid_t &file_id) override;
    virtual void LoadCompBdrROMElement(hid_t &file_id) override;
 
-   virtual void Solve();
+   virtual bool Solve();
 
    virtual void ProjectOperatorOnReducedBasis();
 

--- a/include/stokes_solver.hpp
+++ b/include/stokes_solver.hpp
@@ -185,7 +185,7 @@ public:
    virtual void BuildBdrROMElement(Array<FiniteElementSpace *> &fes_comp);
    virtual void BuildInterfaceROMElement(Array<FiniteElementSpace *> &fes_comp);
 
-   virtual void Solve();
+   virtual bool Solve();
    virtual void Solve_obsolete();
 
    virtual void ProjectOperatorOnReducedBasis();

--- a/sketches/ns_rom.cpp
+++ b/sketches/ns_rom.cpp
@@ -965,8 +965,8 @@ int main(int argc, char *argv[])
          CAROM::Options u_option(udim, nsample, 1, false);
          CAROM::Options p_option(pdim, nsample, 1, false);
          CAROM::BasisGenerator snapshot_generator(option, false, filename);
-         CAROM::BasisGenerator u_snapshot_generator(u_option, false, filename);
-         CAROM::BasisGenerator p_snapshot_generator(p_option, false, filename);
+         CAROM::BasisGenerator u_snapshot_generator(u_option, false, filename + "_vel");
+         CAROM::BasisGenerator p_snapshot_generator(p_option, false, filename + "_pres");
 
          int s = 0;
          while (s < nsample)

--- a/sketches/ns_rom.cpp
+++ b/sketches/ns_rom.cpp
@@ -893,652 +893,81 @@ int main(int argc, char *argv[])
    const int pdim = pfes->GetTrueVSize();
    const double pres_wgt = static_cast<double>(ufes->GetTrueVSize() / dim) / static_cast<double>(pfes->GetTrueVSize());
 
-   switch (mode)
+   if (mode == Mode::MMS)
    {
-      case (Mode::MMS):
+      VectorFunctionCoefficient fcoeff(dim, fFun);
+      FunctionCoefficient gcoeff(gFun);
+
+      VectorFunctionCoefficient ucoeff(dim, uFun_ex);
+      FunctionCoefficient pcoeff(pFun_ex);
+
+      GridFunction u_ex(ufes), p_ex(pfes);
+      u_ex.ProjectCoefficient(ucoeff);
+      p_ex.ProjectCoefficient(pcoeff);
+      const double p_const = p_ex.Sum() / static_cast<double>(p_ex.Size());
+
+      // 12. Create the grid functions u and p. Compute the L2 error norms.
+      GridFunction *u = oper.GetVelocityGridFunction();
+      GridFunction *p = oper.GetPressureGridFunction();
+
+      oper.SetupMMS(fcoeff, gcoeff, ucoeff);
+      oper.Solve();
+
+      if (!pres_dbc)
       {
-         VectorFunctionCoefficient fcoeff(dim, fFun);
-         FunctionCoefficient gcoeff(gFun);
-
-         VectorFunctionCoefficient ucoeff(dim, uFun_ex);
-         FunctionCoefficient pcoeff(pFun_ex);
-
-         GridFunction u_ex(ufes), p_ex(pfes);
-         u_ex.ProjectCoefficient(ucoeff);
-         p_ex.ProjectCoefficient(pcoeff);
-         const double p_const = p_ex.Sum() / static_cast<double>(p_ex.Size());
-
-         // 12. Create the grid functions u and p. Compute the L2 error norms.
-         GridFunction *u = oper.GetVelocityGridFunction();
-         GridFunction *p = oper.GetPressureGridFunction();
-
-         oper.SetupMMS(fcoeff, gcoeff, ucoeff);
-         oper.Solve();
-
-         if (!pres_dbc)
-         {
-            (*p) += p_const;
-         }
-
-         int order_quad = max(2, 2*(order+1)+1);
-         const IntegrationRule *irs[Geometry::NumGeom];
-         for (int i=0; i < Geometry::NumGeom; ++i)
-         {
-            irs[i] = &(IntRules.Get(i, order_quad));
-         }
-
-         double err_u  = u->ComputeL2Error(ucoeff, irs);
-         double norm_u = ComputeLpNorm(2., ucoeff, *mesh, irs);
-         double err_p  = p->ComputeL2Error(pcoeff, irs);
-         double norm_p = ComputeLpNorm(2., pcoeff, *mesh, irs);
-
-         printf("|| u_h - u_ex || / || u_ex || = %.5E\n", err_u / norm_u);
-         printf("|| p_h - p_ex || / || p_ex || = %.5E\n", err_p / norm_p);
-
-         // GridFunction tmp(u);
-         // nVarf->Mult(u, tmp);
-
-         // printf("u\ttmp\n");
-         // for (int k = 0; k < u.Size(); k++)
-         //    printf("%.5E\t%.5E\n", u[k], tmp[k]);
-
-         // 15. Save data in the ParaView format
-         ParaViewDataCollection paraview_dc("ns_mms_paraview", mesh);
-         // paraview_dc.SetPrefixPath("ParaView");
-         paraview_dc.SetLevelsOfDetail(order);
-         // paraview_dc.SetCycle(0);
-      //    paraview_dc.SetDataFormat(VTKFormat::BINARY);
-      //    paraview_dc.SetHighOrderOutput(true);
-      //    paraview_dc.SetTime(0.0); // set the time
-         paraview_dc.RegisterField("velocity", u);
-         paraview_dc.RegisterField("pressure", p);
-         paraview_dc.Save();
+         (*p) += p_const;
       }
-      break;
-      case (Mode::SAMPLE):
+
+      int order_quad = max(2, 2*(order+1)+1);
+      const IntegrationRule *irs[Geometry::NumGeom];
+      for (int i=0; i < Geometry::NumGeom; ++i)
       {
-         assert(nsample > 0);
-
-         const int fom_vdofs = oper.Height();
-
-         CAROM::Options option(fom_vdofs, nsample, 1, false);
-         CAROM::Options u_option(udim, nsample, 1, false);
-         CAROM::Options p_option(pdim, nsample, 1, false);
-         CAROM::BasisGenerator snapshot_generator(option, false, filename);
-         CAROM::BasisGenerator u_snapshot_generator(u_option, false, filename + "_vel");
-         CAROM::BasisGenerator p_snapshot_generator(p_option, false, filename + "_pres");
-
-         int s = 0;
-         while (s < nsample)
-         {
-            if (random_sample)
-            {
-               for (int d = 0; d < problem::u0.Size(); d++)
-               {
-                  problem::u0(d) = 2.0 * UniformRandom() - 1.0;
-                  problem::du(d) = 0.1 * (2.0 * UniformRandom() - 1.0);
-                  problem::offsets(d) = UniformRandom();
-
-                  for (int d2 = 0; d2 < problem::u0.Size(); d2++)
-                     problem::k(d, d2) = 0.5 * (2.0 * UniformRandom() - 1.0);
-               }
-            }
-            else
-            {
-               problem::du = 0.0;
-               problem::offsets = 0.0;
-               problem::k = 0.0;
-
-               problem::u0(0) = (s / 2 == 0) ? 1.0 : -1.0;
-               problem::u0(1) = (s % 2 == 0) ? 1.0 : -1.0;
-               printf("u0: (%f, %f)\n", problem::u0(0), problem::u0(1));
-            }
-
-            SteadyNavierStokes temp(mesh, order, nu, zeta, use_dg, pres_dbc);
-            temp.SetupProblem();
-            bool converged = temp.Solve();
-            if (!converged)
-            {
-               if (random_sample)
-               {
-                  mfem_warning("Failed to converge in sampling. Collecting another sample.\n");
-                  continue;
-               }
-               else
-                  mfem_error("Failed to converge in sampling!\n");
-            }
-
-            snapshot_generator.takeSample(temp.GetSolution()->GetData(), 0.0, 0.01);
-            u_snapshot_generator.takeSample(temp.GetSolution()->GetData(), 0.0, 0.01);
-            p_snapshot_generator.takeSample(temp.GetSolution()->GetData() + udim, 0.0, 0.01);
-
-            // GridFunction *u = temp.GetVelocityGridFunction();
-            // GridFunction *p = temp.GetPressureGridFunction();
-
-            // // 15. Save data in the ParaView format
-            // ParaViewDataCollection paraview_dc("ns_sample_paraview", mesh);
-            // paraview_dc.SetLevelsOfDetail(max(3,order+1));
-            // paraview_dc.RegisterField("velocity", u);
-            // paraview_dc.RegisterField("pressure", p);
-            // paraview_dc.Save();
-
-            s++;
-         }  // while (s < nsample)
-
-         snapshot_generator.writeSnapshot();
-         u_snapshot_generator.writeSnapshot();
-         p_snapshot_generator.writeSnapshot();
-
-         snapshot_generator.endSamples();
-         const CAROM::Vector *rom_sv = snapshot_generator.getSingularValues();
-         printf("Singular values: ");
-         for (int d = 0; d < rom_sv->dim(); d++)
-            printf("%.3E\t", rom_sv->item(d));
-         printf("\n");
-         std::string sv_file = filename + "_sv.txt";
-         CAROM::PrintVector(*rom_sv, sv_file);
-
-         u_snapshot_generator.endSamples();
-         rom_sv = u_snapshot_generator.getSingularValues();
-         printf("Velocity Singular values: ");
-         for (int d = 0; d < rom_sv->dim(); d++)
-            printf("%.3E\t", rom_sv->item(d));
-         printf("\n");
-         sv_file = filename + "_vel_sv.txt";
-         CAROM::PrintVector(*rom_sv, sv_file);
-
-         p_snapshot_generator.endSamples();
-         rom_sv = p_snapshot_generator.getSingularValues();
-         printf("Pressure Singular values: ");
-         for (int d = 0; d < rom_sv->dim(); d++)
-            printf("%.3E\t", rom_sv->item(d));
-         printf("\n");
-         sv_file = filename + "_pres_sv.txt";
-         CAROM::PrintVector(*rom_sv, sv_file);
+         irs[i] = &(IntRules.Get(i, order_quad));
       }
-      break;
-      case (Mode::PROJECT):
-      {
-         assert(nsample > 0);
-         assert(num_basis > 0);
-         if (wgt_basis)
-            mfem_error("not implemented for weighted basis!\n");
 
-         double sigma = -1.0, kappa = (order+2) * (order+2);
-         ConstantCoefficient nu_coeff(nu), zeta_coeff(zeta);
-         ConstantCoefficient minus_one(-1.0);
-         const IntegrationRule *ir = oper.GetNonlinearIntRule();
-
-         BilinearForm M(ufes);
-         NonlinearForm H(ufes);
-         MixedBilinearFormDGExtension S(ufes, pfes);
-
-         M.AddDomainIntegrator(new VectorDiffusionIntegrator(nu_coeff));
-         if (use_dg)
-            M.AddInteriorFaceIntegrator(new DGVectorDiffusionIntegrator(nu_coeff, sigma, kappa));
-
-         S.AddDomainIntegrator(new VectorDivergenceIntegrator(minus_one));
-         if (use_dg)
-            S.AddInteriorFaceIntegrator(new DGNormalFluxIntegrator);
-
-         auto nl_integ = new VectorConvectionTrilinearFormIntegrator(zeta_coeff);
-         nl_integ->SetIntRule(ir);
-         H.AddDomainIntegrator(nl_integ);
-
-         M.Assemble();
-         S.Assemble();
-         M.Finalize();
-         S.Finalize();
-         PrintMatrix(S.SpMat(), filename + "_div_op.txt");
-
-         DenseMatrix basis;
-         CAROM::BasisReader basis_reader(filename);
-         const CAROM::Matrix *carom_basis = basis_reader.getSpatialBasis(0.0, num_basis);
-         CAROM::CopyMatrix(*carom_basis, basis);
-
-         const int fom_vdofs = oper.Height();
-
-         std::string res_filename = filename + "_res";
-         std::string proj_res_filename = filename + "_proj_res";
-         CAROM::Options option(fom_vdofs, nsample, 1, false);
-         CAROM::BasisGenerator sol_snapshot(option, false, filename + "_sol");
-         CAROM::BasisGenerator proj_sol_snapshot(option, false, filename + "_proj_sol");
-         CAROM::BasisGenerator residual_snapshot(option, false, res_filename);
-         CAROM::BasisGenerator proj_residual_snapshot(option, false, proj_res_filename);
-
-         for (int s = 0; s < nsample; s++)
-         {
-            for (int d = 0; d < problem::u0.Size(); d++)
-            {
-               problem::u0(d) = 2.0 * UniformRandom() - 1.0;
-               problem::du(d) = 0.1 * (2.0 * UniformRandom() - 1.0);
-               problem::offsets(d) = UniformRandom();
-
-               for (int d2 = 0; d2 < problem::u0.Size(); d2++)
-                  problem::k(d, d2) = 0.5 * (2.0 * UniformRandom() - 1.0);
-            }
-
-            SteadyNavierStokes fom(mesh, order, nu, zeta, use_dg, pres_dbc);
-            fom.SetupProblem();
-            bool converged = fom.Solve();
-            assert(converged);
-
-            BlockVector *fom_sol = fom.GetSolution();
-            BlockVector *fom_rhs = fom.GetRHS();
-            Vector tmp1(num_basis), fom_proj(fom_sol->Size()), fom_res(fom_sol->Size());
-            basis.MultTranspose(*fom_sol, tmp1);
-            basis.Mult(tmp1, fom_proj);
-
-            {
-               Vector x_u(fom_proj.GetData(), M.Height()), x_p(fom_proj.GetData()+M.Height(), S.Height());
-               Vector y_u(fom_res.GetData(), M.Height()), y_p(fom_res.GetData()+M.Height(), S.Height());
-
-               H.Mult(x_u, y_u);
-               M.AddMult(x_u, y_u);
-               S.AddMultTranspose(x_p, y_u);
-               S.Mult(x_u, y_p);
-            }
-            // fom.Mult(fom_proj, fom_res);
-            // fom_res -= (*fom_rhs);
-
-            Vector proj_res(fom_sol->Size());
-            basis.MultTranspose(fom_res, tmp1);
-            basis.Mult(tmp1, proj_res);
-
-            Vector fomsol_div(pdim), projsol_div(pdim), res_div(pdim), projres_div(pdim);
-            S.Mult(fom_sol->GetBlock(0), fomsol_div);
-            tmp1.MakeRef(fom_proj, 0, udim);
-            S.Mult(tmp1, projsol_div);
-            tmp1.MakeRef(fom_res, 0, udim);
-            S.Mult(tmp1, res_div);
-            tmp1.MakeRef(proj_res, 0, udim);
-            S.Mult(tmp1, projres_div);
-
-            sol_snapshot.takeSample(fom_sol->GetData(), 0.0, 0.01);
-            proj_sol_snapshot.takeSample(fom_proj.GetData(), 0.0, 0.01);
-            residual_snapshot.takeSample(fom_res.GetData(), 0.0, 0.01);
-            proj_residual_snapshot.takeSample(proj_res.GetData(), 0.0, 0.01);
-
-            Array<GridFunction *> ugf(4), pgf(4), divgf(4);
-            for (int k = 0; k < 4; k++) ugf[k] = new GridFunction;
-            for (int k = 0; k < 4; k++) pgf[k] = new GridFunction;
-            for (int k = 0; k < 4; k++) divgf[k] = new GridFunction;
-            ugf[0]->MakeRef(ufes, fom_sol->GetBlock(0), 0);
-            pgf[0]->MakeRef(pfes, fom_sol->GetBlock(1), 0);
-            divgf[0]->MakeRef(pfes, fomsol_div, 0);
-            ugf[1]->MakeRef(ufes, fom_proj, 0);
-            pgf[1]->MakeRef(pfes, fom_proj, fom_sol->GetBlock(0).Size());
-            divgf[1]->MakeRef(pfes, projsol_div, 0);
-            ugf[2]->MakeRef(ufes, fom_res, 0);
-            pgf[2]->MakeRef(pfes, fom_res, fom_sol->GetBlock(0).Size());
-            divgf[2]->MakeRef(pfes, res_div, 0);
-            ugf[3]->MakeRef(ufes, proj_res, 0);
-            pgf[3]->MakeRef(pfes, proj_res, fom_sol->GetBlock(0).Size());
-            divgf[3]->MakeRef(pfes, projres_div, 0);
-
-            std::vector<std::string> suffix(0);
-            suffix.push_back("_fomsol");
-            suffix.push_back("_projsol");
-            suffix.push_back("_fomres");
-            suffix.push_back("_projres");
-
-            // 15. Save data in the ParaView format
-            ParaViewDataCollection paraview_dc("ns_project_paraview_"+std::to_string(s), mesh);
-            paraview_dc.SetLevelsOfDetail(max(3,order+1));
-            for (int k = 0; k < 4; k++)
-            {
-               paraview_dc.RegisterField("u"+suffix[k], ugf[k]);
-               paraview_dc.RegisterField("p"+suffix[k], pgf[k]);
-               paraview_dc.RegisterField("div"+suffix[k], divgf[k]);
-            }
-            paraview_dc.Save();
-         }
-
-         sol_snapshot.writeSnapshot();
-         proj_sol_snapshot.writeSnapshot();
-         residual_snapshot.writeSnapshot();
-         proj_residual_snapshot.writeSnapshot();
-      }
-      break;
-      case (Mode::BUILD):
-      {
-         oper.SetupProblem();
-
-         DenseMatrix basis;
-         if (wgt_basis)
-         {
-            printf("weight on pressure: %.3E\n", pres_wgt);
-
-            std::string basis_file = filename + "_basis.h5";
-            if (FileExists(basis_file))
-            {  // load basis from a hdf5 format.
-               hid_t file_id;
-               herr_t errf = 0;
-               file_id = H5Fopen(basis_file.c_str(), H5F_ACC_RDONLY, H5P_DEFAULT);
-               assert(file_id >= 0);
-
-               hdf5_utils::ReadDataset(file_id, "basis", basis);
-
-               errf = H5Fclose(file_id);
-               assert(errf >= 0);
-
-               if (num_basis != basis.NumCols())
-               {
-                  assert(num_basis < basis.NumCols());
-                  basis.SetSize(basis.NumRows(), num_basis);
-               }
-            }
-            else
-            {  // perform generalized SVD with a weight on the pressure.
-               assert(nsample > 0);
-               const int fom_vdofs = oper.Height();
-               CAROM::Options option(fom_vdofs, nsample, 1, false);
-               CAROM::BasisGenerator snapshot_reader(option, false, filename);
-               snapshot_reader.loadSamples(filename + "_snapshot", "snapshot");
-               const CAROM::Matrix *snapshots = snapshot_reader.getSnapshotMatrix();
-               DenseMatrix wgted_snapshots;
-               CAROM::CopyMatrix(*snapshots, wgted_snapshots);
-               for (int i = ufes->GetTrueVSize(); i < wgted_snapshots.NumRows(); i++)
-                  for (int j = 0; j < wgted_snapshots.NumCols(); j++)
-                     wgted_snapshots(i,j) *= sqrt(pres_wgt);
-
-               CAROM::BasisGenerator basis_generator(option, false, filename);
-               for (int j = 0; j < wgted_snapshots.NumCols(); j++)
-                  basis_generator.takeSample(wgted_snapshots.GetColumn(j), 0.0, 0.01);
-               basis_generator.endSamples();
-
-               const CAROM::Matrix *carom_basis = basis_generator.getSpatialBasis();
-               CAROM::CopyMatrix(*carom_basis, basis);
-               for (int i = ufes->GetTrueVSize(); i < basis.NumRows(); i++)
-                  for (int j = 0; j < basis.NumCols(); j++)
-                     basis(i,j) /= sqrt(pres_wgt);
-
-               {  // save basis in a hdf5 format.
-                  hid_t file_id;
-                  herr_t errf = 0;
-                  file_id = H5Fcreate(basis_file.c_str(), H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT);
-                  assert(file_id >= 0);
-
-                  hdf5_utils::WriteDataset(file_id, "basis", basis);
-
-                  errf = H5Fclose(file_id);
-                  assert(errf >= 0);
-               }
-
-               if (num_basis != basis.NumCols())
-               {
-                  assert(num_basis < basis.NumCols());
-                  basis.SetSize(basis.NumRows(), num_basis);
-               }
-            }
-         }
-         else
-         {
-            CAROM::BasisReader basis_reader(filename);
-            const CAROM::Matrix *carom_basis = basis_reader.getSpatialBasis(0.0, num_basis);
-            CAROM::CopyMatrix(*carom_basis, basis);
-         }
-
-         switch (rom_mode)
-         {
-            case RomMode::TENSOR:
-            {
-               DenseTensor *nlin_rom = oper.GetReducedTensor(basis);
-
-               {  // save the sample to a hdf5 file.
-                  std::string tensor_file = filename + "_tensor.h5";
-
-                  hid_t file_id;
-                  herr_t errf = 0;
-                  file_id = H5Fcreate(tensor_file.c_str(), H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT);
-                  assert(file_id >= 0);
-
-                  hdf5_utils::WriteDataset(file_id, "tensor", *nlin_rom);
-
-                  errf = H5Fclose(file_id);
-                  assert(errf >= 0);
-               }
-
-               delete nlin_rom;
-            }
-            break;
-            case RomMode::TENSOR2:
-            {
-               if (!(FileExists(filename + "_vel.000000") && FileExists(filename + "_pres.000000")))
-               {
-                  const int fom_vdofs = oper.Height();
-                  CAROM::Options option(fom_vdofs, nsample, 1, false);
-                  CAROM::BasisGenerator snapshot_generator(option, false, filename);
-                  // std::string snapshot_filename = filename + "_snapshot";
-                  snapshot_generator.loadSamples(filename + "_snapshot", "snapshot");
-                  // TODO: what happen if we do not deep-copy?
-                  const CAROM::Matrix *snapshots = snapshot_generator.getSnapshotMatrix();
-                  DenseMatrix mfem_snapshots;
-                  CAROM::CopyMatrix(*snapshots, mfem_snapshots);
-
-                  const int u_vdofs = ufes->GetTrueVSize();
-                  const int p_vdofs = pfes->GetTrueVSize();
-                  CAROM::Options u_option(u_vdofs, nsample, 1, false);
-                  CAROM::Options p_option(p_vdofs, nsample, 1, false);
-                  CAROM::BasisGenerator ubasis_generator(u_option, false, filename + "_vel");
-                  CAROM::BasisGenerator pbasis_generator(p_option, false, filename + "_pres");
-
-                  for (int s = 0; s < nsample; s++)
-                  {
-                     ubasis_generator.takeSample(mfem_snapshots.GetColumn(s), 0.0, 0.01);
-                     pbasis_generator.takeSample(mfem_snapshots.GetColumn(s) + u_vdofs, 0.0, 0.01);
-                  }
-                  ubasis_generator.endSamples();
-                  pbasis_generator.endSamples();
-               }
-
-               DenseMatrix ubasis;
-               CAROM::BasisReader ubasis_reader(filename + "_vel");
-               const CAROM::Matrix *carom_ubasis = ubasis_reader.getSpatialBasis(0.0, num_basis);
-               CAROM::CopyMatrix(*carom_ubasis, ubasis);
-
-               DenseTensor *nlin_rom = oper.GetReducedTensor(ubasis);
-               {  // save the sample to a hdf5 file.
-                  std::string tensor_file = filename + "_tensor.h5";
-
-                  hid_t file_id;
-                  herr_t errf = 0;
-                  file_id = H5Fcreate(tensor_file.c_str(), H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT);
-                  assert(file_id >= 0);
-
-                  hdf5_utils::WriteDataset(file_id, "tensor", *nlin_rom);
-
-                  errf = H5Fclose(file_id);
-                  assert(errf >= 0);
-               }
-
-            }
-            break;
-            case RomMode::EQP:
-            {
-               const int fom_vdofs = oper.Height();
-               CAROM::Options option(fom_vdofs, nsample, 1, false);
-               CAROM::BasisGenerator snapshot_generator(option, false, filename);
-               // std::string snapshot_filename = filename + "_snapshot";
-               snapshot_generator.loadSamples(filename + "_snapshot", "snapshot");
-               // TODO: what happen if we do not deep-copy?
-               const CAROM::Matrix *snapshots = snapshot_generator.getSnapshotMatrix();
-
-               const IntegrationRule *ir = oper.GetNonlinearIntRule();
-               auto nl_integ = new VectorConvectionTrilinearFormIntegrator(*(oper.GetZeta()));
-               nl_integ->SetIntRule(ir);
-
-               const int nqe = ir->GetNPoints();
-               const int ne = ufes->GetNE();
-               const int NB = basis.NumCols();
-               const int NQ = ne * nqe;
-               const int nsnap = min(1000, snapshots->numColumns());
-
-               assert(basis.NumRows() == snapshots->numRows());
-               assert(basis.NumRows() == (ufes->GetTrueVSize() + pfes->GetTrueVSize()));
-
-               // Compute G of size (NB * nsnap) x NQ, but only store its transpose Gt.
-               CAROM::Matrix Gt(NQ, NB * nsnap, true);
-               // For 0 <= j < NB, 0 <= i < nsnap, 0 <= e < ne, 0 <= m < nqe,
-               // G(j + (i*NB), (e*nqe) + m)
-               // is the coefficient of v_j^T M(p_i) V v_i at point m of element e,
-               // with respect to the integration rule weight at that point,
-               // where the "exact" quadrature solution is ir0->GetWeights().
-
-               Vector v_i(ufes->GetTrueVSize());
-               Vector r(nqe);
-
-               Array<int> vdofs;
-               Vector el_x, el_tr;
-               DenseMatrix el_quad;
-               const FiniteElement *fe;
-               ElementTransformation *T;
-               DofTransformation *doftrans;
-
-               for (int i = 0; i < nsnap; ++i)
-               {
-                  for (int k = 0; k < ufes->GetTrueVSize(); ++k)
-                        v_i[k] = (*snapshots)(k, i);
-
-                  for (int e = 0; e < ne; ++e)
-                  {
-                     fe = ufes->GetFE(e);
-                     doftrans = ufes->GetElementVDofs(e, vdofs);
-                     T = ufes->GetElementTransformation(e);
-                     v_i.GetSubVector(vdofs, el_x);
-
-                     const int nd = fe->GetDof();
-                     el_quad.SetSize(nd * dim, nqe);
-                     for (int i = 0; i < ir->GetNPoints(); i++)
-                     {
-                        Vector EQ(el_quad.GetColumn(i), nd * dim);
-
-                        const IntegrationPoint &ip = ir->IntPoint(i);
-                        nl_integ->AssembleQuadratureVector(*fe, *T, ip, 1.0, el_x, EQ);
-                     }
-                     // nl_integ->AssembleElementQuadrature(*fe, *T, el_x, el_quad);
-
-                     for (int j = 0; j < NB; ++j)
-                     {
-                        Vector v_j(basis.GetColumn(j), ufes->GetVSize());
-                        v_j.GetSubVector(vdofs, el_tr);
-
-                        el_quad.MultTranspose(el_tr, r);
-
-                        for (int m = 0; m < nqe; ++m)
-                           Gt(m + (e * nqe), j + (i * NB)) = r[m];
-                     }  // for (int j = 0; j < NB; ++j)
-                  }  // for (int e = 0; e < ne; ++e)
-
-                  // if (precondition)
-                  // {
-                     // // Preconditioning is done by (V^T M(p_i) V)^{-1} (of size NB x NB).
-                     // PreconditionNNLS(fespace_R, new VectorFEMassIntegrator(a_coeff), BR, i, Gt);
-                  // }
-               }  // for (int i = 0; i < nsnap; ++i)
-
-               Array<double> const& w_el = ir->GetWeights();
-               CAROM::Vector w(ne * nqe, true);
-
-               for (int i = 0; i < ne; ++i)
-                  for (int j = 0; j < nqe; ++j)
-                     w(j + (i * nqe)) = w_el[j];
-
-               //    void SolveNNLS(const int rank, const double nnls_tol, const int maxNNLSnnz,
-               // CAROM::Vector const& w, CAROM::Matrix & Gt,
-               // CAROM::Vector & sol)
-               double nnls_tol = 1.0e-11;
-               int maxNNLSnnz = 0;
-               const double delta = eqp_tol;
-               CAROM::Vector eqpSol(ne * nqe, true);
-               CAROM::Vector rhs_Gw(Gt.numColumns(), false);
-               // G.mult(w, rhs_ub);  // rhs = Gw
-               // rhs = Gw. Note that by using Gt and multTranspose, we do parallel communication.
-               Gt.transposeMult(w, rhs_Gw);
-               int nnz = 0;
-               {
-                  CAROM::NNLSSolver nnls(nnls_tol, 0, maxNNLSnnz, 2);
-
-                  CAROM::Vector rhs_ub(rhs_Gw);
-                  CAROM::Vector rhs_lb(rhs_Gw);
-
-                  for (int i = 0; i < rhs_ub.dim(); ++i)
-                  {
-                     rhs_lb(i) -= delta;
-                     rhs_ub(i) += delta;
-                  }
-
-                  // nnls.normalize_constraints(Gt, rhs_lb, rhs_ub);
-                  nnls.solve_parallel_with_scalapack(Gt, rhs_lb, rhs_ub, eqpSol);
-
-                  nnz = 0;
-                  for (int i = 0; i < eqpSol.dim(); ++i)
-                  {
-                     if (eqpSol(i) != 0.0)
-                     {
-                           nnz++;
-                     }
-                  }
-
-                  cout << rank << ": Number of nonzeros in NNLS solution: " << nnz
-                        << ", out of " << eqpSol.dim() << endl;
-
-                  MPI_Allreduce(MPI_IN_PLACE, &nnz, 1, MPI_INT, MPI_SUM, MPI_COMM_WORLD);
-
-                  if (rank == 0)
-                     cout << "Global number of nonzeros in NNLS solution: " << nnz << endl;
-
-                  // Check residual of NNLS solution
-                  CAROM::Vector res(Gt.numColumns(), false);
-                  Gt.transposeMult(eqpSol, res);
-
-                  const double normGsol = res.norm();
-                  const double normRHS = rhs_Gw.norm();
-
-                  res -= rhs_Gw;
-                  const double relNorm = res.norm() / std::max(normGsol, normRHS);
-                  cout << rank << ": relative residual norm for NNLS solution of Gs = Gw: " <<
-                        relNorm << endl;
-
-               }
-
-               Array<int> sample_el(0), sample_qp(0);
-               Array<double> sample_qw(0);
-               for (int i = 0; i < eqpSol.dim(); ++i)
-               {
-                  if (eqpSol(i) > 1.0e-12)
-                  {
-                     const int e = i / nqe;  // Element index
-                     sample_el.Append(i / nqe);
-                     sample_qp.Append(i % nqe);
-                     sample_qw.Append(eqpSol(i));
-                  }
-               }
-               printf("Size of sampled qp: %d\n", sample_el.Size());
-               if (nnz != sample_el.Size())
-                  printf("Sample quadrature points with weight < 1.0e-12 are neglected.\n");
-
-               {  // save the sample to a hdf5 file.
-                  std::string sample_file = filename + "_sample.h5";
-
-                  hid_t file_id;
-                  herr_t errf = 0;
-                  file_id = H5Fcreate(sample_file.c_str(), H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT);
-                  assert(file_id >= 0);
-
-                  hdf5_utils::WriteDataset(file_id, "sample_element", sample_el);
-                  hdf5_utils::WriteDataset(file_id, "sample_quadrature_point", sample_qp);
-                  hdf5_utils::WriteDataset(file_id, "sample_quadrature_weight", sample_qw);
-
-                  errf = H5Fclose(file_id);
-                  assert(errf >= 0);
-               }
-            }  // case RomMode::EQP:
-            break;
-         }  // switch (rom_mode)
-      }
-      break;
-      case (Mode::COMPARE):
+      double err_u  = u->ComputeL2Error(ucoeff, irs);
+      double norm_u = ComputeLpNorm(2., ucoeff, *mesh, irs);
+      double err_p  = p->ComputeL2Error(pcoeff, irs);
+      double norm_p = ComputeLpNorm(2., pcoeff, *mesh, irs);
+
+      printf("|| u_h - u_ex || / || u_ex || = %.5E\n", err_u / norm_u);
+      printf("|| p_h - p_ex || / || p_ex || = %.5E\n", err_p / norm_p);
+
+      // GridFunction tmp(u);
+      // nVarf->Mult(u, tmp);
+
+      // printf("u\ttmp\n");
+      // for (int k = 0; k < u.Size(); k++)
+      //    printf("%.5E\t%.5E\n", u[k], tmp[k]);
+
+      // 15. Save data in the ParaView format
+      ParaViewDataCollection paraview_dc("ns_mms_paraview", mesh);
+      // paraview_dc.SetPrefixPath("ParaView");
+      paraview_dc.SetLevelsOfDetail(order);
+      // paraview_dc.SetCycle(0);
+   //    paraview_dc.SetDataFormat(VTKFormat::BINARY);
+   //    paraview_dc.SetHighOrderOutput(true);
+   //    paraview_dc.SetTime(0.0); // set the time
+      paraview_dc.RegisterField("velocity", u);
+      paraview_dc.RegisterField("pressure", p);
+      paraview_dc.Save();
+   }  // if (mode == Mode::MMS)
+
+   if (mode == Mode::SAMPLE)
+   {
+      assert(nsample > 0);
+
+      const int fom_vdofs = oper.Height();
+
+      CAROM::Options option(fom_vdofs, nsample, 1, false);
+      CAROM::Options u_option(udim, nsample, 1, false);
+      CAROM::Options p_option(pdim, nsample, 1, false);
+      CAROM::BasisGenerator snapshot_generator(option, false, filename);
+      CAROM::BasisGenerator u_snapshot_generator(u_option, false, filename + "_vel");
+      CAROM::BasisGenerator p_snapshot_generator(p_option, false, filename + "_pres");
+
+      int s = 0;
+      while (s < nsample)
       {
          if (random_sample)
          {
@@ -1558,390 +987,913 @@ int main(int argc, char *argv[])
             problem::offsets = 0.0;
             problem::k = 0.0;
 
-            problem::u0(0) = 1.0;
-            problem::u0(1) = -1.0;
+            problem::u0(0) = (s / 2 == 0) ? 1.0 : -1.0;
+            problem::u0(1) = (s % 2 == 0) ? 1.0 : -1.0;
             printf("u0: (%f, %f)\n", problem::u0(0), problem::u0(1));
          }
 
-         oper.SetupProblem();
-
-         DenseMatrix basis, u_basis, ubasis, pbasis, basisM;
-         if (wgt_basis)
+         SteadyNavierStokes temp(mesh, order, nu, zeta, use_dg, pres_dbc);
+         temp.SetupProblem();
+         bool converged = temp.Solve();
+         if (!converged)
          {
-            {  // load basis from a hdf5 format.
-               std::string basis_file = filename + "_basis.h5";
+            if (random_sample)
+            {
+               mfem_warning("Failed to converge in sampling. Collecting another sample.\n");
+               continue;
+            }
+            else
+               mfem_error("Failed to converge in sampling!\n");
+         }
+
+         snapshot_generator.takeSample(temp.GetSolution()->GetData(), 0.0, 0.01);
+         u_snapshot_generator.takeSample(temp.GetSolution()->GetData(), 0.0, 0.01);
+         p_snapshot_generator.takeSample(temp.GetSolution()->GetData() + udim, 0.0, 0.01);
+
+         // GridFunction *u = temp.GetVelocityGridFunction();
+         // GridFunction *p = temp.GetPressureGridFunction();
+
+         // // 15. Save data in the ParaView format
+         // ParaViewDataCollection paraview_dc("ns_sample_paraview", mesh);
+         // paraview_dc.SetLevelsOfDetail(max(3,order+1));
+         // paraview_dc.RegisterField("velocity", u);
+         // paraview_dc.RegisterField("pressure", p);
+         // paraview_dc.Save();
+
+         s++;
+      }  // while (s < nsample)
+
+      snapshot_generator.writeSnapshot();
+      u_snapshot_generator.writeSnapshot();
+      p_snapshot_generator.writeSnapshot();
+
+      snapshot_generator.endSamples();
+      const CAROM::Vector *rom_sv = snapshot_generator.getSingularValues();
+      printf("Singular values: ");
+      for (int d = 0; d < rom_sv->dim(); d++)
+         printf("%.3E\t", rom_sv->item(d));
+      printf("\n");
+      std::string sv_file = filename + "_sv.txt";
+      CAROM::PrintVector(*rom_sv, sv_file);
+
+      u_snapshot_generator.endSamples();
+      rom_sv = u_snapshot_generator.getSingularValues();
+      printf("Velocity Singular values: ");
+      for (int d = 0; d < rom_sv->dim(); d++)
+         printf("%.3E\t", rom_sv->item(d));
+      printf("\n");
+      sv_file = filename + "_vel_sv.txt";
+      CAROM::PrintVector(*rom_sv, sv_file);
+
+      p_snapshot_generator.endSamples();
+      rom_sv = p_snapshot_generator.getSingularValues();
+      printf("Pressure Singular values: ");
+      for (int d = 0; d < rom_sv->dim(); d++)
+         printf("%.3E\t", rom_sv->item(d));
+      printf("\n");
+      sv_file = filename + "_pres_sv.txt";
+      CAROM::PrintVector(*rom_sv, sv_file);
+   }  // if (mode == Mode::SAMPLE)
+
+   if (mode == Mode::PROJECT)
+   {
+      assert(nsample > 0);
+      assert(num_basis > 0);
+      if (wgt_basis)
+         mfem_error("not implemented for weighted basis!\n");
+
+      double sigma = -1.0, kappa = (order+2) * (order+2);
+      ConstantCoefficient nu_coeff(nu), zeta_coeff(zeta);
+      ConstantCoefficient minus_one(-1.0);
+      const IntegrationRule *ir = oper.GetNonlinearIntRule();
+
+      BilinearForm M(ufes);
+      NonlinearForm H(ufes);
+      MixedBilinearFormDGExtension S(ufes, pfes);
+
+      M.AddDomainIntegrator(new VectorDiffusionIntegrator(nu_coeff));
+      if (use_dg)
+         M.AddInteriorFaceIntegrator(new DGVectorDiffusionIntegrator(nu_coeff, sigma, kappa));
+
+      S.AddDomainIntegrator(new VectorDivergenceIntegrator(minus_one));
+      if (use_dg)
+         S.AddInteriorFaceIntegrator(new DGNormalFluxIntegrator);
+
+      auto nl_integ = new VectorConvectionTrilinearFormIntegrator(zeta_coeff);
+      nl_integ->SetIntRule(ir);
+      H.AddDomainIntegrator(nl_integ);
+
+      M.Assemble();
+      S.Assemble();
+      M.Finalize();
+      S.Finalize();
+      PrintMatrix(S.SpMat(), filename + "_div_op.txt");
+
+      DenseMatrix basis;
+      CAROM::BasisReader basis_reader(filename);
+      const CAROM::Matrix *carom_basis = basis_reader.getSpatialBasis(0.0, num_basis);
+      CAROM::CopyMatrix(*carom_basis, basis);
+
+      const int fom_vdofs = oper.Height();
+
+      std::string res_filename = filename + "_res";
+      std::string proj_res_filename = filename + "_proj_res";
+      CAROM::Options option(fom_vdofs, nsample, 1, false);
+      CAROM::BasisGenerator sol_snapshot(option, false, filename + "_sol");
+      CAROM::BasisGenerator proj_sol_snapshot(option, false, filename + "_proj_sol");
+      CAROM::BasisGenerator residual_snapshot(option, false, res_filename);
+      CAROM::BasisGenerator proj_residual_snapshot(option, false, proj_res_filename);
+
+      for (int s = 0; s < nsample; s++)
+      {
+         for (int d = 0; d < problem::u0.Size(); d++)
+         {
+            problem::u0(d) = 2.0 * UniformRandom() - 1.0;
+            problem::du(d) = 0.1 * (2.0 * UniformRandom() - 1.0);
+            problem::offsets(d) = UniformRandom();
+
+            for (int d2 = 0; d2 < problem::u0.Size(); d2++)
+               problem::k(d, d2) = 0.5 * (2.0 * UniformRandom() - 1.0);
+         }
+
+         SteadyNavierStokes fom(mesh, order, nu, zeta, use_dg, pres_dbc);
+         fom.SetupProblem();
+         bool converged = fom.Solve();
+         assert(converged);
+
+         BlockVector *fom_sol = fom.GetSolution();
+         BlockVector *fom_rhs = fom.GetRHS();
+         Vector tmp1(num_basis), fom_proj(fom_sol->Size()), fom_res(fom_sol->Size());
+         basis.MultTranspose(*fom_sol, tmp1);
+         basis.Mult(tmp1, fom_proj);
+
+         {
+            Vector x_u(fom_proj.GetData(), M.Height()), x_p(fom_proj.GetData()+M.Height(), S.Height());
+            Vector y_u(fom_res.GetData(), M.Height()), y_p(fom_res.GetData()+M.Height(), S.Height());
+
+            H.Mult(x_u, y_u);
+            M.AddMult(x_u, y_u);
+            S.AddMultTranspose(x_p, y_u);
+            S.Mult(x_u, y_p);
+         }
+         // fom.Mult(fom_proj, fom_res);
+         // fom_res -= (*fom_rhs);
+
+         Vector proj_res(fom_sol->Size());
+         basis.MultTranspose(fom_res, tmp1);
+         basis.Mult(tmp1, proj_res);
+
+         Vector fomsol_div(pdim), projsol_div(pdim), res_div(pdim), projres_div(pdim);
+         S.Mult(fom_sol->GetBlock(0), fomsol_div);
+         tmp1.MakeRef(fom_proj, 0, udim);
+         S.Mult(tmp1, projsol_div);
+         tmp1.MakeRef(fom_res, 0, udim);
+         S.Mult(tmp1, res_div);
+         tmp1.MakeRef(proj_res, 0, udim);
+         S.Mult(tmp1, projres_div);
+
+         sol_snapshot.takeSample(fom_sol->GetData(), 0.0, 0.01);
+         proj_sol_snapshot.takeSample(fom_proj.GetData(), 0.0, 0.01);
+         residual_snapshot.takeSample(fom_res.GetData(), 0.0, 0.01);
+         proj_residual_snapshot.takeSample(proj_res.GetData(), 0.0, 0.01);
+
+         Array<GridFunction *> ugf(4), pgf(4), divgf(4);
+         for (int k = 0; k < 4; k++) ugf[k] = new GridFunction;
+         for (int k = 0; k < 4; k++) pgf[k] = new GridFunction;
+         for (int k = 0; k < 4; k++) divgf[k] = new GridFunction;
+         ugf[0]->MakeRef(ufes, fom_sol->GetBlock(0), 0);
+         pgf[0]->MakeRef(pfes, fom_sol->GetBlock(1), 0);
+         divgf[0]->MakeRef(pfes, fomsol_div, 0);
+         ugf[1]->MakeRef(ufes, fom_proj, 0);
+         pgf[1]->MakeRef(pfes, fom_proj, fom_sol->GetBlock(0).Size());
+         divgf[1]->MakeRef(pfes, projsol_div, 0);
+         ugf[2]->MakeRef(ufes, fom_res, 0);
+         pgf[2]->MakeRef(pfes, fom_res, fom_sol->GetBlock(0).Size());
+         divgf[2]->MakeRef(pfes, res_div, 0);
+         ugf[3]->MakeRef(ufes, proj_res, 0);
+         pgf[3]->MakeRef(pfes, proj_res, fom_sol->GetBlock(0).Size());
+         divgf[3]->MakeRef(pfes, projres_div, 0);
+
+         std::vector<std::string> suffix(0);
+         suffix.push_back("_fomsol");
+         suffix.push_back("_projsol");
+         suffix.push_back("_fomres");
+         suffix.push_back("_projres");
+
+         // 15. Save data in the ParaView format
+         ParaViewDataCollection paraview_dc("ns_project_paraview_"+std::to_string(s), mesh);
+         paraview_dc.SetLevelsOfDetail(max(3,order+1));
+         for (int k = 0; k < 4; k++)
+         {
+            paraview_dc.RegisterField("u"+suffix[k], ugf[k]);
+            paraview_dc.RegisterField("p"+suffix[k], pgf[k]);
+            paraview_dc.RegisterField("div"+suffix[k], divgf[k]);
+         }
+         paraview_dc.Save();
+      }
+
+      sol_snapshot.writeSnapshot();
+      proj_sol_snapshot.writeSnapshot();
+      residual_snapshot.writeSnapshot();
+      proj_residual_snapshot.writeSnapshot();
+   }  // if (mode == Mode::PROJECT)
+
+   if (mode == Mode::BUILD)
+   {
+      oper.SetupProblem();
+
+      DenseMatrix basis;
+      if (wgt_basis)
+      {
+         printf("weight on pressure: %.3E\n", pres_wgt);
+
+         std::string basis_file = filename + "_basis.h5";
+         if (FileExists(basis_file))
+         {  // load basis from a hdf5 format.
+            hid_t file_id;
+            herr_t errf = 0;
+            file_id = H5Fopen(basis_file.c_str(), H5F_ACC_RDONLY, H5P_DEFAULT);
+            assert(file_id >= 0);
+
+            hdf5_utils::ReadDataset(file_id, "basis", basis);
+
+            errf = H5Fclose(file_id);
+            assert(errf >= 0);
+
+            if (num_basis != basis.NumCols())
+            {
+               assert(num_basis < basis.NumCols());
+               basis.SetSize(basis.NumRows(), num_basis);
+            }
+         }  // if (FileExists(basis_file))
+         else
+         {  // perform generalized SVD with a weight on the pressure.
+            assert(nsample > 0);
+            const int fom_vdofs = oper.Height();
+            CAROM::Options option(fom_vdofs, nsample, 1, false);
+            CAROM::BasisGenerator snapshot_reader(option, false, filename);
+            snapshot_reader.loadSamples(filename + "_snapshot", "snapshot");
+            const CAROM::Matrix *snapshots = snapshot_reader.getSnapshotMatrix();
+            DenseMatrix wgted_snapshots;
+            CAROM::CopyMatrix(*snapshots, wgted_snapshots);
+            for (int i = ufes->GetTrueVSize(); i < wgted_snapshots.NumRows(); i++)
+               for (int j = 0; j < wgted_snapshots.NumCols(); j++)
+                  wgted_snapshots(i,j) *= sqrt(pres_wgt);
+
+            CAROM::BasisGenerator basis_generator(option, false, filename);
+            for (int j = 0; j < wgted_snapshots.NumCols(); j++)
+               basis_generator.takeSample(wgted_snapshots.GetColumn(j), 0.0, 0.01);
+            basis_generator.endSamples();
+
+            const CAROM::Matrix *carom_basis = basis_generator.getSpatialBasis();
+            CAROM::CopyMatrix(*carom_basis, basis);
+            for (int i = ufes->GetTrueVSize(); i < basis.NumRows(); i++)
+               for (int j = 0; j < basis.NumCols(); j++)
+                  basis(i,j) /= sqrt(pres_wgt);
+
+            {  // save basis in a hdf5 format.
                hid_t file_id;
                herr_t errf = 0;
-               file_id = H5Fopen(basis_file.c_str(), H5F_ACC_RDONLY, H5P_DEFAULT);
+               file_id = H5Fcreate(basis_file.c_str(), H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT);
                assert(file_id >= 0);
 
-               hdf5_utils::ReadDataset(file_id, "basis", basis);
+               hdf5_utils::WriteDataset(file_id, "basis", basis);
 
                errf = H5Fclose(file_id);
                assert(errf >= 0);
-
-               if (num_basis != basis.NumCols())
-               {
-                  assert(num_basis < basis.NumCols());
-                  basis.SetSize(basis.NumRows(), num_basis);
-               }
             }
 
-            printf("weight on pressure: %.3E\n", pres_wgt);
-            Vector wgt(oper.Height());
-            wgt = 1.0;
-            for (int k = ufes->GetTrueVSize(); k < wgt.Size(); k++) wgt(k) = pres_wgt;
-            basisM = basis;
-            basisM.RightScaling(wgt);
-         }
-         else if (rom_mode == RomMode::TENSOR2)
-         {
-            CAROM::BasisReader ubasis_reader(filename + "_vel");
-            CAROM::BasisReader pbasis_reader(filename + "_pres");
-            const CAROM::Matrix *carom_ubasis = ubasis_reader.getSpatialBasis(0.0, num_basis);
-            const CAROM::Matrix *carom_pbasis = pbasis_reader.getSpatialBasis(0.0, num_pbasis);
-            CAROM::CopyMatrix(*carom_ubasis, ubasis);
-            CAROM::CopyMatrix(*carom_pbasis, pbasis);
-
-            basis.SetSize(ubasis.NumRows() + pbasis.NumRows(), ubasis.NumCols() + pbasis.NumCols());
-            Array<int> uridx(ubasis.NumRows()), ucidx(ubasis.NumCols()), pridx(pbasis.NumRows()), pcidx(pbasis.NumCols());
-            for (int k = 0; k < ubasis.NumRows(); k++) uridx[k] = k;
-            for (int k = 0; k < ubasis.NumCols(); k++) ucidx[k] = k;
-            for (int k = 0; k < pbasis.NumRows(); k++) pridx[k] = k + ubasis.NumRows();
-            for (int k = 0; k < pbasis.NumCols(); k++) pcidx[k] = k + ubasis.NumCols();
-            basis = 0.0;
-            basis.SetSubMatrix(uridx, ucidx, ubasis);
-            basis.SetSubMatrix(pridx, pcidx, pbasis);
-         }
-         else
-         {
-            CAROM::BasisReader basis_reader(filename);
-            const CAROM::Matrix *carom_basis = basis_reader.getSpatialBasis(0.0, num_basis);
-            CAROM::CopyMatrix(*carom_basis, basis);
-         }
-
-         SparseMatrix *linear_term = oper.GetLinearTerm();
-         DenseMatrix lin_rom;
-         if (wgt_basis)
-            mfem::RtAP(basisM, *linear_term, basis, lin_rom);
-         else
-            mfem::RtAP(basis, *linear_term, basis, lin_rom);
-
-         PrintMatrix(*linear_term, filename+"_linop.txt");
-
-         u_basis.CopyRows(basis, 0, ufes->GetTrueVSize() - 1); // indexes are inclusive.
-
-         DenseTensor *nlin_rom = NULL;
-         ROMNonlinearForm *rom_nlinf = NULL;
-         Operator *rom_oper = NULL;
-         TensorROM *tenrom = NULL;
-         EQPROM *eqprom = NULL;
-         switch (rom_mode)
-         {
-            case RomMode::TENSOR:
+            if (num_basis != basis.NumCols())
             {
-               nlin_rom = new DenseTensor;
-               {  // load the sample from a hdf5 file.
-                  std::string tensor_file = filename + "_tensor.h5";
-
-                  hid_t file_id;
-                  herr_t errf = 0;
-                  file_id = H5Fopen(tensor_file.c_str(), H5F_ACC_RDONLY, H5P_DEFAULT);
-                  assert(file_id >= 0);
-
-                  hdf5_utils::ReadDataset(file_id, "tensor", *nlin_rom);
-
-                  errf = H5Fclose(file_id);
-                  assert(errf >= 0);
-               }
-
-               tenrom = new TensorROM(lin_rom, *nlin_rom);
-               rom_oper = tenrom;
+               assert(num_basis < basis.NumCols());
+               basis.SetSize(basis.NumRows(), num_basis);
             }
-            break;
-            case RomMode::TENSOR2:
-            {
-               nlin_rom = new DenseTensor;
-               {  // load the sample from a hdf5 file.
-                  std::string tensor_file = filename + "_tensor.h5";
+         }  // if !(FileExists(basis_file))
+      }  // if (wgt_basis)
+      else
+      {
+         CAROM::BasisReader basis_reader(filename);
+         const CAROM::Matrix *carom_basis = basis_reader.getSpatialBasis(0.0, num_basis);
+         CAROM::CopyMatrix(*carom_basis, basis);
+      }
 
-                  hid_t file_id;
-                  herr_t errf = 0;
-                  file_id = H5Fopen(tensor_file.c_str(), H5F_ACC_RDONLY, H5P_DEFAULT);
-                  assert(file_id >= 0);
+      if (rom_mode == RomMode::TENSOR)
+      {
+         DenseTensor *nlin_rom = oper.GetReducedTensor(basis);
 
-                  hdf5_utils::ReadDataset(file_id, "tensor", *nlin_rom);
+         {  // save the sample to a hdf5 file.
+            std::string tensor_file = filename + "_tensor.h5";
 
-                  errf = H5Fclose(file_id);
-                  assert(errf >= 0);
-               }
-
-               tenrom = new TensorROM2(lin_rom, *nlin_rom);
-               rom_oper = tenrom;
-            }
-            break;
-            case RomMode::EQP:
-            {
-               Array<int> sample_el, sample_qp;
-               Array<double> sample_qw;
-               {  // load the sample from a hdf5 file.
-                  std::string sample_file = filename + "_sample.h5";
-
-                  hid_t file_id;
-                  herr_t errf = 0;
-                  file_id = H5Fopen(sample_file.c_str(), H5F_ACC_RDONLY, H5P_DEFAULT);
-                  assert(file_id >= 0);
-
-                  hdf5_utils::ReadDataset(file_id, "sample_element", sample_el);
-                  hdf5_utils::ReadDataset(file_id, "sample_quadrature_point", sample_qp);
-                  hdf5_utils::ReadDataset(file_id, "sample_quadrature_weight", sample_qw);
-
-                  errf = H5Fclose(file_id);
-                  assert(errf >= 0);
-               }
-
-               const IntegrationRule *ir = oper.GetNonlinearIntRule();
-               auto nl_integ = new VectorConvectionTrilinearFormIntegrator(*(oper.GetZeta()));
-               nl_integ->SetIntRule(ir);
-
-               rom_nlinf = new ROMNonlinearForm(num_basis, ufes);
-               rom_nlinf->AddDomainIntegrator(nl_integ);
-               rom_nlinf->UpdateDomainIntegratorSampling(0, sample_el, sample_qp, sample_qw);
-               rom_nlinf->SetBasis(u_basis);
-               rom_nlinf->SetPrecomputeMode(precompute);
-
-               if (precompute)
-                  rom_nlinf->PrecomputeCoefficients();
-
-               eqprom = new EQPROM(lin_rom, *rom_nlinf);
-               rom_oper = eqprom;
-            }  // case RomMode::EQP:
-            break;
-            default:
-               mfem_error("ROM Mode is not set!");
-            break;
-         }
-         
-         Vector rom_rhs(num_basis), rom_sol(num_basis);
-         if (rom_mode == RomMode::TENSOR2)
-         {
-            rom_rhs.SetSize(num_basis + num_pbasis);
-            rom_sol.SetSize(num_basis + num_pbasis);
-         }
-         basis.MultTranspose((*oper.GetRHS()), rom_rhs);
-         rom_sol = 0.0;
-
-         double atol=1.0e-10, rtol=1.0e-10;
-         int maxIter=10000;
-
-         GMRESSolver J_gmres;
-         J_gmres.SetAbsTol(atol);
-         J_gmres.SetRelTol(rtol);
-         J_gmres.SetMaxIter(maxIter);
-         J_gmres.SetPrintLevel(-1);
-
-         MUMPSSolver J_mumps;
-         J_mumps.SetMatrixSymType(MUMPSSolver::MatType::UNSYMMETRIC);
-
-         Solver *J_solver;
-         if (direct_solve)
-            J_solver = &J_mumps;
-         else
-            J_solver = &J_gmres;
-
-         NewtonSolver newton_solver;
-         newton_solver.SetSolver(*J_solver);
-         newton_solver.SetOperator(*rom_oper);
-         newton_solver.SetPrintLevel(1); // print Newton iterations
-         newton_solver.SetRelTol(rtol);
-         newton_solver.SetAbsTol(atol);
-         newton_solver.SetMaxIter(100);
-
-         StopWatch solveTimer;
-         solveTimer.Start();
-         newton_solver.Mult(rom_rhs, rom_sol);
-         solveTimer.Stop();
-         // printf("ROM mult: %.3E sec\n", rom_oper.multTimer.RealTime());
-         // printf("ROM jac: %.3E sec\n", rom_oper.jacTimer.RealTime());
-         printf("ROM solve: %.3E sec\n", solveTimer.RealTime());
-
-         double rom_mult, rom_jac;
-         switch (rom_mode)
-         {
-            case RomMode::TENSOR:
-            case RomMode::TENSOR2:
-            {
-               rom_mult = tenrom->GetAvgMultTime();
-               rom_jac = tenrom->GetAvgGradTime();
-            }
-            break;
-            case RomMode::EQP:
-            {
-               rom_mult = eqprom->GetAvgMultTime();
-               rom_jac = eqprom->GetAvgGradTime();
-            }
-            break;
-         }
-
-         Vector sol(basis.NumRows());
-         basis.Mult(rom_sol, sol);
-         GridFunction *u_rom = new GridFunction;
-         GridFunction *p_rom = new GridFunction;
-         u_rom->MakeRef(ufes, sol, 0);
-         p_rom->MakeRef(pfes, sol, ufes->GetVSize());
-
-         // FOM solve.
-         oper.Solve();
-         const double fom_mult = oper.GetAvgMultTime();
-         const double fom_jac = oper.GetAvgGradTime();
-         const double fom_solve = oper.GetSolveTime();
-
-         // 12. Create the grid functions u and p. Compute the L2 error norms.
-         GridFunction *u = oper.GetVelocityGridFunction();
-         GridFunction *p = oper.GetPressureGridFunction();
-
-         GridFunction *u_error = new GridFunction(ufes);
-         GridFunction *p_error = new GridFunction(pfes);
-         *u_error = *u_rom;
-         *u_error -= *u;
-         *p_error = *p_rom;
-         *p_error -= *p;
-
-         // set a pressure constant just for relative error.
-         (*p) += 1.0;
-         (*p_rom) += 1.0;
-         VectorGridFunctionCoefficient u_coeff(u), p_coeff(p);
-
-         int order_quad = max(2, 2*(order+1)+1);
-         const IntegrationRule *irs[Geometry::NumGeom];
-         for (int i=0; i < Geometry::NumGeom; ++i)
-         {
-            irs[i] = &(IntRules.Get(i, order_quad));
-         }
-
-         double err_u  = u_rom->ComputeL2Error(u_coeff, irs);
-         double norm_u = ComputeLpNorm(2., u_coeff, *mesh, irs);
-         double err_p  = p_rom->ComputeL2Error(p_coeff, irs);
-         double norm_p = ComputeLpNorm(2., p_coeff, *mesh, irs);
-
-         printf("|| u_h - u_ex || / || u_ex || = %.5E\n", err_u / norm_u);
-         printf("|| p_h - p_ex || / || p_ex || = %.5E\n", err_p / norm_p);
-
-         if ( (err_p / norm_p) > 1.0e-1 )
-         {
-            printf("Pressure relative error > 0.1\n");
-            printf("u0: ");
-            for (int d = 0; d < problem::u0.Size(); d++)
-               printf("%.3E\t", problem::u0(d));
-            printf("\n");
-            printf("du: ");
-            for (int d = 0; d < problem::u0.Size(); d++)
-               printf("%.3E\t", problem::du(d));
-            printf("\n");
-            printf("offsets: ");
-            for (int d = 0; d < problem::u0.Size(); d++)
-               printf("%.3E\t", problem::offsets(d));
-            printf("\n");
-            printf("k:\n");
-            for (int d = 0; d < problem::u0.Size(); d++)
-            {
-               for (int d2 = 0; d2 < problem::u0.Size(); d2++)
-                  printf("%.3E\t", problem::k(d, d2));
-               printf("\n");
-            }
-         }
-
-         // 15. Save data in the ParaView format
-         ParaViewDataCollection paraview_dc("ns_paraview", mesh);
-         paraview_dc.SetLevelsOfDetail(order+1);
-         paraview_dc.RegisterField("velocity", u);
-         paraview_dc.RegisterField("pressure", p);
-         paraview_dc.RegisterField("vel_rom", u_rom);
-         paraview_dc.RegisterField("pres_rom", p_rom);
-         paraview_dc.RegisterField("vel_error", u_error);
-         paraview_dc.RegisterField("pres_error", p_error);
-         Array<GridFunction *> basisgf_u(num_basis), basisgf_p(num_basis);
-         for (int k = 0; k < num_basis; k++)
-         {
-            basisgf_u[k] = new GridFunction(ufes);
-            basisgf_u[k]->MakeRef(ufes, basis.GetColumn(k));
-            std::string ustr = "u_basis" + std::to_string(k);
-            paraview_dc.RegisterField(ustr.c_str(), basisgf_u[k]);
-
-            if (rom_mode != RomMode::TENSOR2)
-            {
-               basisgf_p[k] = new GridFunction(pfes);
-               basisgf_p[k]->MakeRef(pfes, basis.GetColumn(k) + ufes->GetVSize());
-               std::string pstr = "p_basis" + std::to_string(k);
-               paraview_dc.RegisterField(pstr.c_str(), basisgf_p[k]);
-            }
-         }
-         if (rom_mode == RomMode::TENSOR2)
-         {
-            basisgf_p.SetSize(num_pbasis);
-            for (int k = 0; k < num_pbasis; k++)
-            {
-               basisgf_p[k] = new GridFunction(pfes);
-               basisgf_p[k]->MakeRef(pfes, pbasis.GetColumn(k));
-               std::string pstr = "p_basis" + std::to_string(k);
-               paraview_dc.RegisterField(pstr.c_str(), basisgf_p[k]);
-            }
-         }
-
-         paraview_dc.Save();
-
-         {  // save the comparison result to a hdf5 file.
             hid_t file_id;
             herr_t errf = 0;
-            file_id = H5Fcreate(compare_output_file, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT);
+            file_id = H5Fcreate(tensor_file.c_str(), H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT);
             assert(file_id >= 0);
 
-            Array<double> params;
-            for (int d = 0; d < problem::u0.Size(); d++) params.Append(problem::u0(d));
-            for (int d = 0; d < problem::u0.Size(); d++) params.Append(problem::du(d));
-            for (int d = 0; d < problem::u0.Size(); d++) params.Append(problem::offsets(d));
-            for (int d = 0; d < problem::u0.Size(); d++)
-               for (int d2 = 0; d2 < problem::u0.Size(); d2++)
-                  params.Append(problem::k(d, d2));
-
-            hdf5_utils::WriteAttribute(file_id, "fom/mult", fom_mult);
-            hdf5_utils::WriteAttribute(file_id, "fom/grad", fom_jac);
-            hdf5_utils::WriteAttribute(file_id, "fom/solve", fom_solve);
-            hdf5_utils::WriteAttribute(file_id, "rom/mult", rom_mult);
-            hdf5_utils::WriteAttribute(file_id, "rom/grad", rom_jac);
-            hdf5_utils::WriteAttribute(file_id, "rom/solve", solveTimer.RealTime());
-            hdf5_utils::WriteAttribute(file_id, "rel_error/u", err_u / norm_u);
-            hdf5_utils::WriteAttribute(file_id, "rel_error/p", err_p / norm_p);
-            hdf5_utils::WriteDataset(file_id, "params", params);
+            hdf5_utils::WriteDataset(file_id, "tensor", *nlin_rom);
 
             errf = H5Fclose(file_id);
             assert(errf >= 0);
          }
 
-         for (int k = 0; k < num_basis; k++)
-         {
-            delete basisgf_u[k];
-         }
-         int tmp = (rom_mode == RomMode::TENSOR2) ? num_pbasis : num_basis;
-         for (int k = 0; k < tmp; k++)
-         {
-            delete basisgf_p[k];
-         }
-         delete linear_term;
-         delete u_rom;
-         delete p_rom;
-         delete u_error;
-         delete p_error;
          delete nlin_rom;
-         delete rom_oper;
-         delete rom_nlinf;
-      }
-      break;
-      default:
+      }  // if (rom_mode == RomMode::TENSOR)
+      else if (rom_mode == RomMode::TENSOR2)
       {
-         mfem_error("Unknown main mode!\n");
+         DenseMatrix ubasis;
+         CAROM::BasisReader ubasis_reader(filename + "_vel");
+         const CAROM::Matrix *carom_ubasis = ubasis_reader.getSpatialBasis(0.0, num_basis);
+         CAROM::CopyMatrix(*carom_ubasis, ubasis);
+
+         DenseTensor *nlin_rom = oper.GetReducedTensor(ubasis);
+         {  // save the sample to a hdf5 file.
+            std::string tensor_file = filename + "_tensor.h5";
+
+            hid_t file_id;
+            herr_t errf = 0;
+            file_id = H5Fcreate(tensor_file.c_str(), H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT);
+            assert(file_id >= 0);
+
+            hdf5_utils::WriteDataset(file_id, "tensor", *nlin_rom);
+
+            errf = H5Fclose(file_id);
+            assert(errf >= 0);
+         }
+
+      }  // if (rom_mode == RomMode::TENSOR2)
+      else if (rom_mode == RomMode::EQP)
+      {
+         const int fom_vdofs = oper.Height();
+         CAROM::Options option(fom_vdofs, nsample, 1, false);
+         CAROM::BasisGenerator snapshot_generator(option, false, filename);
+         // std::string snapshot_filename = filename + "_snapshot";
+         snapshot_generator.loadSamples(filename + "_snapshot", "snapshot");
+         // TODO: what happen if we do not deep-copy?
+         const CAROM::Matrix *snapshots = snapshot_generator.getSnapshotMatrix();
+
+         const IntegrationRule *ir = oper.GetNonlinearIntRule();
+         auto nl_integ = new VectorConvectionTrilinearFormIntegrator(*(oper.GetZeta()));
+         nl_integ->SetIntRule(ir);
+
+         const int nqe = ir->GetNPoints();
+         const int ne = ufes->GetNE();
+         const int NB = basis.NumCols();
+         const int NQ = ne * nqe;
+         const int nsnap = min(1000, snapshots->numColumns());
+
+         assert(basis.NumRows() == snapshots->numRows());
+         assert(basis.NumRows() == (ufes->GetTrueVSize() + pfes->GetTrueVSize()));
+
+         // Compute G of size (NB * nsnap) x NQ, but only store its transpose Gt.
+         CAROM::Matrix Gt(NQ, NB * nsnap, true);
+         // For 0 <= j < NB, 0 <= i < nsnap, 0 <= e < ne, 0 <= m < nqe,
+         // G(j + (i*NB), (e*nqe) + m)
+         // is the coefficient of v_j^T M(p_i) V v_i at point m of element e,
+         // with respect to the integration rule weight at that point,
+         // where the "exact" quadrature solution is ir0->GetWeights().
+
+         Vector v_i(ufes->GetTrueVSize());
+         Vector r(nqe);
+
+         Array<int> vdofs;
+         Vector el_x, el_tr;
+         DenseMatrix el_quad;
+         const FiniteElement *fe;
+         ElementTransformation *T;
+         DofTransformation *doftrans;
+
+         for (int i = 0; i < nsnap; ++i)
+         {
+            for (int k = 0; k < ufes->GetTrueVSize(); ++k)
+                  v_i[k] = (*snapshots)(k, i);
+
+            for (int e = 0; e < ne; ++e)
+            {
+               fe = ufes->GetFE(e);
+               doftrans = ufes->GetElementVDofs(e, vdofs);
+               T = ufes->GetElementTransformation(e);
+               v_i.GetSubVector(vdofs, el_x);
+
+               const int nd = fe->GetDof();
+               el_quad.SetSize(nd * dim, nqe);
+               for (int i = 0; i < ir->GetNPoints(); i++)
+               {
+                  Vector EQ(el_quad.GetColumn(i), nd * dim);
+
+                  const IntegrationPoint &ip = ir->IntPoint(i);
+                  nl_integ->AssembleQuadratureVector(*fe, *T, ip, 1.0, el_x, EQ);
+               }
+               // nl_integ->AssembleElementQuadrature(*fe, *T, el_x, el_quad);
+
+               for (int j = 0; j < NB; ++j)
+               {
+                  Vector v_j(basis.GetColumn(j), ufes->GetVSize());
+                  v_j.GetSubVector(vdofs, el_tr);
+
+                  el_quad.MultTranspose(el_tr, r);
+
+                  for (int m = 0; m < nqe; ++m)
+                     Gt(m + (e * nqe), j + (i * NB)) = r[m];
+               }  // for (int j = 0; j < NB; ++j)
+            }  // for (int e = 0; e < ne; ++e)
+
+            // if (precondition)
+            // {
+               // // Preconditioning is done by (V^T M(p_i) V)^{-1} (of size NB x NB).
+               // PreconditionNNLS(fespace_R, new VectorFEMassIntegrator(a_coeff), BR, i, Gt);
+            // }
+         }  // for (int i = 0; i < nsnap; ++i)
+
+         Array<double> const& w_el = ir->GetWeights();
+         CAROM::Vector w(ne * nqe, true);
+
+         for (int i = 0; i < ne; ++i)
+            for (int j = 0; j < nqe; ++j)
+               w(j + (i * nqe)) = w_el[j];
+
+         //    void SolveNNLS(const int rank, const double nnls_tol, const int maxNNLSnnz,
+         // CAROM::Vector const& w, CAROM::Matrix & Gt,
+         // CAROM::Vector & sol)
+         double nnls_tol = 1.0e-11;
+         int maxNNLSnnz = 0;
+         const double delta = eqp_tol;
+         CAROM::Vector eqpSol(ne * nqe, true);
+         CAROM::Vector rhs_Gw(Gt.numColumns(), false);
+         // G.mult(w, rhs_ub);  // rhs = Gw
+         // rhs = Gw. Note that by using Gt and multTranspose, we do parallel communication.
+         Gt.transposeMult(w, rhs_Gw);
+         int nnz = 0;
+         {
+            CAROM::NNLSSolver nnls(nnls_tol, 0, maxNNLSnnz, 2);
+
+            CAROM::Vector rhs_ub(rhs_Gw);
+            CAROM::Vector rhs_lb(rhs_Gw);
+
+            for (int i = 0; i < rhs_ub.dim(); ++i)
+            {
+               rhs_lb(i) -= delta;
+               rhs_ub(i) += delta;
+            }
+
+            // nnls.normalize_constraints(Gt, rhs_lb, rhs_ub);
+            nnls.solve_parallel_with_scalapack(Gt, rhs_lb, rhs_ub, eqpSol);
+
+            nnz = 0;
+            for (int i = 0; i < eqpSol.dim(); ++i)
+            {
+               if (eqpSol(i) != 0.0)
+               {
+                     nnz++;
+               }
+            }
+
+            cout << rank << ": Number of nonzeros in NNLS solution: " << nnz
+                  << ", out of " << eqpSol.dim() << endl;
+
+            MPI_Allreduce(MPI_IN_PLACE, &nnz, 1, MPI_INT, MPI_SUM, MPI_COMM_WORLD);
+
+            if (rank == 0)
+               cout << "Global number of nonzeros in NNLS solution: " << nnz << endl;
+
+            // Check residual of NNLS solution
+            CAROM::Vector res(Gt.numColumns(), false);
+            Gt.transposeMult(eqpSol, res);
+
+            const double normGsol = res.norm();
+            const double normRHS = rhs_Gw.norm();
+
+            res -= rhs_Gw;
+            const double relNorm = res.norm() / std::max(normGsol, normRHS);
+            cout << rank << ": relative residual norm for NNLS solution of Gs = Gw: " <<
+                  relNorm << endl;
+
+         }
+
+         Array<int> sample_el(0), sample_qp(0);
+         Array<double> sample_qw(0);
+         for (int i = 0; i < eqpSol.dim(); ++i)
+         {
+            if (eqpSol(i) > 1.0e-12)
+            {
+               const int e = i / nqe;  // Element index
+               sample_el.Append(i / nqe);
+               sample_qp.Append(i % nqe);
+               sample_qw.Append(eqpSol(i));
+            }
+         }
+         printf("Size of sampled qp: %d\n", sample_el.Size());
+         if (nnz != sample_el.Size())
+            printf("Sample quadrature points with weight < 1.0e-12 are neglected.\n");
+
+         {  // save the sample to a hdf5 file.
+            std::string sample_file = filename + "_sample.h5";
+
+            hid_t file_id;
+            herr_t errf = 0;
+            file_id = H5Fcreate(sample_file.c_str(), H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT);
+            assert(file_id >= 0);
+
+            hdf5_utils::WriteDataset(file_id, "sample_element", sample_el);
+            hdf5_utils::WriteDataset(file_id, "sample_quadrature_point", sample_qp);
+            hdf5_utils::WriteDataset(file_id, "sample_quadrature_weight", sample_qw);
+
+            errf = H5Fclose(file_id);
+            assert(errf >= 0);
+         }
+      }  // if (rom_mode == RomMode::EQP)
+   }  // if (mode == Mode::BUILD)
+
+   if (mode == Mode::COMPARE)
+   {
+      if (random_sample)
+      {
+         for (int d = 0; d < problem::u0.Size(); d++)
+         {
+            problem::u0(d) = 2.0 * UniformRandom() - 1.0;
+            problem::du(d) = 0.1 * (2.0 * UniformRandom() - 1.0);
+            problem::offsets(d) = UniformRandom();
+
+            for (int d2 = 0; d2 < problem::u0.Size(); d2++)
+               problem::k(d, d2) = 0.5 * (2.0 * UniformRandom() - 1.0);
+         }
       }
-   }  // mms mode
+      else
+      {
+         problem::du = 0.0;
+         problem::offsets = 0.0;
+         problem::k = 0.0;
+
+         problem::u0(0) = 1.0;
+         problem::u0(1) = -1.0;
+         printf("u0: (%f, %f)\n", problem::u0(0), problem::u0(1));
+      }
+
+      oper.SetupProblem();
+
+      DenseMatrix basis, u_basis, ubasis, pbasis, basisM;
+      if (wgt_basis)
+      {
+         {  // load basis from a hdf5 format.
+            std::string basis_file = filename + "_basis.h5";
+            hid_t file_id;
+            herr_t errf = 0;
+            file_id = H5Fopen(basis_file.c_str(), H5F_ACC_RDONLY, H5P_DEFAULT);
+            assert(file_id >= 0);
+
+            hdf5_utils::ReadDataset(file_id, "basis", basis);
+
+            errf = H5Fclose(file_id);
+            assert(errf >= 0);
+
+            if (num_basis != basis.NumCols())
+            {
+               assert(num_basis < basis.NumCols());
+               basis.SetSize(basis.NumRows(), num_basis);
+            }
+         }
+
+         printf("weight on pressure: %.3E\n", pres_wgt);
+         Vector wgt(oper.Height());
+         wgt = 1.0;
+         for (int k = ufes->GetTrueVSize(); k < wgt.Size(); k++) wgt(k) = pres_wgt;
+         basisM = basis;
+         basisM.RightScaling(wgt);
+      }  // if (wgt_basis)
+      else if (rom_mode == RomMode::TENSOR2)
+      {
+         CAROM::BasisReader ubasis_reader(filename + "_vel");
+         CAROM::BasisReader pbasis_reader(filename + "_pres");
+         const CAROM::Matrix *carom_ubasis = ubasis_reader.getSpatialBasis(0.0, num_basis);
+         const CAROM::Matrix *carom_pbasis = pbasis_reader.getSpatialBasis(0.0, num_pbasis);
+         CAROM::CopyMatrix(*carom_ubasis, ubasis);
+         CAROM::CopyMatrix(*carom_pbasis, pbasis);
+
+         basis.SetSize(ubasis.NumRows() + pbasis.NumRows(), ubasis.NumCols() + pbasis.NumCols());
+         Array<int> uridx(ubasis.NumRows()), ucidx(ubasis.NumCols()), pridx(pbasis.NumRows()), pcidx(pbasis.NumCols());
+         for (int k = 0; k < ubasis.NumRows(); k++) uridx[k] = k;
+         for (int k = 0; k < ubasis.NumCols(); k++) ucidx[k] = k;
+         for (int k = 0; k < pbasis.NumRows(); k++) pridx[k] = k + ubasis.NumRows();
+         for (int k = 0; k < pbasis.NumCols(); k++) pcidx[k] = k + ubasis.NumCols();
+         basis = 0.0;
+         basis.SetSubMatrix(uridx, ucidx, ubasis);
+         basis.SetSubMatrix(pridx, pcidx, pbasis);
+      }  // if (rom_mode == RomMode::TENSOR2)
+      else
+      {
+         CAROM::BasisReader basis_reader(filename);
+         const CAROM::Matrix *carom_basis = basis_reader.getSpatialBasis(0.0, num_basis);
+         CAROM::CopyMatrix(*carom_basis, basis);
+      }
+
+      SparseMatrix *linear_term = oper.GetLinearTerm();
+      DenseMatrix lin_rom;
+      if (wgt_basis)
+         mfem::RtAP(basisM, *linear_term, basis, lin_rom);
+      else
+         mfem::RtAP(basis, *linear_term, basis, lin_rom);
+
+      PrintMatrix(*linear_term, filename+"_linop.txt");
+
+      u_basis.CopyRows(basis, 0, ufes->GetTrueVSize() - 1); // indexes are inclusive.
+
+      DenseTensor *nlin_rom = NULL;
+      ROMNonlinearForm *rom_nlinf = NULL;
+      Operator *rom_oper = NULL;
+      TensorROM *tenrom = NULL;
+      EQPROM *eqprom = NULL;
+
+      if (rom_mode == RomMode::TENSOR)
+      {
+         nlin_rom = new DenseTensor;
+         {  // load the sample from a hdf5 file.
+            std::string tensor_file = filename + "_tensor.h5";
+
+            hid_t file_id;
+            herr_t errf = 0;
+            file_id = H5Fopen(tensor_file.c_str(), H5F_ACC_RDONLY, H5P_DEFAULT);
+            assert(file_id >= 0);
+
+            hdf5_utils::ReadDataset(file_id, "tensor", *nlin_rom);
+
+            errf = H5Fclose(file_id);
+            assert(errf >= 0);
+         }
+
+         tenrom = new TensorROM(lin_rom, *nlin_rom);
+         rom_oper = tenrom;
+      }  // if (rom_mode == RomMode::TENSOR)
+      else if (rom_mode == RomMode::TENSOR2)
+      {
+         nlin_rom = new DenseTensor;
+         {  // load the sample from a hdf5 file.
+            std::string tensor_file = filename + "_tensor.h5";
+
+            hid_t file_id;
+            herr_t errf = 0;
+            file_id = H5Fopen(tensor_file.c_str(), H5F_ACC_RDONLY, H5P_DEFAULT);
+            assert(file_id >= 0);
+
+            hdf5_utils::ReadDataset(file_id, "tensor", *nlin_rom);
+
+            errf = H5Fclose(file_id);
+            assert(errf >= 0);
+         }
+
+         tenrom = new TensorROM2(lin_rom, *nlin_rom);
+         rom_oper = tenrom;
+      }  // if (rom_mode == RomMode::TENSOR2)
+      else if (rom_mode == RomMode::EQP)
+      {
+         Array<int> sample_el, sample_qp;
+         Array<double> sample_qw;
+         {  // load the sample from a hdf5 file.
+            std::string sample_file = filename + "_sample.h5";
+
+            hid_t file_id;
+            herr_t errf = 0;
+            file_id = H5Fopen(sample_file.c_str(), H5F_ACC_RDONLY, H5P_DEFAULT);
+            assert(file_id >= 0);
+
+            hdf5_utils::ReadDataset(file_id, "sample_element", sample_el);
+            hdf5_utils::ReadDataset(file_id, "sample_quadrature_point", sample_qp);
+            hdf5_utils::ReadDataset(file_id, "sample_quadrature_weight", sample_qw);
+
+            errf = H5Fclose(file_id);
+            assert(errf >= 0);
+         }
+
+         const IntegrationRule *ir = oper.GetNonlinearIntRule();
+         auto nl_integ = new VectorConvectionTrilinearFormIntegrator(*(oper.GetZeta()));
+         nl_integ->SetIntRule(ir);
+
+         rom_nlinf = new ROMNonlinearForm(num_basis, ufes);
+         rom_nlinf->AddDomainIntegrator(nl_integ);
+         rom_nlinf->UpdateDomainIntegratorSampling(0, sample_el, sample_qp, sample_qw);
+         rom_nlinf->SetBasis(u_basis);
+         rom_nlinf->SetPrecomputeMode(precompute);
+
+         if (precompute)
+            rom_nlinf->PrecomputeCoefficients();
+
+         eqprom = new EQPROM(lin_rom, *rom_nlinf);
+         rom_oper = eqprom;
+      }  // if (rom_mode == RomMode::EQP)
+      else
+         mfem_error("ROM Mode is not set!");
+      
+      Vector rom_rhs(num_basis), rom_sol(num_basis);
+      if (rom_mode == RomMode::TENSOR2)
+      {
+         rom_rhs.SetSize(num_basis + num_pbasis);
+         rom_sol.SetSize(num_basis + num_pbasis);
+      }
+      basis.MultTranspose((*oper.GetRHS()), rom_rhs);
+      rom_sol = 0.0;
+
+      double atol=1.0e-10, rtol=1.0e-10;
+      int maxIter=10000;
+
+      GMRESSolver J_gmres;
+      J_gmres.SetAbsTol(atol);
+      J_gmres.SetRelTol(rtol);
+      J_gmres.SetMaxIter(maxIter);
+      J_gmres.SetPrintLevel(-1);
+
+      MUMPSSolver J_mumps;
+      J_mumps.SetMatrixSymType(MUMPSSolver::MatType::UNSYMMETRIC);
+
+      Solver *J_solver;
+      if (direct_solve)
+         J_solver = &J_mumps;
+      else
+         J_solver = &J_gmres;
+
+      NewtonSolver newton_solver;
+      newton_solver.SetSolver(*J_solver);
+      newton_solver.SetOperator(*rom_oper);
+      newton_solver.SetPrintLevel(1); // print Newton iterations
+      newton_solver.SetRelTol(rtol);
+      newton_solver.SetAbsTol(atol);
+      newton_solver.SetMaxIter(100);
+
+      StopWatch solveTimer;
+      solveTimer.Start();
+      newton_solver.Mult(rom_rhs, rom_sol);
+      solveTimer.Stop();
+      // printf("ROM mult: %.3E sec\n", rom_oper.multTimer.RealTime());
+      // printf("ROM jac: %.3E sec\n", rom_oper.jacTimer.RealTime());
+      printf("ROM solve: %.3E sec\n", solveTimer.RealTime());
+
+      double rom_mult, rom_jac;
+      switch (rom_mode)
+      {
+         case RomMode::TENSOR:
+         case RomMode::TENSOR2:
+         {
+            rom_mult = tenrom->GetAvgMultTime();
+            rom_jac = tenrom->GetAvgGradTime();
+         }
+         break;
+         case RomMode::EQP:
+         {
+            rom_mult = eqprom->GetAvgMultTime();
+            rom_jac = eqprom->GetAvgGradTime();
+         }
+         break;
+      }
+
+      Vector sol(basis.NumRows());
+      basis.Mult(rom_sol, sol);
+      GridFunction *u_rom = new GridFunction;
+      GridFunction *p_rom = new GridFunction;
+      u_rom->MakeRef(ufes, sol, 0);
+      p_rom->MakeRef(pfes, sol, ufes->GetVSize());
+
+      // FOM solve.
+      oper.Solve();
+      const double fom_mult = oper.GetAvgMultTime();
+      const double fom_jac = oper.GetAvgGradTime();
+      const double fom_solve = oper.GetSolveTime();
+
+      // 12. Create the grid functions u and p. Compute the L2 error norms.
+      GridFunction *u = oper.GetVelocityGridFunction();
+      GridFunction *p = oper.GetPressureGridFunction();
+
+      GridFunction *u_error = new GridFunction(ufes);
+      GridFunction *p_error = new GridFunction(pfes);
+      *u_error = *u_rom;
+      *u_error -= *u;
+      *p_error = *p_rom;
+      *p_error -= *p;
+
+      // set a pressure constant just for relative error.
+      (*p) += 1.0;
+      (*p_rom) += 1.0;
+      VectorGridFunctionCoefficient u_coeff(u), p_coeff(p);
+
+      int order_quad = max(2, 2*(order+1)+1);
+      const IntegrationRule *irs[Geometry::NumGeom];
+      for (int i=0; i < Geometry::NumGeom; ++i)
+      {
+         irs[i] = &(IntRules.Get(i, order_quad));
+      }
+
+      double err_u  = u_rom->ComputeL2Error(u_coeff, irs);
+      double norm_u = ComputeLpNorm(2., u_coeff, *mesh, irs);
+      double err_p  = p_rom->ComputeL2Error(p_coeff, irs);
+      double norm_p = ComputeLpNorm(2., p_coeff, *mesh, irs);
+
+      printf("|| u_h - u_ex || / || u_ex || = %.5E\n", err_u / norm_u);
+      printf("|| p_h - p_ex || / || p_ex || = %.5E\n", err_p / norm_p);
+
+      if ( (err_p / norm_p) > 1.0e-1 )
+      {
+         printf("Pressure relative error > 0.1\n");
+         printf("u0: ");
+         for (int d = 0; d < problem::u0.Size(); d++)
+            printf("%.3E\t", problem::u0(d));
+         printf("\n");
+         printf("du: ");
+         for (int d = 0; d < problem::u0.Size(); d++)
+            printf("%.3E\t", problem::du(d));
+         printf("\n");
+         printf("offsets: ");
+         for (int d = 0; d < problem::u0.Size(); d++)
+            printf("%.3E\t", problem::offsets(d));
+         printf("\n");
+         printf("k:\n");
+         for (int d = 0; d < problem::u0.Size(); d++)
+         {
+            for (int d2 = 0; d2 < problem::u0.Size(); d2++)
+               printf("%.3E\t", problem::k(d, d2));
+            printf("\n");
+         }
+      }
+
+      // 15. Save data in the ParaView format
+      ParaViewDataCollection paraview_dc("ns_paraview", mesh);
+      paraview_dc.SetLevelsOfDetail(order+1);
+      paraview_dc.RegisterField("velocity", u);
+      paraview_dc.RegisterField("pressure", p);
+      paraview_dc.RegisterField("vel_rom", u_rom);
+      paraview_dc.RegisterField("pres_rom", p_rom);
+      paraview_dc.RegisterField("vel_error", u_error);
+      paraview_dc.RegisterField("pres_error", p_error);
+      Array<GridFunction *> basisgf_u(num_basis), basisgf_p(num_basis);
+      for (int k = 0; k < num_basis; k++)
+      {
+         basisgf_u[k] = new GridFunction(ufes);
+         basisgf_u[k]->MakeRef(ufes, basis.GetColumn(k));
+         std::string ustr = "u_basis" + std::to_string(k);
+         paraview_dc.RegisterField(ustr.c_str(), basisgf_u[k]);
+
+         if (rom_mode != RomMode::TENSOR2)
+         {
+            basisgf_p[k] = new GridFunction(pfes);
+            basisgf_p[k]->MakeRef(pfes, basis.GetColumn(k) + ufes->GetVSize());
+            std::string pstr = "p_basis" + std::to_string(k);
+            paraview_dc.RegisterField(pstr.c_str(), basisgf_p[k]);
+         }
+      }
+      if (rom_mode == RomMode::TENSOR2)
+      {
+         basisgf_p.SetSize(num_pbasis);
+         for (int k = 0; k < num_pbasis; k++)
+         {
+            basisgf_p[k] = new GridFunction(pfes);
+            basisgf_p[k]->MakeRef(pfes, pbasis.GetColumn(k));
+            std::string pstr = "p_basis" + std::to_string(k);
+            paraview_dc.RegisterField(pstr.c_str(), basisgf_p[k]);
+         }
+      }
+
+      paraview_dc.Save();
+
+      {  // save the comparison result to a hdf5 file.
+         hid_t file_id;
+         herr_t errf = 0;
+         file_id = H5Fcreate(compare_output_file, H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT);
+         assert(file_id >= 0);
+
+         Array<double> params;
+         for (int d = 0; d < problem::u0.Size(); d++) params.Append(problem::u0(d));
+         for (int d = 0; d < problem::u0.Size(); d++) params.Append(problem::du(d));
+         for (int d = 0; d < problem::u0.Size(); d++) params.Append(problem::offsets(d));
+         for (int d = 0; d < problem::u0.Size(); d++)
+            for (int d2 = 0; d2 < problem::u0.Size(); d2++)
+               params.Append(problem::k(d, d2));
+
+         hdf5_utils::WriteAttribute(file_id, "fom/mult", fom_mult);
+         hdf5_utils::WriteAttribute(file_id, "fom/grad", fom_jac);
+         hdf5_utils::WriteAttribute(file_id, "fom/solve", fom_solve);
+         hdf5_utils::WriteAttribute(file_id, "rom/mult", rom_mult);
+         hdf5_utils::WriteAttribute(file_id, "rom/grad", rom_jac);
+         hdf5_utils::WriteAttribute(file_id, "rom/solve", solveTimer.RealTime());
+         hdf5_utils::WriteAttribute(file_id, "rel_error/u", err_u / norm_u);
+         hdf5_utils::WriteAttribute(file_id, "rel_error/p", err_p / norm_p);
+         hdf5_utils::WriteDataset(file_id, "params", params);
+
+         errf = H5Fclose(file_id);
+         assert(errf >= 0);
+      }
+
+      for (int k = 0; k < num_basis; k++)
+      {
+         delete basisgf_u[k];
+      }
+      int tmp = (rom_mode == RomMode::TENSOR2) ? num_pbasis : num_basis;
+      for (int k = 0; k < tmp; k++)
+      {
+         delete basisgf_p[k];
+      }
+      delete linear_term;
+      delete u_rom;
+      delete p_rom;
+      delete u_error;
+      delete p_error;
+      delete nlin_rom;
+      delete rom_oper;
+      delete rom_nlinf;
+   }  // if (mode == Mode::BUILD)
    
    // 17. Free the used memory.
    delete mesh;

--- a/sketches/ns_rom.cpp
+++ b/sketches/ns_rom.cpp
@@ -1022,6 +1022,8 @@ int main(int argc, char *argv[])
          for (int d = 0; d < rom_sv->dim(); d++)
             printf("%.3E\t", rom_sv->item(d));
          printf("\n");
+         std::string sv_file = filename + "_sv.txt";
+         CAROM::PrintVector(*rom_sv, sv_file);
       }
       break;
       case (Mode::BUILD):
@@ -1388,10 +1390,6 @@ int main(int argc, char *argv[])
          }
 
          oper.SetupProblem();
-         oper.Solve();
-         const double fom_mult = oper.GetAvgMultTime();
-         const double fom_jac = oper.GetAvgGradTime();
-         const double fom_solve = oper.GetSolveTime();
 
          DenseMatrix basis, u_basis, ubasis, pbasis, basisM;
          if (wgt_basis)
@@ -1454,6 +1452,8 @@ int main(int argc, char *argv[])
             mfem::RtAP(basisM, *linear_term, basis, lin_rom);
          else
             mfem::RtAP(basis, *linear_term, basis, lin_rom);
+
+         PrintMatrix(*linear_term, filename+"_linop.txt");
 
          u_basis.CopyRows(basis, 0, ufes->GetTrueVSize() - 1); // indexes are inclusive.
 
@@ -1615,6 +1615,12 @@ int main(int argc, char *argv[])
          GridFunction *p_rom = new GridFunction;
          u_rom->MakeRef(ufes, sol, 0);
          p_rom->MakeRef(pfes, sol, ufes->GetVSize());
+
+         // FOM solve.
+         oper.Solve();
+         const double fom_mult = oper.GetAvgMultTime();
+         const double fom_jac = oper.GetAvgGradTime();
+         const double fom_solve = oper.GetSolveTime();
 
          // 12. Create the grid functions u and p. Compute the L2 error norms.
          GridFunction *u = oper.GetVelocityGridFunction();

--- a/src/linalg_utils.cpp
+++ b/src/linalg_utils.cpp
@@ -589,22 +589,24 @@ void TensorAddScaledMultTranspose(const DenseTensor &tensor, const double w, con
 double CGOptimizer::Objective(const Vector &rhs, const Vector &sol) const
 {
    assert(oper);
-   oper->Mult(sol, res);
-   res -= rhs;
-   return (res * res);
+   resvec = 0.0;
+   oper->Mult(sol, resvec);
+   resvec -= rhs;
+   return (resvec * resvec);
 }
 
 void CGOptimizer::Gradient(const Vector &rhs, const Vector &sol, Vector &grad) const
 {
    assert(oper);
    grad.SetSize(sol.Size());
+   resvec = 0.0;
    grad = 0.0;
 
-   oper->Mult(sol, res);
-   res -= rhs;
-   res *= 2.0;
+   oper->Mult(sol, resvec);
+   resvec -= rhs;
+   resvec *= 2.0;
    Operator *jac = &(oper->GetGradient(sol));
-   jac->MultTranspose(res, grad);
+   jac->MultTranspose(resvec, grad);
    return;
 }
 
@@ -620,7 +622,7 @@ double CGOptimizer::Brent(const Vector &rhs, const Vector &xi, Vector &sol, doub
    J_brak[0] = Objective(rhs, sol);
    add(sol, b0, xi, sol1); // sol1 = sol + b0 * xi;
    double J1 = Objective(rhs, sol1);
-   while (J1 > J_brak[1])
+   while (J1 > J_brak[0])
    {
       b0 /= golden_ratio;
       add(sol, b0, xi, sol1); // sol1 = sol + b0 * xi;
@@ -696,6 +698,7 @@ void CGOptimizer::Mult(const Vector &rhs, Vector &sol) const
 
    double Jmin = Objective(rhs, sol);
    double res0 = sqrt(Jmin);
+   printf("Initial iteration: ||r|| = %.4E\n", res0);
 
    Gradient(rhs, sol, g);
 

--- a/src/linalg_utils.cpp
+++ b/src/linalg_utils.cpp
@@ -134,6 +134,25 @@ void PrintVector(const CAROM::Vector &vec,
 namespace mfem
 {
 
+void GramSchmidt(DenseMatrix& mat)
+{
+   const int num_row = mat.NumCols();
+   const int num_col = mat.NumCols();
+   Vector vec_c, tmp;
+   for (int c = 0; c < num_col; c++)
+   {
+      mat.GetColumnReference(c, vec_c);
+
+      for (int i = 0; i < c; i++)
+      {
+         mat.GetColumnReference(i, tmp);
+         vec_c.Add(-(tmp * vec_c), tmp);
+      }
+
+      vec_c /= sqrt(vec_c * vec_c);
+   }
+}
+
 void RtAP(DenseMatrix& R,
          const Operator& A,
          DenseMatrix& P,

--- a/src/linalg_utils.cpp
+++ b/src/linalg_utils.cpp
@@ -586,4 +586,165 @@ void TensorAddScaledMultTranspose(const DenseTensor &tensor, const double w, con
    return;
 }
 
+double CGOptimizer::Objective(const Vector &rhs, const Vector &sol) const
+{
+   assert(oper);
+   oper->Mult(sol, res);
+   res -= rhs;
+   return (res * res);
+}
+
+void CGOptimizer::Gradient(const Vector &rhs, const Vector &sol, Vector &grad) const
+{
+   assert(oper);
+   grad.SetSize(sol.Size());
+   grad = 0.0;
+
+   oper->Mult(sol, res);
+   res -= rhs;
+   res *= 2.0;
+   Operator *jac = &(oper->GetGradient(sol));
+   jac->MultTranspose(res, grad);
+   return;
+}
+
+double CGOptimizer::Brent(const Vector &rhs, const Vector &xi, Vector &sol, double b0, double lin_tol) const
+{
+   sol1.SetSize(sol.Size());
+
+   // initial bracket
+   Vector step(N_mnbrak+1), J_brak(N_mnbrak);
+   step = 0.0;
+   J_brak = 0.0;
+
+   J_brak[0] = Objective(rhs, sol);
+   add(sol, b0, xi, sol1); // sol1 = sol + b0 * xi;
+   double J1 = Objective(rhs, sol1);
+   while (J1 > J_brak[1])
+   {
+      b0 /= golden_ratio;
+      add(sol, b0, xi, sol1); // sol1 = sol + b0 * xi;
+      J1 = Objective(rhs, sol1);
+   }
+
+   double amp = b0;
+   double a, b, c, fa, fb, fc;
+   for (int j = 1; j < N_mnbrak+1; j++)
+   {
+      add(sol, amp, xi, sol1); // sol1 = sol + amp * xi;
+      step[j] = amp;
+      J_brak[j] = Objective(rhs, sol1);
+      
+      if (J_brak[j] > J_brak[j-1])
+      {
+         a = step[j-2]; b = step[j-1]; c = step[j];
+         fa = J_brak[j-2]; fb = J_brak[j-1]; fc = J_brak[j];
+         break;
+      }
+      else
+         amp *= golden_ratio;
+   }
+
+   assert ((a >= 0) && (b > a) && (c > b));
+   Array<double> x_arr(4), J_arr(4);
+
+   // parabolic estimation
+   for (int j = 0; j < N_para; j++)
+   {
+      if ( (c-a) < b * lin_tol + eps ) break;
+      
+      double b_new = b - 0.5 * ( pow(b-a, 2) * (fb-fc) - pow(b-c, 2) * (fb-fa) ) / ( (b-a) * (fb-fc) - (b-c) * (fb-fa) );
+      if ((b_new > c) || (b_new < a) || (abs(log10((c-b) / (b-a))) > 1.0))
+         if ( b > 0.5 * (a+c) )
+            b_new = b - Cr * (b-a);
+         else
+            b_new = b + Cr * (c-b);
+      
+      add(sol, b_new, xi, sol1); // sol1 = sol + b_new * xi;
+      double fbx = Objective(rhs, sol1);
+      
+      x_arr[0] = a; x_arr[3] = c;
+      J_arr[0] = fa; J_arr[3] = fc;
+      if (b_new > b)
+      {
+         x_arr[1] = b; x_arr[2] = b_new;
+         J_arr[1] = fb, J_arr[2] = fbx;
+      }
+      else
+      {
+         x_arr[1] = b_new; x_arr[2] = b;
+         J_arr[1] = fbx, J_arr[2] = fb;
+      }
+
+      fb = J_arr.Min();
+      int idx = J_arr.Find(fb); assert(idx > 0);
+      fa = J_arr[idx-1]; fc = J_arr[idx+1];
+      a = x_arr[idx-1]; b = x_arr[idx]; c = x_arr[idx+1];
+   }
+   
+   sol.Add(b, xi); // sol += b * xi;
+
+   return b;
+}
+
+void CGOptimizer::Mult(const Vector &rhs, Vector &sol) const
+{
+   g.SetSize(sol.Size());
+   xi.SetSize(sol.Size());
+   xi1.SetSize(sol.Size());
+   h.SetSize(sol.Size());
+
+   double Jmin = Objective(rhs, sol);
+   double res0 = sqrt(Jmin);
+
+   Gradient(rhs, sol, g);
+
+   g *= -1.0; xi = g; h = g;
+   double gg0 = g * g;
+
+   double b0 = ib / sqrt(gg0);
+
+   double gg, gg1, dgg, dgg1, res;
+   double gamma, gamma_FR;
+   for (int j = 0; j < max_iter; j++)
+   {
+      // sol is updated within Brent.
+      b0 = Brent(rhs, xi, sol, b0);
+
+      // evaluate one more time to obtain sub-objective functional.
+      Jmin = Objective(rhs, sol);
+      
+      Gradient(rhs, sol, xi);
+      gg = g * g;
+      
+      add(xi, g, xi1);
+      dgg = xi1 * xi;
+      dgg1 = xi * xi;
+      gg1 = g * xi;
+      
+      res = sqrt(Jmin);
+      printf("Iter %d: ||r|| = %.4E, ||r|| / ||r0|| = %.4E\n", j, res, res / res0);
+      if ((res < abs_tol) || (res / res0 < rel_tol))
+      {
+         converged = true;
+         printf("CG minimization finished.");
+         break;
+      }
+         
+      gamma = dgg / gg;
+      gamma_FR = dgg1 / gg;
+      if (j > 0)
+         if (gamma < -gamma_FR)
+            gamma = -gamma_FR;
+         else if (gamma > gamma_FR)
+            gamma = gamma_FR;
+      
+      g.Set(-1.0, xi);
+      add(g, gamma, h, xi);
+      h = xi;
+   }
+
+   return;
+}
+
 }

--- a/src/main_workflow.cpp
+++ b/src/main_workflow.cpp
@@ -113,7 +113,9 @@ void GenerateSamples(MPI_Comm comm)
       test->BuildOperators();
       test->SetupBCOperators();
       test->Assemble();
-      test->Solve();
+      bool converged = test->Solve();
+      if (!converged)
+         mfem_error("A sample solution fails to converge!\n");
       test->SaveSolution(sol_file);
       test->SaveVisualization();
 

--- a/src/main_workflow.cpp
+++ b/src/main_workflow.cpp
@@ -89,10 +89,12 @@ void GenerateSamples(MPI_Comm comm)
    YAML::Node dict0 = YAML::Clone(config.dict_);
    ParameterizedProblem *problem = InitParameterizedProblem();
    SampleGenerator *sample_generator = InitSampleGenerator(comm);
+   SampleGeneratorType sample_gen_type = sample_generator->GetType();
    sample_generator->SetParamSpaceSizes();
    MultiBlockSolver *test = NULL;
 
-   for (int s = 0; s < sample_generator->GetTotalSampleSize(); s++)
+   int s = 0;
+   while (s < sample_generator->GetTotalSampleSize())
    {
       if (!sample_generator->IsMyJob(s)) continue;
 
@@ -113,9 +115,22 @@ void GenerateSamples(MPI_Comm comm)
       test->BuildOperators();
       test->SetupBCOperators();
       test->Assemble();
+
       bool converged = test->Solve();
       if (!converged)
-         mfem_error("A sample solution fails to converge!\n");
+      {
+         // If deterministic, terminate the sampling here.
+         if (sample_gen_type == BASE)
+            mfem_error("A sample solution fails to converge!\n");
+         else if (sample_gen_type == RANDOM)
+         {
+            // if random, try another sample.
+            mfem_warning("A sample solution failed to converge. Trying another sample.\n");
+            delete test;
+            continue;
+         }
+      }
+         
       test->SaveSolution(sol_file);
       test->SaveVisualization();
 
@@ -131,6 +146,8 @@ void GenerateSamples(MPI_Comm comm)
 
       delete U_snapshots;
       delete test;
+
+      s++;
    }
    sample_generator->WriteSnapshots();
 

--- a/src/poisson_solver.cpp
+++ b/src/poisson_solver.cpp
@@ -431,8 +431,11 @@ void PoissonSolver::BuildInterfaceROMElement(Array<FiniteElementSpace *> &fes_co
    }  // for (int p = 0; p < num_ref_ports; p++)
 }
 
-void PoissonSolver::Solve()
+bool PoissonSolver::Solve()
 {
+   // If using direct solver, returns always true.
+   bool converged = true;
+
    int maxIter = config.GetOption<int>("solver/max_iter", 10000);
    double rtol = config.GetOption<double>("solver/relative_tolerance", 1.e-15);
    double atol = config.GetOption<double>("solver/absolute_tolerance", 1.e-15);
@@ -488,6 +491,7 @@ void PoissonSolver::Solve()
       solver->Mult(*RHS, *U);
       // test.Stop();
       // printf("test: %f seconds.\n", test.RealTime());
+      converged = solver->GetConverged();
 
       // delete the created objects.
       if (use_amg)
@@ -500,6 +504,8 @@ void PoissonSolver::Solve()
       }
       delete solver;
    }
+
+   return converged;
 }
 
 void PoissonSolver::ProjectOperatorOnReducedBasis()

--- a/src/rom_handler.cpp
+++ b/src/rom_handler.cpp
@@ -746,15 +746,33 @@ void MFEMROMHandler::NonlinearSolve(Operator &oper, BlockVector* U, Solver *prec
       J_solver = iter_solver;
    }
 
-   NewtonSolver newton_solver;
-   newton_solver.SetSolver(*J_solver);
-   newton_solver.SetOperator(oper);
-   newton_solver.SetPrintLevel(print_level); // print Newton iterations
-   newton_solver.SetRelTol(rtol);
-   newton_solver.SetAbsTol(atol);
-   newton_solver.SetMaxIter(maxIter);
+   std::string nlin_solver = config.GetOption<std::string>("model_reduction/nonlinear_solver_type", "newton");
 
-   newton_solver.Mult(*reduced_rhs, *reduced_sol);
+   if (nlin_solver == "newton")
+   {
+      NewtonSolver newton_solver;
+      newton_solver.SetSolver(*J_solver);
+      newton_solver.SetOperator(oper);
+      newton_solver.SetPrintLevel(print_level); // print Newton iterations
+      newton_solver.SetRelTol(rtol);
+      newton_solver.SetAbsTol(atol);
+      newton_solver.SetMaxIter(maxIter);
+
+      newton_solver.Mult(*reduced_rhs, *reduced_sol);
+   }
+   else if (nlin_solver == "cg")
+   {
+      CGOptimizer optim;
+      optim.SetOperator(oper);
+      optim.SetPrintLevel(print_level); // print Newton iterations
+      optim.SetRelTol(rtol);
+      optim.SetAbsTol(atol);
+      optim.SetMaxIter(maxIter);
+
+      optim.Mult(*reduced_rhs, *reduced_sol);
+   }
+   else
+      mfem_error("MFEMROMHandler::NonlinearSolve- Unknown ROM nonlinear solver type!\n");
 
    for (int i = 0; i < numSub; i++)
    {

--- a/src/steady_ns_solver.cpp
+++ b/src/steady_ns_solver.cpp
@@ -613,6 +613,14 @@ void SteadyNSSolver::SolveROM()
    for (int m = 0; m < numSub; m++) assert(subdomain_tensors[m]);
 
    BlockVector U_domain(U->GetData(), domain_offsets); // View vector for U.
+   bool use_restart = config.GetOption<bool>("solver/use_restart", false);
+   std::string restart_file;
+   if (use_restart)
+   {
+      restart_file = config.GetRequiredOption<std::string>("solver/restart_file");
+      LoadSolution(restart_file);
+   }
+
    // NOTE(kevin): currently assumes direct solve.
    SteadyNSTensorROM rom_oper(rom_handler->GetOperator(), subdomain_tensors, *(rom_handler->GetBlockOffsets()));
    rom_handler->NonlinearSolve(rom_oper, &U_domain);

--- a/src/steady_ns_solver.cpp
+++ b/src/steady_ns_solver.cpp
@@ -481,7 +481,7 @@ void SteadyNSSolver::LoadCompBdrROMElement(hid_t &file_id)
       subdomain_tensors[m] = comp_tensors[rom_handler->GetBasisIndexForSubdomain(m)];
 }
 
-void SteadyNSSolver::Solve()
+bool SteadyNSSolver::Solve()
 {
    int maxIter = config.GetOption<int>("solver/max_iter", 100);
    double rtol = config.GetOption<double>("solver/relative_tolerance", 1.e-10);
@@ -551,6 +551,7 @@ void SteadyNSSolver::Solve()
    newton_solver->SetMaxIter(maxIter);
 
    newton_solver->Mult(rhs_byvar, sol_byvar);
+   bool converged = newton_solver->GetConverged();
 
    // orthogonalize the pressure.
    if (!pres_dbc)
@@ -563,6 +564,8 @@ void SteadyNSSolver::Solve()
    }
 
    SortBySubdomains(sol_byvar, *U);
+
+   return converged;
 }
 
 void SteadyNSSolver::ProjectOperatorOnReducedBasis()

--- a/src/stokes_solver.cpp
+++ b/src/stokes_solver.cpp
@@ -677,8 +677,11 @@ void StokesSolver::BuildInterfaceROMElement(Array<FiniteElementSpace *> &fes_com
    }  // for (int p = 0; p < num_ref_ports; p++)
 }
 
-void StokesSolver::Solve()
+bool StokesSolver::Solve()
 {
+   // If using direct solver, returns always true.
+   bool converged = true;
+
    int maxIter = config.GetOption<int>("solver/max_iter", 10000);
    double rtol = config.GetOption<double>("solver/relative_tolerance", 1.e-15);
    double atol = config.GetOption<double>("solver/absolute_tolerance", 1.e-15);
@@ -753,6 +756,7 @@ void StokesSolver::Solve()
          solver.SetPreconditioner(*systemPrec);
       solver.SetPrintLevel(print_level);
       solver.Mult(rhs_byvar, sol_byvar);
+      converged = solver.GetConverged();
 
       if (use_amg)
       {
@@ -775,6 +779,8 @@ void StokesSolver::Solve()
    }
 
    SortBySubdomains(sol_byvar, *U);
+
+   return converged;
 }
 
 void StokesSolver::Solve_obsolete()

--- a/test/gmsh/test_multi_comp_workflow.cpp
+++ b/test/gmsh/test_multi_comp_workflow.cpp
@@ -11,6 +11,7 @@ using namespace mfem;
 
 static const double threshold = 1.0e-14;
 static const double stokes_threshold = 1.0e-12;
+static const double ns_threshold = 1.0e-9;
 
 /**
  * Simple smoke test to make sure Google Test is properly linked
@@ -133,6 +134,42 @@ TEST(MultiComponentGlobalROM, StokesTestDirectSolve)
    // This reproductive case must have a very small error at the level of finite-precision.
    printf("Error: %.15E\n", error);
    EXPECT_TRUE(error < stokes_threshold);
+
+   return;
+}
+
+TEST(MultiComponentGlobalROM, SteadyNSTestDirectSolve)
+{
+   config = InputParser("stokes.component.yml");
+   config.dict_["main"]["solver"] = "steady-ns";
+   config.dict_["mesh"]["uniform_refinement"] = 3;
+   config.dict_["solver"]["print_level"] = 1;
+
+   config.dict_["model_reduction"]["save_operator"]["level"] = "global";
+   config.dict_["solver"]["direct_solve"] = true;
+   config.dict_["model_reduction"]["linear_solver_type"] = "direct";
+   config.dict_["model_reduction"]["linear_system_type"] = "sid";
+
+   printf("\nSample Generation \n\n");
+   
+   config.dict_["main"]["mode"] = "sample_generation";
+   GenerateSamples(MPI_COMM_WORLD);
+
+   config.dict_["main"]["mode"] = "train_rom";
+   TrainROM(MPI_COMM_WORLD);
+
+   printf("\nBuild ROM \n\n");
+
+   config.dict_["mesh"]["type"] = "component-wise";
+   config.dict_["main"]["mode"] = "build_rom";
+   BuildROM(MPI_COMM_WORLD);
+
+   config.dict_["main"]["mode"] = "single_run";
+   double error = SingleRun(MPI_COMM_WORLD);
+
+   // This reproductive case must have a very small error at the level of finite-precision.
+   printf("Error: %.15E\n", error);
+   EXPECT_TRUE(error < ns_threshold);
 
    return;
 }


### PR DESCRIPTION
`sketches/ns_rom` supports various ROM basis and projection:
- `RomMode::TENSOR`: u/p unified basis
- `RomMode::TENSOR2`: u/p separate basis
- `RomMode::TENSOR3`: u-only basis
- `RomMode::TENSOR4`: u/p separate basis with supremizer enrichment
- `RomMode::TENSOR5`: u/p separate basis with supremizer projection

Minor changes in `SteadyNSSolver`:
- Sample generation process collects another sample if a sample fails to converge.
- `CGOptimizer` class of optimization solver.
- `SteadyNSSolver::SolveROM` supports restart from a FOM solution.