### PR TITLE
ROM elements saved with the universal names

### DIFF
--- a/include/component_topology_handler.hpp
+++ b/include/component_topology_handler.hpp
@@ -148,6 +148,7 @@ public:
 
    // return component indexes for a reference port (ComponentTopologyHandler only)
    virtual void GetComponentPair(const int &ref_port_idx, int &comp1, int &comp2);
+   virtual void GetRefPortInfo(const int &ref_port_idx, int &comp1, int &comp2, int &attr1, int &attr2);
 
    // Export mesh pointers and interface info.
    virtual void ExportInfo(Array<Mesh*> &mesh_ptrs, TopologyData &topol_data);

--- a/include/linalg_utils.hpp
+++ b/include/linalg_utils.hpp
@@ -119,7 +119,7 @@ printf("operator= const MatrixBlocks.\n");
 
 void AddToBlockMatrix(const Array<int> &ridx, const Array<int> &cidx, const MatrixBlocks &mats, BlockMatrix &bmat);
 
-void GramSchmidt(DenseMatrix& mat);
+void modifiedGramSchmidt(DenseMatrix& mat);
 
 /* Orthonormalize mat over mat1 and itself. */
 void Orthonormalize(DenseMatrix& mat1, DenseMatrix& mat);

--- a/include/multiblock_solver.hpp
+++ b/include/multiblock_solver.hpp
@@ -110,6 +110,7 @@ public:
    const int GetDim() const { return dim; }
    const int GetNumSubdomains() const { return numSub; }
    const int GetNumBdr() const { return numBdr; }
+   const int GetNumVar() const { return num_var; }
    Mesh* GetMesh(const int k) { return &(*meshes[k]); }
    GridFunction* GetGridFunction(const int k) { return us[k]; }
    const int GetDiscretizationOrder() const { return order; }
@@ -223,8 +224,8 @@ public:
    virtual void SetParameterizedProblem(ParameterizedProblem *problem) = 0;
 
    void ComputeSubdomainErrorAndNorm(GridFunction *fom_sol, GridFunction *rom_sol, double &error, double &norm);
-   double ComputeRelativeError(Array<GridFunction *> fom_sols, Array<GridFunction *> rom_sols);
-   double CompareSolution(BlockVector &test_U);
+   void ComputeRelativeError(Array<GridFunction *> fom_sols, Array<GridFunction *> rom_sols, Vector &error);
+   void CompareSolution(BlockVector &test_U, Vector &error);
 };
 
 #endif

--- a/include/topology_handler.hpp
+++ b/include/topology_handler.hpp
@@ -110,6 +110,8 @@ public:
    // return component indexes for a reference port
    virtual void GetComponentPair(const int &ref_port_idx, int &comp1, int &comp2)
    { mfem_error("TopologyHandler::GetComponentPair is abstract method!\n"); return; }
+   virtual void GetRefPortInfo(const int &ref_port_idx, int &comp1, int &comp2, int &attr1, int &attr2)
+   { mfem_error("TopologyHandler::GetRefPortInfo is abstract method!\n"); return; }
    virtual Array<InterfaceInfo>* const GetRefInterfaceInfos(const int &k)
    { mfem_error("TopologyHandler::GetRefInterfaceInfos is abstract method!\n"); return NULL; }
    virtual Array<int>* GetBdrAttrComponentToGlobalMap(const int &m)

--- a/sketches/ns_rom.cpp
+++ b/sketches/ns_rom.cpp
@@ -1375,7 +1375,7 @@ int main(int argc, char *argv[])
          basis.SetSubMatrix(uridx, ucidx, supreme);
 
          // Orthonormalize over the entire velocity basis for now.
-         GramSchmidt(basis);
+         modifiedGramSchmidt(basis);
 
          DenseTensor *nlin_rom = NULL;
          if (rom_mode == RomMode::TENSOR4)

--- a/sketches/ns_rom.cpp
+++ b/sketches/ns_rom.cpp
@@ -1576,6 +1576,22 @@ int main(int argc, char *argv[])
          if (nnz != sample_el.Size())
             printf("Sample quadrature points with weight < 1.0e-12 are neglected.\n");
 
+         {  // save empirical quadrature point locations.
+            ElementTransformation *T;
+            Vector loc(dim);
+            DenseMatrix qp_loc(sample_el.Size(), dim);
+            for (int p = 0; p < sample_el.Size(); p++)
+            {
+               T = ufes->GetElementTransformation(sample_el[p]);
+               const IntegrationPoint &ip = ir->IntPoint(sample_qp[p]);
+               T->Transform(ip, loc);
+
+               for (int d = 0; d < dim; d++)
+                  qp_loc(p, d) = loc(d);
+            }
+            PrintMatrix(qp_loc, filename + "_eqp_loc.txt");
+         }
+
          {  // save the sample to a hdf5 file.
             std::string sample_file = filename + "_sample.h5";
 

--- a/src/component_topology_handler.cpp
+++ b/src/component_topology_handler.cpp
@@ -86,6 +86,14 @@ void ComponentTopologyHandler::GetComponentPair(const int &ref_port_idx, int &co
    return;
 }
 
+void ComponentTopologyHandler::GetRefPortInfo(const int &ref_port_idx, int &comp1, int &comp2, int &attr1, int &attr2)
+{
+   GetComponentPair(ref_port_idx, comp1, comp2);
+
+   attr1 = ref_ports[ref_port_idx]->Attr1;
+   attr2 = ref_ports[ref_port_idx]->Attr2;
+}
+
 void ComponentTopologyHandler::ExportInfo(Array<Mesh*> &mesh_ptrs, TopologyData &topol_data)
 {
    mesh_ptrs = meshes;

--- a/src/linalg_utils.cpp
+++ b/src/linalg_utils.cpp
@@ -164,22 +164,22 @@ void AddToBlockMatrix(const Array<int> &ridx, const Array<int> &cidx, const Matr
       }
 }
 
-void GramSchmidt(DenseMatrix& mat)
+void modifiedGramSchmidt(DenseMatrix& mat)
 {
    const int num_row = mat.NumRows();
    const int num_col = mat.NumCols();
    Vector vec_c, tmp;
+   /* modified Gram-Schmidt orthonormalization */
    for (int c = 0; c < num_col; c++)
    {
       mat.GetColumnReference(c, vec_c);
+      vec_c /= sqrt(vec_c * vec_c);
 
-      for (int i = 0; i < c; i++)
+      for (int i = c + 1; i < num_col; i++)
       {
          mat.GetColumnReference(i, tmp);
-         vec_c.Add(-(tmp * vec_c), tmp);
+         tmp.Add(-(tmp * vec_c), vec_c);
       }
-
-      vec_c /= sqrt(vec_c * vec_c);
    }
 }
 
@@ -191,25 +191,21 @@ void Orthonormalize(DenseMatrix& mat1, DenseMatrix& mat)
    assert(num_row == mat1.NumRows());
 
    Vector vec_c, tmp;
-   for (int c = 0; c < num_col; c++)
+   double tmp_dot;
+   /* we don't assume mat1 is normalized. */
+   for (int i = 0; i < num_col1; i++)
    {
-      mat.GetColumnReference(c, vec_c);
-
-      /* we don't assume mat1 is normalized. */
-      for (int i = 0; i < num_col1; i++)
+      mat1.GetColumnReference(i, tmp);
+      tmp_dot = (tmp * tmp);
+      for (int c = 0; c < num_col; c++)
       {
-         mat1.GetColumnReference(i, tmp);
-         vec_c.Add(-(tmp * vec_c) / (tmp * tmp), tmp);
+         mat.GetColumnReference(c, vec_c);
+         vec_c.Add(-(tmp * vec_c) / tmp_dot, tmp);
       }
-
-      for (int i = 0; i < c; i++)
-      {
-         mat.GetColumnReference(i, tmp);
-         vec_c.Add(-(tmp * vec_c), tmp);
-      }
-
-      vec_c /= sqrt(vec_c * vec_c);
    }
+
+   /* modified Gram-Schmidt orthonormalization */
+   modifiedGramSchmidt(mat);
 }
 
 void RtAP(DenseMatrix& R,

--- a/src/multiblock_solver.cpp
+++ b/src/multiblock_solver.cpp
@@ -315,10 +315,13 @@ void MultiBlockSolver::SaveCompBdrROMElement(hid_t &file_id)
 
    hdf5_utils::WriteAttribute(grp_id, "number_of_components", num_comp);
 
+   std::string dset_name;
    for (int c = 0; c < num_comp; c++)
    {
+      dset_name = topol_handler->GetComponentName(c);
+
       hid_t comp_grp_id;
-      comp_grp_id = H5Gcreate(grp_id, std::to_string(c).c_str(), H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
+      comp_grp_id = H5Gcreate(grp_id, dset_name.c_str(), H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
       assert(comp_grp_id >= 0);
 
       hdf5_utils::WriteDataset(comp_grp_id, "domain", *comp_mats[c]);
@@ -418,14 +421,17 @@ void MultiBlockSolver::LoadCompBdrROMElement(hid_t &file_id)
 
    int num_comp;
    hdf5_utils::ReadAttribute(grp_id, "number_of_components", num_comp);
-   assert(num_comp == topol_handler->GetNumComponents());
-   assert(comp_mats.Size() == num_comp);
-   assert(bdr_mats.Size() == num_comp);
+   assert(num_comp >= topol_handler->GetNumComponents());
+   assert(comp_mats.Size() == topol_handler->GetNumComponents());
+   assert(bdr_mats.Size() == topol_handler->GetNumComponents());
 
+   std::string dset_name;
    for (int c = 0; c < num_comp; c++)
    {
+      dset_name = topol_handler->GetComponentName(c);
+
       hid_t comp_grp_id;
-      comp_grp_id = H5Gopen2(grp_id, std::to_string(c).c_str(), H5P_DEFAULT);
+      comp_grp_id = H5Gopen2(grp_id, dset_name.c_str(), H5P_DEFAULT);
       assert(comp_grp_id >= 0);
 
       hdf5_utils::ReadDataset(comp_grp_id, "domain", *comp_mats[c]);

--- a/src/multiblock_solver.cpp
+++ b/src/multiblock_solver.cpp
@@ -426,7 +426,7 @@ void MultiBlockSolver::LoadCompBdrROMElement(hid_t &file_id)
    assert(bdr_mats.Size() == topol_handler->GetNumComponents());
 
    std::string dset_name;
-   for (int c = 0; c < num_comp; c++)
+   for (int c = 0; c < topol_handler->GetNumComponents(); c++)
    {
       dset_name = topol_handler->GetComponentName(c);
 
@@ -486,7 +486,7 @@ void MultiBlockSolver::LoadInterfaceROMElement(hid_t &file_id)
 
    std::string dset_name;
    int c1, c2, a1, a2;
-   for (int p = 0; p < num_ref_ports; p++)
+   for (int p = 0; p < topol_handler->GetNumRefPorts(); p++)
    {
       topol_handler->GetRefPortInfo(p, c1, c2, a1, a2);
       dset_name = topol_handler->GetComponentName(c1) + ":" + topol_handler->GetComponentName(c2);

--- a/src/multiblock_solver.cpp
+++ b/src/multiblock_solver.cpp
@@ -841,12 +841,13 @@ void MultiBlockSolver::ComputeSubdomainErrorAndNorm(GridFunction *fom_sol, GridF
    }
 }
 
-double MultiBlockSolver::ComputeRelativeError(Array<GridFunction *> fom_sols, Array<GridFunction *> rom_sols)
+void MultiBlockSolver::ComputeRelativeError(Array<GridFunction *> fom_sols, Array<GridFunction *> rom_sols, Vector &error)
 {
    assert(fom_sols.Size() == (num_var * numSub));
    assert(rom_sols.Size() == (num_var * numSub));
 
-   Vector norm(num_var), error(num_var);
+   Vector norm(num_var);
+   error.SetSize(num_var);
    norm = 0.0; error = 0.0;
    for (int m = 0, idx = 0; m < numSub; m++)
    {
@@ -867,11 +868,9 @@ double MultiBlockSolver::ComputeRelativeError(Array<GridFunction *> fom_sols, Ar
       error[v] /= norm[v];
       printf("Variable %d relative error: %.5E\n", v, error[v]);
    }
-
-   return error.Max();
 }
 
-double MultiBlockSolver::CompareSolution(BlockVector &test_U)
+void MultiBlockSolver::CompareSolution(BlockVector &test_U, Vector &error)
 {
    assert(test_U.NumBlocks() == U->NumBlocks());
    for (int b = 0; b < U->NumBlocks(); b++)
@@ -890,10 +889,8 @@ double MultiBlockSolver::CompareSolution(BlockVector &test_U)
 
    // Compare the solution.
    // Maximum L2-error / L2-norm over all variables.
-   double error = ComputeRelativeError(us, test_us);
-   printf("Relative error: %.5E\n", error);
+   error.SetSize(num_var);
+   ComputeRelativeError(us, test_us, error);
 
    DeletePointers(test_us);
-
-   return error;
 }

--- a/src/multiblock_solver.cpp
+++ b/src/multiblock_solver.cpp
@@ -371,8 +371,15 @@ void MultiBlockSolver::SaveInterfaceROMElement(hid_t &file_id)
 
    hdf5_utils::WriteAttribute(grp_id, "number_of_ports", num_ref_ports);
    
+   std::string dset_name;
+   int c1, c2, a1, a2;
    for (int p = 0; p < num_ref_ports; p++)
-      hdf5_utils::WriteDataset(grp_id, std::to_string(p), *port_mats[p]);
+   {
+      topol_handler->GetRefPortInfo(p, c1, c2, a1, a2);
+      dset_name = topol_handler->GetComponentName(c1) + ":" + topol_handler->GetComponentName(c2);
+      dset_name += "-" + std::to_string(a1) + ":" + std::to_string(a2);
+      hdf5_utils::WriteDataset(grp_id, dset_name, *port_mats[p]);
+   }
 
    errf = H5Gclose(grp_id);
    assert(errf >= 0);
@@ -468,11 +475,18 @@ void MultiBlockSolver::LoadInterfaceROMElement(hid_t &file_id)
 
    int num_ref_ports;
    hdf5_utils::ReadAttribute(grp_id, "number_of_ports", num_ref_ports);
-   assert(num_ref_ports == topol_handler->GetNumRefPorts());
-   assert(port_mats.Size() == num_ref_ports);
+   assert(num_ref_ports >= topol_handler->GetNumRefPorts());
+   assert(port_mats.Size() == topol_handler->GetNumRefPorts());
 
+   std::string dset_name;
+   int c1, c2, a1, a2;
    for (int p = 0; p < num_ref_ports; p++)
-      hdf5_utils::ReadDataset(grp_id, std::to_string(p), *port_mats[p]);
+   {
+      topol_handler->GetRefPortInfo(p, c1, c2, a1, a2);
+      dset_name = topol_handler->GetComponentName(c1) + ":" + topol_handler->GetComponentName(c2);
+      dset_name += "-" + std::to_string(a1) + ":" + std::to_string(a2);
+      hdf5_utils::ReadDataset(grp_id, dset_name, *port_mats[p]);
+   }
 
    errf = H5Gclose(grp_id);
    assert(errf >= 0);

--- a/src/steady_ns_solver.cpp
+++ b/src/steady_ns_solver.cpp
@@ -468,12 +468,14 @@ void SteadyNSSolver::SaveCompBdrROMElement(hid_t &file_id)
    grp_id = H5Gopen2(file_id, "components", H5P_DEFAULT);
    assert(grp_id >= 0);
 
+   std::string dset_name;
    for (int c = 0; c < num_comp; c++)
    {
       assert(comp_tensors[c]);
+      dset_name = topol_handler->GetComponentName(c);
 
       hid_t comp_grp_id;
-      comp_grp_id = H5Gopen2(grp_id, std::to_string(c).c_str(), H5P_DEFAULT);
+      comp_grp_id = H5Gopen2(grp_id, dset_name.c_str(), H5P_DEFAULT);
       assert(comp_grp_id >= 0);
 
       hdf5_utils::WriteDataset(comp_grp_id, "tensor", *comp_tensors[c]);
@@ -499,10 +501,13 @@ void SteadyNSSolver::LoadCompBdrROMElement(hid_t &file_id)
    grp_id = H5Gopen2(file_id, "components", H5P_DEFAULT);
    assert(grp_id >= 0);
 
+   std::string dset_name;
    for (int c = 0; c < num_comp; c++)
    {
+      dset_name = topol_handler->GetComponentName(c);
+
       hid_t comp_grp_id;
-      comp_grp_id = H5Gopen2(grp_id, std::to_string(c).c_str(), H5P_DEFAULT);
+      comp_grp_id = H5Gopen2(grp_id, dset_name.c_str(), H5P_DEFAULT);
       assert(comp_grp_id >= 0);
 
       comp_tensors[c] = new DenseTensor;

--- a/src/stokes_solver.cpp
+++ b/src/stokes_solver.cpp
@@ -965,7 +965,7 @@ void StokesSolver::LoadSupremizer()
       {
          hid_t file_id;
          herr_t errf = 0;
-         std::string filename(basis_prefix + basis_tag + ".h5");
+         std::string filename(basis_prefix + "_" + basis_tag + ".h5");
          printf("\nOpening file %s.. ", filename.c_str());
          file_id = H5Fopen(filename.c_str(), H5F_ACC_RDONLY, H5P_DEFAULT);
          assert(file_id >= 0);
@@ -1325,7 +1325,7 @@ void StokesSolver::EnrichSupremizer()
       {
          hid_t file_id;
          herr_t errf = 0;
-         std::string filename(basis_prefix + basis_tag + ".h5");
+         std::string filename(basis_prefix + "_" + basis_tag + ".h5");
          file_id = H5Fcreate(filename.c_str(), H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT);
          assert(file_id >= 0);
 

--- a/test/nonlinear_integ_grad.cpp
+++ b/test/nonlinear_integ_grad.cpp
@@ -144,7 +144,7 @@ void CheckGradient(NonlinearFormIntegrator *integ, const IntegratorType type, bo
             error1 = error;
       }
    }
-   EXPECT_TRUE(error1 < 1.0e-7);
+   EXPECT_TRUE(error1 < 1.0e-6);
 
    // 17. Free the used memory.
    delete nform;

--- a/test/test_linalg_utils.cpp
+++ b/test/test_linalg_utils.cpp
@@ -84,7 +84,7 @@ TEST(linalg_test, AddMultTransposeSubMatrix)
 
 TEST(linalg_test, Orthonormalize)
 {
-   const double thre = 1.0e-15;
+   const double thre = 1.0e-14;
    const int nrow = 15, ncol1 = 7, ncol = 5;
    DenseMatrix mat1(nrow, ncol1);
    DenseMatrix mat(nrow, ncol);

--- a/test/test_linalg_utils.cpp
+++ b/test/test_linalg_utils.cpp
@@ -82,6 +82,58 @@ TEST(linalg_test, AddMultTransposeSubMatrix)
    return;
 }
 
+TEST(linalg_test, Orthonormalize)
+{
+   const double thre = 1.0e-15;
+   const int nrow = 15, ncol1 = 7, ncol = 5;
+   DenseMatrix mat1(nrow, ncol1);
+   DenseMatrix mat(nrow, ncol);
+   DenseMatrix test(ncol, ncol), test1(ncol1, ncol);
+
+   for (int i = 0; i < nrow; i++)
+   {
+      for (int j = 0; j < ncol; j++)
+         mat(i, j) = UniformRandom();
+
+      for (int j = 0; j < ncol1; j++)
+         mat1(i, j) = UniformRandom();
+   }
+
+   modifiedGramSchmidt(mat1);
+   Vector scale(ncol1);
+   for (int d = 0; d < ncol1; d++)
+      scale(d) = UniformRandom();
+   mat1.RightScaling(scale);
+
+   Orthonormalize(mat1, mat);
+
+   Vector tmp1, tmp2;
+   for (int j = 0; j < ncol; j++)
+   {
+      mat.GetColumnReference(j, tmp1);
+      test.GetColumnReference(j, tmp2);
+      mat.MultTranspose(tmp1, tmp2);
+   }
+   for (int i = 0; i < ncol; i++)
+      for (int j = 0; j < ncol; j++)
+      {
+         double val = (i == j) ? 1.0 : 0.0;
+         EXPECT_NEAR(test(i, j), val, thre);
+      };
+   
+   for (int j = 0; j < ncol; j++)
+   {
+      mat.GetColumnReference(j, tmp1);
+      test1.GetColumnReference(j, tmp2);
+      mat1.MultTranspose(tmp1, tmp2);
+   }
+   for (int i = 0; i < ncol1; i++)
+      for (int j = 0; j < ncol; j++)
+         EXPECT_NEAR(test1(i, j), 0.0, thre);
+
+   return;
+}
+
 // TODO: add more tests from sketches/yaml_example.cpp.
 
 int main(int argc, char* argv[])

--- a/test/test_workflow.cpp
+++ b/test/test_workflow.cpp
@@ -544,7 +544,7 @@ TEST(SteadyNS_Workflow, ComponentSeparateVariable)
    BuildROM(MPI_COMM_WORLD);
 
    config.dict_["main"]["mode"] = "single_run";
-   double error = SingleRun(MPI_COMM_WORLD);
+   double error = SingleRun(MPI_COMM_WORLD, "test_output.h5");
 
    // This reproductive case must have a very small error at the level of finite-precision.
    printf("Error: %.15E\n", error);

--- a/utils/python/box_channel_config.py
+++ b/utils/python/box_channel_config.py
@@ -64,7 +64,12 @@ class BoxChannelConfig(Configuration):
             if ((face1 < 0) or (face2 < 0)): continue
             self.appendInterface(k, -1, face1, face2)
 
-        self.avail_locs.remove(new_loc)
+        used_idx = False
+        for idx, loc in enumerate(self.avail_locs):
+            if (np.array_equal(new_loc, loc)):
+                used_idx = idx
+                break
+        self.avail_locs.pop(used_idx)
         self.comp_used[comp_idx] = True
         return
     

--- a/utils/python/box_comp_config.py
+++ b/utils/python/box_comp_config.py
@@ -1,0 +1,40 @@
+# Copyright 2023 Lawrence Livermore National Security, LLC. See the top-level LICENSE file for details.
+#
+# SPDX-License-Identifier: MIT
+
+import numpy as np
+from copy import deepcopy
+from config import Empty, ObjectInSpace
+from box_channel_config import BoxChannelConfig
+
+if __name__ == "__main__":
+    comp_list = {'empty': Empty(),
+                 'circle': ObjectInSpace('square-circle'),
+                 'square': ObjectInSpace('square-square'),
+                 'triangle': ObjectInSpace('square-triangle'),
+                 'star': ObjectInSpace('square-star'),}
+    
+    example = BoxChannelConfig(1,5)
+    for name, comp in comp_list.items():
+        example.addComponent(comp)
+    
+    for icomp in example.comps:
+        for iloc, iface in icomp.face_map.items():
+            jloc = np.array(iloc)
+            jloc *= -1
+            jloc = tuple(jloc)
+            jface = -1
+            for jcomp in example.comps:
+                if (jloc in jcomp.face_map):
+                    jface = jcomp.face_map[jloc]
+                    break
+            if (jface < 0):
+                continue
+            else:
+                example.appendRefPort(icomp.name, jcomp.name, iface, jface)
+
+    for c in range(len(example.comps)):
+        example.addMesh(c, 0)
+
+    example.close()
+    example.save('box-channel.comp.h5')

--- a/utils/python/box_comp_config.py
+++ b/utils/python/box_comp_config.py
@@ -23,15 +23,18 @@ if __name__ == "__main__":
             jloc = np.array(iloc)
             jloc *= -1
             jloc = tuple(jloc)
-            jface = -1
             for jcomp in example.comps:
+                jface = -1
                 if (jloc in jcomp.face_map):
                     jface = jcomp.face_map[jloc]
-                    break
-            if (jface < 0):
-                continue
-            else:
-                example.appendRefPort(icomp.name, jcomp.name, iface, jface)
+                else:
+                    continue
+                print(icomp.name, jcomp.name, iface, jface)
+                if (jface < 0):
+                    continue
+                else:
+                    print('accepted')
+                    example.appendRefPort(icomp.name, jcomp.name, iface, jface)
 
     for c in range(len(example.comps)):
         example.addMesh(c, 0)

--- a/utils/python/config.py
+++ b/utils/python/config.py
@@ -145,17 +145,10 @@ class Configuration:
         self.meshes[midx1].avail_face.pop(face1)
         self.meshes[midx2].avail_face.pop(face2)
 
-        if (face1 < face2):
-            interface = (self.meshes[midx1].name, self.meshes[midx2].name,
-                         face1, face2)
-        else:
-            interface = (self.meshes[midx2].name, self.meshes[midx1].name,
-                         face2, face1)
-            
-        # add the interface if not exists.
-        if interface not in self.ports:
-            self.ports[interface] = len(self.ports)
-        port = self.ports[interface]
+        self.appendRefPort(self.meshes[midx1].name, self.meshes[midx2].name,
+                           face1, face2)
+        port = self.getRefPort(self.meshes[midx1].name, self.meshes[midx2].name,
+                               face1, face2)
 
         if (face1 < face2):
             if_data = [[midx1, midx2, face1, face2, port]]
@@ -167,6 +160,52 @@ class Configuration:
         else:
             self.if_data = np.append(self.if_data, if_data, axis=0)
         return
+
+    def appendRefPort(self, cname1, cname2, face1, face2):
+        have_c1, have_c2 = False, False
+        for comp in self.comps:
+            if ((not have_c1) and (comp.name == cname1)):
+                have_c1 = True
+            if ((not have_c2) and (comp.name == cname2)):
+                have_c2 = True
+            if (have_c1 and have_c2):
+                break
+        if (not (have_c1 and have_c2)):
+            raise RuntimeError("Configuration does not have components named %s and %s!" % (cname1, cname2))
+
+        if (face1 < face2):
+            interface = (cname1, cname2, face1, face2)
+        else:
+            interface = (cname2, cname1, face2, face1)
+
+        # add the interface if not exists.
+        if interface not in self.ports:
+            self.ports[interface] = len(self.ports)
+        
+        return
+
+    def getRefPort(self, cname1, cname2, face1, face2):
+        have_c1, have_c2 = False, False
+        for comp in self.comps:
+            if ((not have_c1) and (comp.name == cname1)):
+                have_c1 = True
+            if ((not have_c2) and (comp.name == cname2)):
+                have_c2 = True
+            if (have_c1 and have_c2):
+                break
+        if (not (have_c1 and have_c2)):
+            raise RuntimeError("Configuration does not have components named %s and %s!" % (cname1, cname2))
+
+        if (face1 < face2):
+            interface = (cname1, cname2, face1, face2)
+        else:
+            interface = (cname2, cname1, face2, face1)
+
+        # add the interface if not exists.
+        if interface not in self.ports:
+            raise RuntimeError("Configuration does not have the interface (%s, %s, %d, %d)!" % interface)
+        
+        return self.ports[interface]
     
     def save(self, filename):
         comp_name2idx = {}


### PR DESCRIPTION
So far, ROM elements have been saved with names in an arbitrary order. As a result, the ROM elements have to be built for every global configuration, even though they use the same component/port ROM elements. Now the ROM elements are saved with their specific component names or specific pair of the port components. As long as the ROM element file has all the required component/ports, any global configuration can use them without a problem.

Minor changes are:
- `StokesSolver::LoadSupremizer` can load a specified number of supremizers, not necessarily all supremizers saved in the file.
- `utils/python/box_comp_config.py` can built reference component configuration, out of which all ROM elements can be built.
- `sketches/ns_rom`: building EQP will save locations of all empirical quadrature points.
- `StokesSolver::EnrichSupremizer` now uses modified GS, instead of the classic one.