### PR TITLE
EQP training routines in `ROMNonlinearForm` and its application to `SteadyNSSolver`

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,14 +11,17 @@ scaleupROM is mainly built upon [MFEM](https://mfem.org/) and [libROM](https://w
 
 - Discontinuous Galerkin domain decomposition
 - Projection-based reduced order model
+- EQP for nonlinear partial differential equations
 - Supporting physics equations:
   - Poisson equation
   - Stokes flow
+  - Steady Navier-Stokes flow
 
 ## Features to be added
 
-- Steady Navier-Stokes flow
-- EQP for nonlinear partial differential equations
+- Linear elasticity
+- Nonlinear elasticity
+- Time-dependent Navier-Stokes flow
 
 # Installation
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -51,7 +51,7 @@ ENV YAML_DIR=$LIB_DIR/yaml-cpp
 WORKDIR $LIB_DIR
 RUN sudo git clone https://github.com/LLNL/libROM.git
 WORKDIR ./libROM
-RUN sudo git pull && sudo git checkout svd-fix
+RUN sudo git pull && sudo git checkout mpi-io
 WORKDIR ./build
 # libROM is using the MFEM without MUMPS right now.
 RUN sudo cmake .. -DCMAKE_TOOLCHAIN_FILE=${TOOLCHAIN_FILE} -DCMAKE_BUILD_TYPE=${BUILD_TYPE} -DUSE_MFEM=${USE_MFEM} -DMFEM_USE_GSLIB=${MFEM_USE_GSLIB}

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,5 @@
-# FROM ghcr.io/llnl/librom/librom_env:arm64
-FROM ghcr.io/llnl/librom/librom_env:latest
+FROM ghcr.io/llnl/librom/librom_env:arm64
+# FROM ghcr.io/llnl/librom/librom_env:latest
 
 # install parmetis
 WORKDIR $LIB_DIR
@@ -51,7 +51,7 @@ ENV YAML_DIR=$LIB_DIR/yaml-cpp
 WORKDIR $LIB_DIR
 RUN sudo git clone https://github.com/LLNL/libROM.git
 WORKDIR ./libROM
-RUN sudo git pull && sudo git checkout generator-fix2
+RUN sudo git pull && sudo git checkout svd-fix
 WORKDIR ./build
 # libROM is using the MFEM without MUMPS right now.
 RUN sudo cmake .. -DCMAKE_TOOLCHAIN_FILE=${TOOLCHAIN_FILE} -DCMAKE_BUILD_TYPE=${BUILD_TYPE} -DUSE_MFEM=${USE_MFEM} -DMFEM_USE_GSLIB=${MFEM_USE_GSLIB}

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,5 @@
-FROM ghcr.io/llnl/librom/librom_env:arm64
-# FROM ghcr.io/llnl/librom/librom_env:latest
+# FROM ghcr.io/llnl/librom/librom_env:arm64
+FROM ghcr.io/llnl/librom/librom_env:latest
 
 # install parmetis
 WORKDIR $LIB_DIR

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -50,7 +50,9 @@ ENV YAML_DIR=$LIB_DIR/yaml-cpp
 # install libROM for scaleupROM
 WORKDIR $LIB_DIR
 RUN sudo git clone https://github.com/LLNL/libROM.git
-WORKDIR ./libROM/build
+WORKDIR ./libROM
+RUN sudo git pull && sudo git checkout generator-fix2
+WORKDIR ./build
 # libROM is using the MFEM without MUMPS right now.
 RUN sudo cmake .. -DCMAKE_TOOLCHAIN_FILE=${TOOLCHAIN_FILE} -DCMAKE_BUILD_TYPE=${BUILD_TYPE} -DUSE_MFEM=${USE_MFEM} -DMFEM_USE_GSLIB=${MFEM_USE_GSLIB}
 RUN sudo make -j 16

--- a/include/main_workflow.hpp
+++ b/include/main_workflow.hpp
@@ -22,6 +22,8 @@ void BuildROM(MPI_Comm comm);
 void TrainROM(MPI_Comm comm);
 // supremizer-enrichment, hypre-reduction optimization, etc..
 void AuxiliaryTrainROM(MPI_Comm comm);
+// Input parsing routine to list out all snapshot files for training a basis.
+void FindSnapshotFilesForBasis(const std::string &basis_tag, const std::string &default_filename, std::vector<std::string> &file_list);
 // return relative error if comparing solution.
 double SingleRun(MPI_Comm comm, const std::string output_file = "");
 

--- a/include/main_workflow.hpp
+++ b/include/main_workflow.hpp
@@ -21,7 +21,7 @@ void GenerateSamples(MPI_Comm comm);
 void BuildROM(MPI_Comm comm);
 void TrainROM(MPI_Comm comm);
 // supremizer-enrichment, hypre-reduction optimization, etc..
-void AuxiliaryTrainROM(MPI_Comm comm);
+void AuxiliaryTrainROM(MPI_Comm comm, SampleGenerator *sample_generator);
 // Input parsing routine to list out all snapshot files for training a basis.
 void FindSnapshotFilesForBasis(const std::string &basis_tag, const std::string &default_filename, std::vector<std::string> &file_list);
 // return relative error if comparing solution.

--- a/include/multiblock_solver.hpp
+++ b/include/multiblock_solver.hpp
@@ -217,6 +217,8 @@ public:
    { mfem_error("Abstract method MultiBlockSolver::TrainEQP!\n"); }
    virtual void SaveEQP()
    { mfem_error("Abstract method MultiBlockSolver::TrainEQP!\n"); }
+   virtual void LoadEQP()
+   { mfem_error("Abstract method MultiBlockSolver::TrainEQP!\n"); }
 
    void InitROMHandler();
    void GetBasisTags(std::vector<std::string> &basis_tags);

--- a/include/multiblock_solver.hpp
+++ b/include/multiblock_solver.hpp
@@ -215,6 +215,8 @@ public:
 
    virtual void TrainEQP(SampleGenerator *sample_generator)
    { mfem_error("Abstract method MultiBlockSolver::TrainEQP!\n"); }
+   virtual void SaveEQP()
+   { mfem_error("Abstract method MultiBlockSolver::TrainEQP!\n"); }
 
    void InitROMHandler();
    void GetBasisTags(std::vector<std::string> &basis_tags);

--- a/include/multiblock_solver.hpp
+++ b/include/multiblock_solver.hpp
@@ -12,6 +12,7 @@
 #include "parameterized_problem.hpp"
 #include "rom_handler.hpp"
 #include "hdf5_utils.hpp"
+#include "sample_generator.hpp"
 
 // By convention we only use mfem namespace as default, not CAROM.
 using namespace mfem;
@@ -29,6 +30,7 @@ protected:
 
    bool full_dg = true;
    int skip_zeros = 1;
+   bool nonlinear_mode = false;
 
    TopologyHandlerMode topol_mode = NUM_TOPOL_MODE;
    TopologyHandler *topol_handler = NULL;
@@ -114,6 +116,7 @@ public:
    Mesh* GetMesh(const int k) { return &(*meshes[k]); }
    GridFunction* GetGridFunction(const int k) { return us[k]; }
    const int GetDiscretizationOrder() const { return order; }
+   const bool IsNonlinear() const { return nonlinear_mode; }
    const bool UseRom() const { return use_rom; }
    ROMHandlerBase* GetROMHandler() const { return rom_handler; }
    const TrainMode GetTrainMode() { return train_mode; }
@@ -209,6 +212,9 @@ public:
    void SaveSolution(std::string filename = "");
    void LoadSolution(const std::string &filename);
    void CopySolution(BlockVector *input_sol);
+
+   virtual void TrainEQP(SampleGenerator *sample_generator)
+   { mfem_error("Abstract method MultiBlockSolver::TrainEQP!\n"); }
 
    void InitROMHandler();
    void GetBasisTags(std::vector<std::string> &basis_tags);

--- a/include/rom_handler.hpp
+++ b/include/rom_handler.hpp
@@ -135,7 +135,12 @@ public:
    const Array<int>* GetVarBlockOffsets() { return &rom_varblock_offsets; }
    virtual SparseMatrix* GetOperator() = 0;
    const bool GetNonlinearMode() { return nonlinear_mode; }
-   void SetNonlinearMode(const bool nl_mode) { nonlinear_mode = nl_mode; }
+   void SetNonlinearMode(const bool nl_mode)
+   {
+      if (nlin_handle == NonlinearHandling::NUM_NLNHNDL)
+         mfem_error("ROMHandler::SetNonlinearMode - nonlinear handling is not set!\n");
+      nonlinear_mode = nl_mode;
+   }
    const NonlinearHandling GetNonlinearHandling() { return nlin_handle; }
 
    /* parse inputs for supremizer. only for Stokes/SteadyNS Solver. */

--- a/include/rom_handler.hpp
+++ b/include/rom_handler.hpp
@@ -127,8 +127,10 @@ public:
    const ROMBuildingLevel GetBuildingLevel() { return save_operator; }
    const bool BasisLoaded() { return basis_loaded; }
    const bool OperatorLoaded() { return operator_loaded; }
+   const bool SeparateVariable() { return separate_variable; }
    const std::string GetOperatorPrefix() { return operator_prefix; }
    const std::string GetBasisPrefix() { return basis_prefix; }
+   const std::string GetRefBasisTag(const int ref_idx) { return basis_tags[ref_idx]; }
    const Array<int>* GetBlockOffsets() { return &rom_block_offsets; }
    const Array<int>* GetVarBlockOffsets() { return &rom_varblock_offsets; }
    virtual SparseMatrix* GetOperator() = 0;
@@ -144,7 +146,6 @@ public:
    int GetBasisIndexForSubdomain(const int &subdomain_index);
    virtual void GetReferenceBasis(const int &basis_index, DenseMatrix* &basis) = 0;
    virtual void GetDomainBasis(const int &basis_index, DenseMatrix* &basis) = 0;
-   virtual void GetBasisOnSubdomain(const int &subdomain_index, DenseMatrix* &basis) = 0;
    virtual void SetBlockSizes();
 
    // P_i^T * mat * P_j
@@ -230,7 +231,6 @@ public:
    virtual void LoadReducedBasis();
    virtual void GetReferenceBasis(const int &basis_index, DenseMatrix* &basis) override;
    virtual void GetDomainBasis(const int &basis_index, DenseMatrix* &basis);
-   virtual void GetBasisOnSubdomain(const int &subdomain_index, DenseMatrix* &basis) override;
 
    // P_i^T * mat * P_j
    virtual SparseMatrix* ProjectToRefBasis(const int &i, const int &j, const Operator *mat);

--- a/include/rom_handler.hpp
+++ b/include/rom_handler.hpp
@@ -30,6 +30,13 @@ enum ROMBuildingLevel
    NUM_BLD_LVL
 };
 
+enum NonlinearHandling
+{
+   TENSOR,
+   EQP,
+   NUM_NLNHNDL
+};
+
 const TrainMode SetTrainMode();
 
 const std::string GetBasisTagForComponent(const int &comp_idx, const TrainMode &train_mode, const TopologyHandler *topol_handler, const std::string var_name="");
@@ -57,6 +64,7 @@ protected:
    TrainMode train_mode = NUM_TRAINMODE;
    bool nonlinear_mode = false;
    bool separate_variable = false;
+   NonlinearHandling nlin_handle = NUM_NLNHNDL;
    // ProjectionMode proj_mode = NUM_PROJMODE;
 
    // file names.
@@ -77,6 +85,7 @@ protected:
    Array<int> num_ref_basis;
    Array<const CAROM::Matrix*> carom_ref_basis;
    Array<int> rom_comp_block_offsets;
+   std::vector<std::string> basis_tags;
    bool basis_loaded;
    bool operator_loaded;
 
@@ -125,6 +134,7 @@ public:
    virtual SparseMatrix* GetOperator() = 0;
    const bool GetNonlinearMode() { return nonlinear_mode; }
    void SetNonlinearMode(const bool nl_mode) { nonlinear_mode = nl_mode; }
+   const NonlinearHandling GetNonlinearHandling() { return nlin_handle; }
 
    /* parse inputs for supremizer. only for Stokes/SteadyNS Solver. */
    void ParseSupremizerInput(Array<int> &num_ref_supreme, Array<int> &num_supreme);

--- a/include/rom_handler.hpp
+++ b/include/rom_handler.hpp
@@ -122,6 +122,7 @@ public:
    // access
    const int GetNumSubdomains() { return numSub; }
    const TrainMode GetTrainMode() { return train_mode; }
+   const int GetNumROMRefComps() { return num_rom_comp; }
    const int GetNumROMRefBlocks() { return num_rom_ref_blocks; }
    const int GetRefNumBasis(const int &basis_idx) { return num_ref_basis[basis_idx]; }
    const ROMBuildingLevel GetBuildingLevel() { return save_operator; }
@@ -148,7 +149,7 @@ public:
 
    virtual void LoadReducedBasis();
 
-   int GetBasisIndexForSubdomain(const int &subdomain_index);
+   int GetRefIndexForSubdomain(const int &subdomain_index);
    virtual void GetReferenceBasis(const int &basis_index, DenseMatrix* &basis) = 0;
    virtual void GetDomainBasis(const int &basis_index, DenseMatrix* &basis) = 0;
    virtual void SetBlockSizes();

--- a/include/rom_nonlinearform.hpp
+++ b/include/rom_nonlinearform.hpp
@@ -53,6 +53,7 @@ public:
        NonlinearFormIntegrator%s and gradient Operator. */
    virtual ~ROMNonlinearForm();
 
+   const bool PrecomputeMode() { return precompute; }
    void SetPrecomputeMode(const bool precompute_) { precompute = precompute_; }
 
    void PrecomputeCoefficients();
@@ -74,6 +75,7 @@ public:
 
    void GetEQPForDomainIntegrator(const int k, Array<int> &sample_el, Array<int> &sample_qp, Array<double> &sample_qw);
    void SaveEQPForDomainIntegrator(const int k, hid_t file_id, const std::string &dsetname);
+   void LoadEQPForDomainIntegrator(const int k, hid_t file_id, const std::string &dsetname);
 
    /// Adds new Domain Integrator.
    void AddDomainIntegrator(HyperReductionIntegrator *nlfi)

--- a/include/rom_nonlinearform.hpp
+++ b/include/rom_nonlinearform.hpp
@@ -67,11 +67,9 @@ public:
    void SetupEQPSystemForDomainIntegrator(const CAROM::Matrix &snapshots, HyperReductionIntegrator *nlfi, 
                                           CAROM::Matrix &Gt, CAROM::Vector &rhs_Gw);
    void SetupEQPSystemForInteriorFaceIntegrator(const CAROM::Matrix &snapshots, HyperReductionIntegrator *nlfi, 
-                                                CAROM::Matrix &Gt, CAROM::Vector &rhs_Gw)
-   { mfem_error("SetupEQPSystemForInteriorFaceIntegrator is not implemented yet!\n"); }
+                                                CAROM::Matrix &Gt, CAROM::Vector &rhs_Gw, Array<int> &fidxs);
    void SetupEQPSystemForBdrFaceIntegrator(const CAROM::Matrix &snapshots, HyperReductionIntegrator *nlfi, 
-                                           CAROM::Matrix &Gt, CAROM::Vector &rhs_Gw)
-   { mfem_error("SetupEQPSystemForInteriorFaceIntegrator is not implemented yet!\n"); }
+                                           const Array<int> &bdr_attr_marker, CAROM::Matrix &Gt, CAROM::Vector &rhs_Gw, Array<int> &bidxs);
 
    void GetEQPForDomainIntegrator(const int k, Array<int> &sample_el, Array<int> &sample_qp, Array<double> &sample_qw);
    void SaveEQPForDomainIntegrator(const int k, hid_t file_id, const std::string &dsetname);

--- a/include/rom_nonlinearform.hpp
+++ b/include/rom_nonlinearform.hpp
@@ -21,7 +21,7 @@ private:
 protected:
    /// ROM basis for projection.
    /// Needs to be converted to MFEM DenseMatrix.
-   DenseMatrix *basis = NULL;   // not owned
+   DenseMatrix *basis = NULL;   // owned
 
    /// Projection ROM's jacobian matrix is dense most of time.
    mutable DenseMatrix *Grad = NULL;
@@ -56,12 +56,7 @@ public:
 
    void PrecomputeCoefficients();
 
-   void SetBasis(DenseMatrix &basis_)
-   {
-      assert(basis_.NumCols() == height);
-      assert(basis_.NumRows() == fes->GetTrueVSize());
-      basis = &basis_;
-   }
+   void SetBasis(DenseMatrix &basis_, const int offset=0);
 
    void TrainEQP(const CAROM::Matrix &snapshots, const double eqp_tol = 1.0e-2);
    void TrainEQPForIntegrator(const CAROM::Matrix &snapshots, HyperReductionIntegrator *nlfi,

--- a/include/rom_nonlinearform.hpp
+++ b/include/rom_nonlinearform.hpp
@@ -61,8 +61,8 @@ public:
    void SetBasis(DenseMatrix &basis_, const int offset=0);
 
    void TrainEQP(const CAROM::Matrix &snapshots, const double eqp_tol = 1.0e-2);
-   void TrainEQPForIntegrator(const CAROM::Matrix &snapshots, HyperReductionIntegrator *nlfi,
-                              const CAROM::Matrix &Gt, const CAROM::Vector &rhs_Gw, const double eqp_tol,
+   void TrainEQPForIntegrator(HyperReductionIntegrator *nlfi, const CAROM::Matrix &Gt,
+                              const CAROM::Vector &rhs_Gw, const double eqp_tol,
                               Array<int> &sample_el, Array<int> &sample_qp, Array<double> &sample_qw);
    void SetupEQPSystemForDomainIntegrator(const CAROM::Matrix &snapshots, HyperReductionIntegrator *nlfi, 
                                           CAROM::Matrix &Gt, CAROM::Vector &rhs_Gw);

--- a/include/rom_nonlinearform.hpp
+++ b/include/rom_nonlinearform.hpp
@@ -13,6 +13,14 @@
 namespace mfem
 {
 
+enum IntegratorType
+{
+   DOMAIN,
+   INTERIORFACE,
+   BDRFACE,
+   NUM_INTEG_TYPE
+};
+
 class ROMNonlinearForm : public NonlinearForm
 {
 private:
@@ -71,9 +79,9 @@ public:
    void SetupEQPSystemForBdrFaceIntegrator(const CAROM::Matrix &snapshots, HyperReductionIntegrator *nlfi, 
                                            const Array<int> &bdr_attr_marker, CAROM::Matrix &Gt, CAROM::Vector &rhs_Gw, Array<int> &bidxs);
 
-   void GetEQPForDomainIntegrator(const int k, Array<int> &sample_el, Array<int> &sample_qp, Array<double> &sample_qw);
-   void SaveEQPForDomainIntegrator(const int k, hid_t file_id, const std::string &dsetname);
-   void LoadEQPForDomainIntegrator(const int k, hid_t file_id, const std::string &dsetname);
+   void GetEQPForIntegrator(const IntegratorType type, const int k, Array<int> &sample_el, Array<int> &sample_qp, Array<double> &sample_qw);
+   void SaveEQPForIntegrator(const IntegratorType type, const int k, hid_t file_id, const std::string &dsetname);
+   void LoadEQPForIntegrator(const IntegratorType type, const int k, hid_t file_id, const std::string &dsetname);
 
    /// Adds new Domain Integrator.
    void AddDomainIntegrator(HyperReductionIntegrator *nlfi)

--- a/include/rom_nonlinearform.hpp
+++ b/include/rom_nonlinearform.hpp
@@ -7,6 +7,7 @@
 
 #include "mfem.hpp"
 #include "hyperreduction_integ.hpp"
+#include "linalg/NNLS.h"
 
 namespace mfem
 {
@@ -61,6 +62,21 @@ public:
       assert(basis_.NumRows() == fes->GetTrueVSize());
       basis = &basis_;
    }
+
+   void TrainEQP(const CAROM::Matrix &snapshots, const double eqp_tol = 1.0e-2);
+   void TrainEQPForIntegrator(const CAROM::Matrix &snapshots, HyperReductionIntegrator *nlfi,
+                              const CAROM::Matrix &Gt, const CAROM::Vector &rhs_Gw, const double eqp_tol,
+                              Array<int> &sample_el, Array<int> &sample_qp, Array<double> &sample_qw);
+   void SetupEQPSystemForDomainIntegrator(const CAROM::Matrix &snapshots, HyperReductionIntegrator *nlfi, 
+                                          CAROM::Matrix &Gt, CAROM::Vector &rhs_Gw);
+   void SetupEQPSystemForInteriorFaceIntegrator(const CAROM::Matrix &snapshots, HyperReductionIntegrator *nlfi, 
+                                                CAROM::Matrix &Gt, CAROM::Vector &rhs_Gw)
+   { mfem_error("SetupEQPSystemForInteriorFaceIntegrator is not implemented yet!\n"); }
+   void SetupEQPSystemForBdrFaceIntegrator(const CAROM::Matrix &snapshots, HyperReductionIntegrator *nlfi, 
+                                           CAROM::Matrix &Gt, CAROM::Vector &rhs_Gw)
+   { mfem_error("SetupEQPSystemForInteriorFaceIntegrator is not implemented yet!\n"); }
+
+   void GetEQPForDomainIntegrator(const int k, Array<int> &sample_el, Array<int> &sample_qp, Array<double> &sample_qw);
 
    /// Adds new Domain Integrator.
    void AddDomainIntegrator(HyperReductionIntegrator *nlfi)

--- a/include/rom_nonlinearform.hpp
+++ b/include/rom_nonlinearform.hpp
@@ -8,6 +8,7 @@
 #include "mfem.hpp"
 #include "hyperreduction_integ.hpp"
 #include "linalg/NNLS.h"
+#include "hdf5_utils.hpp"
 
 namespace mfem
 {
@@ -72,6 +73,7 @@ public:
    { mfem_error("SetupEQPSystemForInteriorFaceIntegrator is not implemented yet!\n"); }
 
    void GetEQPForDomainIntegrator(const int k, Array<int> &sample_el, Array<int> &sample_qp, Array<double> &sample_qw);
+   void SaveEQPForDomainIntegrator(const int k, hid_t file_id, const std::string &dsetname);
 
    /// Adds new Domain Integrator.
    void AddDomainIntegrator(HyperReductionIntegrator *nlfi)

--- a/include/sample_generator.hpp
+++ b/include/sample_generator.hpp
@@ -8,7 +8,7 @@
 #include "mfem.hpp"
 #include "parameter.hpp"
 #include "linalg/BasisGenerator.h"
-#include "multiblock_solver.hpp"
+#include "linalg_utils.hpp"
 
 using namespace mfem;
 
@@ -92,6 +92,7 @@ public:
    void SaveSnapshot(BlockVector *U_snapshots, std::vector<std::string> &snapshot_basis_tags);
    void AddSnapshotGenerator(const int &fom_vdofs, const std::string &prefix, const std::string &basis_tag);
    void WriteSnapshots();
+   const CAROM::Matrix* LookUpSnapshot(const std::string &basis_tag);
 
    void ReportStatus(const int &sample_idx);
 

--- a/include/steady_ns_solver.hpp
+++ b/include/steady_ns_solver.hpp
@@ -6,6 +6,7 @@
 #define SCALEUPROM_STEADY_NS_SOLVER_HPP
 
 #include "stokes_solver.hpp"
+#include "rom_nonlinearform.hpp"
 
 // By convention we only use mfem namespace as default, not CAROM.
 using namespace mfem;
@@ -87,6 +88,21 @@ public:
       : SteadyNSROM(linearOp_, hs_.Size(), block_offsets_, direct_solve_), hs(hs_) {}
 
    virtual ~SteadyNSTensorROM() {}
+
+   virtual void Mult(const Vector &x, Vector &y) const;
+   virtual Operator &GetGradient(const Vector &x) const;
+};
+
+class SteadyNSEQPROM : public SteadyNSROM
+{
+protected:
+   Array<ROMNonlinearForm *> hs; // not owned by SteadyNSEQPROM.
+
+public:
+   SteadyNSEQPROM(SparseMatrix *linearOp_, Array<ROMNonlinearForm *> &hs_, const Array<int> &block_offsets_, const bool direct_solve_=true)
+      : SteadyNSROM(linearOp_, hs_.Size(), block_offsets_, direct_solve_), hs(hs_) {}
+
+   virtual ~SteadyNSEQPROM() {}
 
    virtual void Mult(const Vector &x, Vector &y) const;
    virtual Operator &GetGradient(const Vector &x) const;

--- a/include/steady_ns_solver.hpp
+++ b/include/steady_ns_solver.hpp
@@ -137,6 +137,7 @@ protected:
    // component ROM element for nonlinear convection.
    Array<DenseTensor *> comp_tensors, subdomain_tensors;
    Array<ROMNonlinearForm *> comp_eqps, subdomain_eqps;
+   Array<FiniteElementSpace *> comp_fes;  // pointers to existing fespace, no need to delete
 
    Solver *J_solver = NULL;
    GMRESSolver *J_gmres = NULL;
@@ -177,9 +178,11 @@ public:
 
    virtual void TrainEQP(SampleGenerator *sample_generator) override;
    virtual void SaveEQP() override;
+   virtual void LoadEQP() override;
 
 private:
    DenseTensor* GetReducedTensor(DenseMatrix *basis, FiniteElementSpace *fespace);
+   void SetupEQPOperators();
 };
 
 #endif

--- a/include/steady_ns_solver.hpp
+++ b/include/steady_ns_solver.hpp
@@ -136,6 +136,7 @@ protected:
 
    // component ROM element for nonlinear convection.
    Array<DenseTensor *> comp_tensors, subdomain_tensors;
+   Array<ROMNonlinearForm *> comp_eqps, subdomain_eqps;
 
    Solver *J_solver = NULL;
    GMRESSolver *J_gmres = NULL;
@@ -173,6 +174,8 @@ public:
    virtual void ProjectOperatorOnReducedBasis();
 
    virtual void SolveROM() override;
+
+   virtual void TrainEQP(SampleGenerator *sample_generator) override;
 
 private:
    DenseTensor* GetReducedTensor(DenseMatrix *basis, FiniteElementSpace *fespace);

--- a/include/steady_ns_solver.hpp
+++ b/include/steady_ns_solver.hpp
@@ -176,6 +176,7 @@ public:
    virtual void SolveROM() override;
 
    virtual void TrainEQP(SampleGenerator *sample_generator) override;
+   virtual void SaveEQP() override;
 
 private:
    DenseTensor* GetReducedTensor(DenseMatrix *basis, FiniteElementSpace *fespace);

--- a/sketches/librom_svd.cpp
+++ b/sketches/librom_svd.cpp
@@ -31,12 +31,13 @@ int main(int argc, char *argv[])
       bool addSample;
 
       rom_options = new CAROM::Options(dim, max_num_snapshots, 1, update_right_SV);
+      rom_options->static_svd_preserve_snapshot = true;
       basis_generator = new CAROM::BasisGenerator(*rom_options, incremental, filename);
-      addSample = basis_generator->takeSample(sample1, 0.0, 0.01);
+      addSample = basis_generator->takeSample(sample1);
       // basis_generator->writeSnapshot();
-      addSample = basis_generator->takeSample(sample2, 0.0, 0.01);
+      addSample = basis_generator->takeSample(sample2);
       // basis_generator->writeSnapshot();
-      addSample = basis_generator->takeSample(sample3, 0.0, 0.01);
+      addSample = basis_generator->takeSample(sample3);
       // basis_generator->writeSnapshot();
 
       basis_generator->endSamples();

--- a/sketches/linalg_interface.cpp
+++ b/sketches/linalg_interface.cpp
@@ -42,11 +42,12 @@ int main(int argc, char *argv[])
    // librom svd
    // SVD class constructors are protected, so using BasisGenerator.
    CAROM::Options options(fes->GetTrueVSize(), 100, 1, true);
+   options.static_svd_preserve_snapshot = true;
    std::string filename("test");
    CAROM::BasisGenerator *generator = new CAROM::BasisGenerator(options, false, filename);
    for (int s = 0; s < nsample; s++)
    {
-      bool addSample = generator->takeSample(snapshots[s]->getData(), 0.0, 0.01);
+      bool addSample = generator->takeSample(snapshots[s]->getData());
    }
 
    // librom snapshot matrix.
@@ -175,7 +176,7 @@ int main(int argc, char *argv[])
    generator = new CAROM::BasisGenerator(options, false, filename);
    for (int s = 0; s < nsample; s++)
    {
-      bool addSample = generator->takeSample(transformed_snapshots[s]->GetData(), 0.0, 0.01);
+      bool addSample = generator->takeSample(transformed_snapshots[s]->GetData());
    }
 
    // librom pod basis.
@@ -248,7 +249,7 @@ int main(int argc, char *argv[])
       generator = new CAROM::BasisGenerator(options, false, filename);
       for (int s = 0; s < nsample; s++)
       {
-         bool addSample = generator->takeSample(snapshots[s]->getData(), 0.0, 0.01);
+         bool addSample = generator->takeSample(snapshots[s]->getData());
       }
 
       basis = generator->getSpatialBasis();

--- a/sketches/ns_rom.cpp
+++ b/sketches/ns_rom.cpp
@@ -1491,8 +1491,8 @@ int main(int argc, char *argv[])
          problem::offsets = 0.0;
          problem::k = 0.0;
 
-         problem::u0(0) = 1.0;
-         problem::u0(1) = -1.0;
+         problem::u0(0) = -1.0;
+         problem::u0(1) = 1.0;
          printf("u0: (%f, %f)\n", problem::u0(0), problem::u0(1));
       }
 
@@ -1747,10 +1747,10 @@ int main(int argc, char *argv[])
             rom_nlinf->PrecomputeCoefficients();
 
          eqprom = new EQPROM(lin_rom, *rom_nlinf);
-         eqp_opers[0] = rom_nlinf;
-         eqprom1 = new SteadyNSEQPROM(&lin_rom1, eqp_opers, block_offsets);
-         // rom_oper = eqprom;
-         rom_oper = eqprom1;
+         // eqp_opers[0] = rom_nlinf;
+         // eqprom1 = new SteadyNSEQPROM(&lin_rom1, eqp_opers, block_offsets);
+         rom_oper = eqprom;
+         // rom_oper = eqprom1;
       }  // if (rom_mode == RomMode::EQP)
       else
          mfem_error("ROM Mode is not set!");

--- a/sketches/ns_rom.cpp
+++ b/sketches/ns_rom.cpp
@@ -1437,7 +1437,7 @@ int main(int argc, char *argv[])
          rom_nlinf->TrainEQP(*snapshots, eqp_tol);
          Array<int> sample_el, sample_qp;
          Array<double> sample_qw;
-         rom_nlinf->GetEQPForDomainIntegrator(0, sample_el, sample_qp, sample_qw);
+         rom_nlinf->GetEQPForIntegrator(IntegratorType::DOMAIN, 0, sample_el, sample_qp, sample_qw);
 
          {  // save empirical quadrature point locations.
             ElementTransformation *T;
@@ -1463,7 +1463,7 @@ int main(int argc, char *argv[])
             file_id = H5Fcreate(sample_file.c_str(), H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT);
             assert(file_id >= 0);
 
-            rom_nlinf->SaveEQPForDomainIntegrator(0, file_id, "sample");
+            rom_nlinf->SaveEQPForIntegrator(IntegratorType::DOMAIN, 0, file_id, "sample");
 
             errf = H5Fclose(file_id);
             assert(errf >= 0);
@@ -1737,7 +1737,7 @@ int main(int argc, char *argv[])
             file_id = H5Fopen(sample_file.c_str(), H5F_ACC_RDONLY, H5P_DEFAULT);
             assert(file_id >= 0);
 
-            rom_nlinf->LoadEQPForDomainIntegrator(0, file_id, "sample");
+            rom_nlinf->LoadEQPForIntegrator(IntegratorType::DOMAIN, 0, file_id, "sample");
 
             errf = H5Fclose(file_id);
             assert(errf >= 0);

--- a/sketches/ns_rom.cpp
+++ b/sketches/ns_rom.cpp
@@ -1016,9 +1016,9 @@ int main(int argc, char *argv[])
                mfem_error("Failed to converge in sampling!\n");
          }
 
-         snapshot_generator.takeSample(temp.GetSolution()->GetData(), 0.0, 0.01);
-         u_snapshot_generator.takeSample(temp.GetSolution()->GetData(), 0.0, 0.01);
-         p_snapshot_generator.takeSample(temp.GetSolution()->GetData() + udim, 0.0, 0.01);
+         snapshot_generator.takeSample(temp.GetSolution()->GetData());
+         u_snapshot_generator.takeSample(temp.GetSolution()->GetData());
+         p_snapshot_generator.takeSample(temp.GetSolution()->GetData() + udim);
 
          // GridFunction *u = temp.GetVelocityGridFunction();
          // GridFunction *p = temp.GetPressureGridFunction();
@@ -1101,7 +1101,7 @@ int main(int argc, char *argv[])
 
       DenseMatrix basis;
       CAROM::BasisReader basis_reader(filename);
-      const CAROM::Matrix *carom_basis = basis_reader.getSpatialBasis(0.0, num_basis);
+      const CAROM::Matrix *carom_basis = basis_reader.getSpatialBasis(num_basis);
       CAROM::CopyMatrix(*carom_basis, basis);
 
       const int fom_vdofs = oper.Height();
@@ -1162,10 +1162,10 @@ int main(int argc, char *argv[])
          tmp1.MakeRef(proj_res, 0, udim);
          S.Mult(tmp1, projres_div);
 
-         sol_snapshot.takeSample(fom_sol->GetData(), 0.0, 0.01);
-         proj_sol_snapshot.takeSample(fom_proj.GetData(), 0.0, 0.01);
-         residual_snapshot.takeSample(fom_res.GetData(), 0.0, 0.01);
-         proj_residual_snapshot.takeSample(proj_res.GetData(), 0.0, 0.01);
+         sol_snapshot.takeSample(fom_sol->GetData());
+         proj_sol_snapshot.takeSample(fom_proj.GetData());
+         residual_snapshot.takeSample(fom_res.GetData());
+         proj_residual_snapshot.takeSample(proj_res.GetData());
 
          Array<GridFunction *> ugf(4), pgf(4), divgf(4);
          for (int k = 0; k < 4; k++) ugf[k] = new GridFunction;
@@ -1252,7 +1252,7 @@ int main(int argc, char *argv[])
 
             CAROM::BasisGenerator basis_generator(option, false, filename);
             for (int j = 0; j < wgted_snapshots.NumCols(); j++)
-               basis_generator.takeSample(wgted_snapshots.GetColumn(j), 0.0, 0.01);
+               basis_generator.takeSample(wgted_snapshots.GetColumn(j));
             basis_generator.endSamples();
 
             const CAROM::Matrix *carom_basis = basis_generator.getSpatialBasis();
@@ -1283,7 +1283,7 @@ int main(int argc, char *argv[])
       else
       {
          CAROM::BasisReader basis_reader(filename);
-         const CAROM::Matrix *carom_basis = basis_reader.getSpatialBasis(0.0, num_basis);
+         const CAROM::Matrix *carom_basis = basis_reader.getSpatialBasis(num_basis);
          CAROM::CopyMatrix(*carom_basis, basis);
       }
 
@@ -1311,7 +1311,7 @@ int main(int argc, char *argv[])
       {
          DenseMatrix ubasis;
          CAROM::BasisReader ubasis_reader(filename + "_vel");
-         const CAROM::Matrix *carom_ubasis = ubasis_reader.getSpatialBasis(0.0, num_basis);
+         const CAROM::Matrix *carom_ubasis = ubasis_reader.getSpatialBasis(num_basis);
          CAROM::CopyMatrix(*carom_ubasis, ubasis);
 
          DenseTensor *nlin_rom = oper.GetReducedTensor(ubasis, ubasis);
@@ -1337,8 +1337,8 @@ int main(int argc, char *argv[])
          DenseMatrix ubasis, pbasis;
          CAROM::BasisReader ubasis_reader(filename + "_vel");
          CAROM::BasisReader pbasis_reader(filename + "_pres");
-         const CAROM::Matrix *carom_ubasis = ubasis_reader.getSpatialBasis(0.0, num_basis);
-         const CAROM::Matrix *carom_pbasis = pbasis_reader.getSpatialBasis(0.0, num_pbasis);
+         const CAROM::Matrix *carom_ubasis = ubasis_reader.getSpatialBasis(num_basis);
+         const CAROM::Matrix *carom_pbasis = pbasis_reader.getSpatialBasis(num_pbasis);
          CAROM::CopyMatrix(*carom_ubasis, ubasis);
          CAROM::CopyMatrix(*carom_pbasis, pbasis);
 
@@ -1535,8 +1535,8 @@ int main(int argc, char *argv[])
       {
          CAROM::BasisReader ubasis_reader(filename + "_vel");
          CAROM::BasisReader pbasis_reader(filename + "_pres");
-         const CAROM::Matrix *carom_ubasis = ubasis_reader.getSpatialBasis(0.0, num_basis);
-         const CAROM::Matrix *carom_pbasis = pbasis_reader.getSpatialBasis(0.0, num_pbasis);
+         const CAROM::Matrix *carom_ubasis = ubasis_reader.getSpatialBasis(num_basis);
+         const CAROM::Matrix *carom_pbasis = pbasis_reader.getSpatialBasis(num_pbasis);
          CAROM::CopyMatrix(*carom_ubasis, ubasis);
          CAROM::CopyMatrix(*carom_pbasis, pbasis);
 
@@ -1553,7 +1553,7 @@ int main(int argc, char *argv[])
       else if (rom_mode == RomMode::TENSOR3)
       {
          CAROM::BasisReader ubasis_reader(filename + "_vel");
-         const CAROM::Matrix *carom_ubasis = ubasis_reader.getSpatialBasis(0.0, num_basis);
+         const CAROM::Matrix *carom_ubasis = ubasis_reader.getSpatialBasis(num_basis);
          CAROM::CopyMatrix(*carom_ubasis, ubasis);
 
          basis.SetSize(ubasis.NumRows() + pdim, ubasis.NumCols());
@@ -1582,7 +1582,7 @@ int main(int argc, char *argv[])
          }
 
          CAROM::BasisReader pbasis_reader(filename + "_pres");
-         const CAROM::Matrix *carom_pbasis = pbasis_reader.getSpatialBasis(0.0, num_pbasis);
+         const CAROM::Matrix *carom_pbasis = pbasis_reader.getSpatialBasis(num_pbasis);
          CAROM::CopyMatrix(*carom_pbasis, pbasis);
 
          basis.SetSize(ubasis.NumRows() + pbasis.NumRows(), ubasis.NumCols() + pbasis.NumCols());
@@ -1599,8 +1599,8 @@ int main(int argc, char *argv[])
       {
          CAROM::BasisReader ubasis_reader(filename + "_vel");
          CAROM::BasisReader pbasis_reader(filename + "_pres");
-         const CAROM::Matrix *carom_ubasis = ubasis_reader.getSpatialBasis(0.0, num_basis);
-         const CAROM::Matrix *carom_pbasis = pbasis_reader.getSpatialBasis(0.0, num_pbasis);
+         const CAROM::Matrix *carom_ubasis = ubasis_reader.getSpatialBasis(num_basis);
+         const CAROM::Matrix *carom_pbasis = pbasis_reader.getSpatialBasis(num_pbasis);
          CAROM::CopyMatrix(*carom_ubasis, ubasis);
          CAROM::CopyMatrix(*carom_pbasis, pbasis);
 
@@ -1646,7 +1646,7 @@ int main(int argc, char *argv[])
       else
       {
          CAROM::BasisReader basis_reader(filename);
-         const CAROM::Matrix *carom_basis = basis_reader.getSpatialBasis(0.0, num_basis);
+         const CAROM::Matrix *carom_basis = basis_reader.getSpatialBasis(num_basis);
          CAROM::CopyMatrix(*carom_basis, basis);
       }
 

--- a/src/main_workflow.cpp
+++ b/src/main_workflow.cpp
@@ -243,6 +243,11 @@ void TrainROM(MPI_Comm comm)
    for (int p = 0; p < basis_tags.size(); p++)
    {
       std::vector<std::string> file_list(0);
+      std::string default_filename = sample_generator->GetBaseFilename(sample_generator->GetSamplePrefix(), basis_tags[p]);
+      default_filename += "_snapshot";
+      FindSnapshotFilesForBasis(basis_tags[p], default_filename, file_list);
+      assert(file_list.size() > 0);
+
       int num_basis;
 
       // if optional inputs are specified, parse them first.
@@ -252,21 +257,9 @@ void TrainROM(MPI_Comm comm)
          YAML::Node basis_tag_input = config.LookUpFromDict("name", basis_tags[p], basis_list);
          
          // If basis_tags[p] has additional inputs, parse them.
+         // parse tag-specific number of basis.
          if (basis_tag_input)
-         {
-            // parse tag-specific number of basis.
             num_basis = config.GetOptionFromDict<int>("number_of_basis", num_basis_default, basis_tag_input);
-
-            // parse the sample snapshot file list.
-            file_list = config.GetOptionFromDict<std::vector<std::string>>(
-                        "snapshot_files", std::vector<std::string>(0), basis_tag_input);
-            YAML::Node snapshot_format = config.FindNodeFromDict("snapshot_format", basis_tag_input);
-            if (snapshot_format)
-            {
-               FilenameParam snapshot_param("", snapshot_format);
-               snapshot_param.ParseFilenames(file_list);
-            }
-         }  // if (basis_tag_input)
          else
             num_basis = num_basis_default;
       }
@@ -275,14 +268,6 @@ void TrainROM(MPI_Comm comm)
          num_basis = num_basis_default;
 
       assert(num_basis > 0);
-
-      // if additional inputs are not specified for snapshot files, set default snapshot file name.
-      if (file_list.size() == 0)
-      {
-         std::string filename = sample_generator->GetBaseFilename(sample_generator->GetSamplePrefix(), basis_tags[p]);
-         filename += "_snapshot";
-         file_list.push_back(filename);
-      }
 
       sample_generator->FormReducedBasis(basis_prefix, basis_tags[p], file_list, num_basis);
    }  // for (int p = 0; p < basis_tags.size(); p++)
@@ -317,7 +302,60 @@ void AuxiliaryTrainROM(MPI_Comm comm)
       delete solver;
    }
 
-   // TODO: EQP weight optimization procedure.
+   /* EQP NNLS procedure */
+   std::string eqp_str = config.GetOption<std::string>("model_reduction/nonlinear_handling", "none");
+   if (eqp_str == "eqp")
+   {
+      MultiBlockSolver *test = NULL;
+      test = InitSolver();
+      test->InitVariables();
+
+      if (!test->IsNonlinear())
+      {
+         delete test;
+         return;
+      }
+
+      if (!test->UseRom()) mfem_error("ROM must be enabled for EQP training!\n");
+
+      test->LoadReducedBasis();
+
+      delete test;
+   }
+}
+
+void FindSnapshotFilesForBasis(const std::string &basis_tag, const std::string &default_filename, std::vector<std::string> &file_list)
+{
+   file_list.clear();
+
+   // tag-specific optional inputs.
+   YAML::Node basis_list = config.FindNode("basis/tags");
+
+   // if optional inputs are specified, parse them first.
+   if (basis_list)
+   {
+      // Find if additional inputs are specified for basis_tag.
+      YAML::Node basis_tag_input = config.LookUpFromDict("name", basis_tag, basis_list);
+      
+      // If basis_tag has additional inputs, parse them.
+      if (basis_tag_input)
+      {
+         // parse the sample snapshot file list.
+         file_list = config.GetOptionFromDict<std::vector<std::string>>(
+                     "snapshot_files", std::vector<std::string>(0), basis_tag_input);
+         YAML::Node snapshot_format = config.FindNodeFromDict("snapshot_format", basis_tag_input);
+         // if file list is specified with a format, parse through the format.
+         if (snapshot_format)
+         {
+            FilenameParam snapshot_param("", snapshot_format);
+            snapshot_param.ParseFilenames(file_list);
+         }
+      }  // if (basis_tag_input)
+   }
+
+   // if additional inputs are not specified for snapshot files, set default snapshot file name.
+   if (file_list.size() == 0)
+      file_list.push_back(default_filename);
 }
 
 void BuildROM(MPI_Comm comm)

--- a/src/main_workflow.cpp
+++ b/src/main_workflow.cpp
@@ -458,6 +458,9 @@ double SingleRun(MPI_Comm comm, const std::string output_file)
    {
       rom = test->GetROMHandler();
       test->LoadReducedBasis();
+
+      if ((test->IsNonlinear()) && (rom->GetNonlinearHandling() == NonlinearHandling::EQP))
+         test->LoadEQP();
    }
 
    solveTimer.Start();

--- a/src/main_workflow.cpp
+++ b/src/main_workflow.cpp
@@ -322,6 +322,8 @@ void AuxiliaryTrainROM(MPI_Comm comm, SampleGenerator *sample_generator)
 
       test->TrainEQP(sample_generator);
 
+      test->SaveEQP();
+
       delete test;
    }
 }

--- a/src/main_workflow.cpp
+++ b/src/main_workflow.cpp
@@ -272,12 +272,12 @@ void TrainROM(MPI_Comm comm)
       sample_generator->FormReducedBasis(basis_prefix, basis_tags[p], file_list, num_basis);
    }  // for (int p = 0; p < basis_tags.size(); p++)
 
-   delete sample_generator;
+   AuxiliaryTrainROM(comm, sample_generator);
 
-   AuxiliaryTrainROM(comm);
+   delete sample_generator;
 }
 
-void AuxiliaryTrainROM(MPI_Comm comm)
+void AuxiliaryTrainROM(MPI_Comm comm, SampleGenerator *sample_generator)
 {
    std::string solver_type = config.GetRequiredOption<std::string>("main/solver");
    bool separate_variable_basis = config.GetOption<bool>("model_reduction/separate_variable_basis", false);
@@ -319,6 +319,8 @@ void AuxiliaryTrainROM(MPI_Comm comm)
       if (!test->UseRom()) mfem_error("ROM must be enabled for EQP training!\n");
 
       test->LoadReducedBasis();
+
+      test->TrainEQP(sample_generator);
 
       delete test;
    }

--- a/src/poisson_solver.cpp
+++ b/src/poisson_solver.cpp
@@ -326,7 +326,7 @@ void PoissonSolver::AssembleOperator()
       sys_glob_size = globalMat_mono->NumRows();
       sys_row_starts[0] = 0;
       sys_row_starts[1] = globalMat_mono->NumRows();
-      globalMat_hypre = new HypreParMatrix(MPI_COMM_WORLD, sys_glob_size, sys_row_starts, globalMat_mono);
+      globalMat_hypre = new HypreParMatrix(MPI_COMM_SELF, sys_glob_size, sys_row_starts, globalMat_mono);
 
       mumps = new MUMPSSolver();
       mumps->SetMatrixSymType(MUMPSSolver::MatType::SYMMETRIC_POSITIVE_DEFINITE);
@@ -463,7 +463,7 @@ bool PoissonSolver::Solve()
          // Initializating HypreParMatrix needs the monolithic sparse matrix.
          assert(globalMat_mono != NULL);
 
-         solver = new CGSolver(MPI_COMM_WORLD);
+         solver = new CGSolver(MPI_COMM_SELF);
 
          M = new HypreBoomerAMG(*globalMat_hypre);
          M->SetPrintLevel(print_level);

--- a/src/rom_handler.cpp
+++ b/src/rom_handler.cpp
@@ -546,7 +546,7 @@ void MFEMROMHandler::Solve(BlockVector* U)
          // TODO: need to change when the actual parallelization is implemented.
          HYPRE_BigInt glob_size = rom_block_offsets.Last();
          HYPRE_BigInt row_starts[2] = {0, rom_block_offsets.Last()};
-         parRomMat = new HypreParMatrix(MPI_COMM_WORLD, glob_size, row_starts, romMat_mono);
+         parRomMat = new HypreParMatrix(MPI_COMM_SELF, glob_size, row_starts, romMat_mono);
          K = parRomMat;
       }
       else if ((prec_str == "gs") || (prec_str == "none"))
@@ -1001,19 +1001,19 @@ IterativeSolver* MFEMROMHandler::SetIterativeSolver(const MFEMROMHandler::Solver
    {
       case (SolverType::CG):
       {
-         if (prec_type == "amg") solver = new CGSolver(MPI_COMM_WORLD);
+         if (prec_type == "amg") solver = new CGSolver(MPI_COMM_SELF);
          else                    solver = new CGSolver();
          break;
       }
       case (SolverType::MINRES):
       {
-         if (prec_type == "amg") solver = new MINRESSolver(MPI_COMM_WORLD);
+         if (prec_type == "amg") solver = new MINRESSolver(MPI_COMM_SELF);
          else                    solver = new MINRESSolver();
          break;
       }
       case (SolverType::GMRES):
       {
-         if (prec_type == "amg") solver = new GMRESSolver(MPI_COMM_WORLD);
+         if (prec_type == "amg") solver = new GMRESSolver(MPI_COMM_SELF);
          else                    solver = new GMRESSolver();
          break;
       }
@@ -1040,7 +1040,7 @@ void MFEMROMHandler::SetupDirectSolver()
    sys_glob_size = romMat_mono->NumRows();
    sys_row_starts[0] = 0;
    sys_row_starts[1] = romMat_mono->NumRows();
-   romMat_hypre = new HypreParMatrix(MPI_COMM_WORLD, sys_glob_size, sys_row_starts, romMat_mono);
+   romMat_hypre = new HypreParMatrix(MPI_COMM_SELF, sys_glob_size, sys_row_starts, romMat_mono);
 
    mumps = new MUMPSSolver();
    mumps->SetMatrixSymType(mat_type);

--- a/src/rom_handler.cpp
+++ b/src/rom_handler.cpp
@@ -229,7 +229,7 @@ void ROMHandlerBase::LoadReducedBasis()
          basis_tags[k] = GetBasisTagForComponent(k, train_mode, topol_handler);
       basis_reader = new CAROM::BasisReader(basis_name + basis_tags[k]);
 
-      carom_ref_basis[k] = basis_reader->getSpatialBasis(0.0, num_ref_basis[k]);
+      carom_ref_basis[k] = basis_reader->getSpatialBasis(num_ref_basis[k]);
       numRowRB = carom_ref_basis[k]->numRows();
       numColumnRB = carom_ref_basis[k]->numColumns();
       printf("spatial basis-%d dimension is %d x %d\n", k, numRowRB, numColumnRB);

--- a/src/rom_handler.cpp
+++ b/src/rom_handler.cpp
@@ -240,7 +240,7 @@ void ROMHandlerBase::LoadReducedBasis()
    basis_loaded = true;
 }
 
-int ROMHandlerBase::GetBasisIndexForSubdomain(const int &subdomain_index)
+int ROMHandlerBase::GetRefIndexForSubdomain(const int &subdomain_index)
 {
    int idx = -1;
    switch (train_mode)

--- a/src/rom_handler.cpp
+++ b/src/rom_handler.cpp
@@ -397,14 +397,6 @@ void MFEMROMHandler::GetDomainBasis(const int &basis_index, DenseMatrix* &basis)
    basis = dom_basis[basis_index];
 }
 
-void MFEMROMHandler::GetBasisOnSubdomain(const int &subdomain_index, DenseMatrix* &basis)
-{
-   assert(basis_loaded);
-
-   int idx = GetBasisIndexForSubdomain(subdomain_index);
-   GetReferenceBasis(idx, basis);
-}
-
 void MFEMROMHandler::ProjectOperatorOnReducedBasis(const Array2D<Operator*> &mats)
 {
    assert(mats.NumRows() == num_rom_blocks);

--- a/src/rom_nonlinearform.cpp
+++ b/src/rom_nonlinearform.cpp
@@ -686,14 +686,14 @@ void ROMNonlinearForm::TrainEQP(const CAROM::Matrix &snapshots, const double eqp
    {
       SetupEQPSystemForInteriorFaceIntegrator(snapshots, fnfi[k], Gt, rhs_Gw);
       TrainEQPForIntegrator(fnfi[k], Gt, rhs_Gw, eqp_tol, el, qp, qw);
-      UpdateDomainIntegratorSampling(k, el, qp, qw);
+      UpdateInteriorFaceIntegratorSampling(k, el, qp, qw);
    }
 
    for (int k = 0; k < bfnfi.Size(); k++)
    {
       SetupEQPSystemForBdrFaceIntegrator(snapshots, bfnfi[k], Gt, rhs_Gw);
       TrainEQPForIntegrator(bfnfi[k], Gt, rhs_Gw, eqp_tol, el, qp, qw);
-      UpdateDomainIntegratorSampling(k, el, qp, qw);
+      UpdateBdrFaceIntegratorSampling(k, el, qp, qw);
    }
 }
 

--- a/src/rom_nonlinearform.cpp
+++ b/src/rom_nonlinearform.cpp
@@ -678,29 +678,28 @@ void ROMNonlinearForm::TrainEQP(const CAROM::Matrix &snapshots, const double eqp
    for (int k = 0; k < dnfi.Size(); k++)
    {
       SetupEQPSystemForDomainIntegrator(snapshots, dnfi[k], Gt, rhs_Gw);
-      TrainEQPForIntegrator(snapshots, dnfi[k], Gt, rhs_Gw, eqp_tol, el, qp, qw);
+      TrainEQPForIntegrator(dnfi[k], Gt, rhs_Gw, eqp_tol, el, qp, qw);
       UpdateDomainIntegratorSampling(k, el, qp, qw);
    }
 
    for (int k = 0; k < fnfi.Size(); k++)
    {
       SetupEQPSystemForInteriorFaceIntegrator(snapshots, fnfi[k], Gt, rhs_Gw);
-      TrainEQPForIntegrator(snapshots, fnfi[k], Gt, rhs_Gw, eqp_tol, el, qp, qw);
+      TrainEQPForIntegrator(fnfi[k], Gt, rhs_Gw, eqp_tol, el, qp, qw);
       UpdateDomainIntegratorSampling(k, el, qp, qw);
    }
 
    for (int k = 0; k < bfnfi.Size(); k++)
    {
       SetupEQPSystemForBdrFaceIntegrator(snapshots, bfnfi[k], Gt, rhs_Gw);
-      TrainEQPForIntegrator(snapshots, bfnfi[k], Gt, rhs_Gw, eqp_tol, el, qp, qw);
+      TrainEQPForIntegrator(bfnfi[k], Gt, rhs_Gw, eqp_tol, el, qp, qw);
       UpdateDomainIntegratorSampling(k, el, qp, qw);
    }
 }
 
 void ROMNonlinearForm::TrainEQPForIntegrator(
-   const CAROM::Matrix &snapshots, HyperReductionIntegrator *nlfi,
-   const CAROM::Matrix &Gt, const CAROM::Vector &rhs_Gw, const double eqp_tol,
-   Array<int> &sample_el, Array<int> &sample_qp, Array<double> &sample_qw)
+   HyperReductionIntegrator *nlfi, const CAROM::Matrix &Gt, const CAROM::Vector &rhs_Gw,
+   const double eqp_tol, Array<int> &sample_el, Array<int> &sample_qp, Array<double> &sample_qw)
 {
    const IntegrationRule *ir = nlfi->GetIntegrationRule();
 

--- a/src/rom_nonlinearform.cpp
+++ b/src/rom_nonlinearform.cpp
@@ -683,10 +683,18 @@ void ROMNonlinearForm::TrainEQP(const CAROM::Matrix &snapshots, const double eqp
    }
 
    for (int k = 0; k < fnfi.Size(); k++)
-      mfem_error("ROMNonlinearForm::TrainEQP- not implemented for interior face integrators yet!\n");
+   {
+      SetupEQPSystemForInteriorFaceIntegrator(snapshots, fnfi[k], Gt, rhs_Gw);
+      TrainEQPForIntegrator(snapshots, fnfi[k], Gt, rhs_Gw, eqp_tol, el, qp, qw);
+      UpdateDomainIntegratorSampling(k, el, qp, qw);
+   }
 
    for (int k = 0; k < bfnfi.Size(); k++)
-      mfem_error("ROMNonlinearForm::TrainEQP- not implemented for boundary face integrators yet!\n");
+   {
+      SetupEQPSystemForBdrFaceIntegrator(snapshots, bfnfi[k], Gt, rhs_Gw);
+      TrainEQPForIntegrator(snapshots, bfnfi[k], Gt, rhs_Gw, eqp_tol, el, qp, qw);
+      UpdateDomainIntegratorSampling(k, el, qp, qw);
+   }
 }
 
 void ROMNonlinearForm::TrainEQPForIntegrator(

--- a/src/rom_nonlinearform.cpp
+++ b/src/rom_nonlinearform.cpp
@@ -693,7 +693,6 @@ void ROMNonlinearForm::TrainEQPForIntegrator(
    // CAROM::Vector & sol)
    double nnls_tol = 1.0e-11;
    int maxNNLSnnz = 0;
-   const double delta = eqp_tol;
    CAROM::Vector eqpSol(Gt.numRows(), true);
    int nnz = 0;
    {
@@ -702,12 +701,12 @@ void ROMNonlinearForm::TrainEQPForIntegrator(
       CAROM::Vector rhs_ub(rhs_Gw);
       CAROM::Vector rhs_lb(rhs_Gw);
 
+      double delta;
       for (int i = 0; i < rhs_ub.dim(); ++i)
       {
-         // rhs_lb(i) *= (1.0 - delta);
-         // rhs_ub(i) *= (1.0 + delta);
-         rhs_lb(i) -= (delta);
-         rhs_ub(i) += (delta);
+         delta = eqp_tol * abs(rhs_Gw(i));
+         rhs_lb(i) -= delta;
+         rhs_ub(i) += delta;
       }
 
       /*
@@ -719,7 +718,7 @@ void ROMNonlinearForm::TrainEQPForIntegrator(
 
       /*
          The optimization will continue until
-            max_i || rhs_Gw(i) - eqp_Gw(i) || / || rhs_Gw(i) || < delta
+            max_i || rhs_Gw(i) - eqp_Gw(i) || / || rhs_Gw(i) || < eqp_tol
       */
       nnls.solve_parallel_with_scalapack(Gt, rhs_lb, rhs_ub, eqpSol);
 

--- a/src/rom_nonlinearform.cpp
+++ b/src/rom_nonlinearform.cpp
@@ -21,6 +21,7 @@ ROMNonlinearForm::ROMNonlinearForm(const int num_basis, FiniteElementSpace *f)
 ROMNonlinearForm::~ROMNonlinearForm()
 {
    delete Grad;
+   delete basis;
 
    for (int i = 0; i <  dnfi.Size(); i++)
    {
@@ -651,6 +652,17 @@ void ROMNonlinearForm::PrecomputeCoefficients()
          }  // for (int i = 0; i < sample_info->Size(); i++, sample++)
       }  // for (int k = 0; k < bfnfi.Size(); k++)
    }  // if (bfnfi.Size())
+}
+
+void ROMNonlinearForm::SetBasis(DenseMatrix &basis_, const int offset)
+{
+   assert(basis_.NumCols() == height);
+   assert(basis_.NumRows() >= fes->GetTrueVSize() + offset);
+   if (basis) delete basis;
+
+   const int nrow = fes->GetTrueVSize();
+   basis = new DenseMatrix(nrow, height);
+   basis_.GetSubMatrix(offset, offset+nrow, 0, height, *basis);
 }
 
 void ROMNonlinearForm::TrainEQP(const CAROM::Matrix &snapshots, const double eqp_tol)

--- a/src/rom_nonlinearform.cpp
+++ b/src/rom_nonlinearform.cpp
@@ -843,6 +843,8 @@ void ROMNonlinearForm::SetupEQPSystemForDomainIntegrator(
          T = fes->GetElementTransformation(e);
          v_i.GetSubVector(vdofs, el_x);
 
+         if (doftrans) { doftrans->InvTransformPrimal(el_x); }
+
          const int nd = fe->GetDof();
          el_quad.SetSize(nd * vdim, nqe);
          for (int i = 0; i < ir->GetNPoints(); i++)
@@ -851,6 +853,7 @@ void ROMNonlinearForm::SetupEQPSystemForDomainIntegrator(
 
             const IntegrationPoint &ip = ir->IntPoint(i);
             nlfi->AssembleQuadratureVector(*fe, *T, ip, 1.0, el_x, EQ);
+            if (doftrans) { doftrans->TransformDual(EQ); }
          }
          // nlfi->AssembleElementQuadrature(*fe, *T, el_x, el_quad);
 

--- a/src/rom_nonlinearform.cpp
+++ b/src/rom_nonlinearform.cpp
@@ -908,4 +908,26 @@ void ROMNonlinearForm::GetEQPForDomainIntegrator(
    }
 }
 
+void ROMNonlinearForm::SaveEQPForDomainIntegrator(const int k, hid_t file_id, const std::string &dsetname)
+{
+   Array<int> el, qp;
+   Array<double> qw;
+   GetEQPForDomainIntegrator(k, el, qp, qw);
+
+   assert(file_id >= 0);
+   hid_t grp_id;
+   herr_t errf;
+
+   grp_id = H5Gcreate(file_id, dsetname.c_str(), H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
+   assert(grp_id >= 0);
+
+   hdf5_utils::WriteDataset(grp_id, "elem", el);
+   hdf5_utils::WriteDataset(grp_id, "quad-pt", qp);
+   hdf5_utils::WriteDataset(grp_id, "quad-wt", qw);
+
+   errf = H5Gclose(grp_id);
+   assert(errf >= 0);
+   return;
+}
+
 }

--- a/src/rom_nonlinearform.cpp
+++ b/src/rom_nonlinearform.cpp
@@ -930,4 +930,27 @@ void ROMNonlinearForm::SaveEQPForDomainIntegrator(const int k, hid_t file_id, co
    return;
 }
 
+void ROMNonlinearForm::LoadEQPForDomainIntegrator(const int k, hid_t file_id, const std::string &dsetname)
+{
+   Array<int> el, qp;
+   Array<double> qw;
+
+   assert(file_id >= 0);
+   hid_t grp_id;
+   herr_t errf;
+
+   grp_id = H5Gopen2(file_id, dsetname.c_str(), H5P_DEFAULT);
+   assert(grp_id >= 0);
+
+   hdf5_utils::ReadDataset(grp_id, "elem", el);
+   hdf5_utils::ReadDataset(grp_id, "quad-pt", qp);
+   hdf5_utils::ReadDataset(grp_id, "quad-wt", qw);
+
+   errf = H5Gclose(grp_id);
+   assert(errf >= 0);
+
+   UpdateDomainIntegratorSampling(k, el, qp, qw);
+   return;
+}
+
 }

--- a/src/sample_generator.cpp
+++ b/src/sample_generator.cpp
@@ -204,6 +204,28 @@ void SampleGenerator::WriteSnapshots()
    }
 }
 
+const CAROM::Matrix* SampleGenerator::LookUpSnapshot(const std::string &basis_tag)
+{
+   assert(snapshot_generators.Size() > 0);
+   assert(snapshot_generators.Size() == basis_tags.size());
+
+   int idx = -1;
+   for (int k = 0; k < basis_tags.size(); k++)
+      if (basis_tags[k] == basis_tag)
+      {
+         idx = k;
+         break;
+      }
+
+   if (idx < 0)
+   {
+      printf("basis tag: %s\n", basis_tag.c_str());
+      mfem_error("SampleGenerator::LookUpSnapshot- basis tag does not exist in snapshot list!\n");
+   }
+
+   return snapshot_generators[idx]->getSnapshotMatrix();
+}
+
 void SampleGenerator::ReportStatus(const int &sample_idx)
 {
    if (sample_idx % report_freq != 0) return;

--- a/src/sample_generator.cpp
+++ b/src/sample_generator.cpp
@@ -229,6 +229,7 @@ const CAROM::Matrix* SampleGenerator::LookUpSnapshot(const std::string &basis_ta
 void SampleGenerator::ReportStatus(const int &sample_idx)
 {
    if (sample_idx % report_freq != 0) return;
+   if (proc_rank != 0) return;
 
    printf("==========  SampleGenerator Status  ==========\n");
    printf("%d-th sample is collected.\n", sample_idx);

--- a/src/sample_generator.cpp
+++ b/src/sample_generator.cpp
@@ -173,7 +173,7 @@ void SampleGenerator::SaveSnapshot(BlockVector *U_snapshots, std::vector<std::st
       }
 
       int index = basis_tag2idx[snapshot_basis_tags[s]];
-      bool addSample = snapshot_generators[index]->takeSample(U_snapshots->GetBlock(s).GetData(), 0.0, 0.01);
+      bool addSample = snapshot_generators[index]->takeSample(U_snapshots->GetBlock(s).GetData());
       assert(addSample);
    }
 }
@@ -183,6 +183,7 @@ void SampleGenerator::AddSnapshotGenerator(const int &fom_vdofs, const std::stri
    const std::string filename = GetBaseFilename(prefix, basis_tag);
 
    snapshot_options.Append(new CAROM::Options(fom_vdofs, max_num_snapshots, 1, update_right_SV));
+   snapshot_options.Last()->static_svd_preserve_snapshot = true;
    snapshot_generators.Append(new CAROM::BasisGenerator(*(snapshot_options.Last()), incremental, filename));
 
    basis_tag2idx[basis_tag] = basis_tags.size();
@@ -265,7 +266,7 @@ const int SampleGenerator::GetDimFromSnapshots(const std::string &filename)
 {
    CAROM::BasisReader d_basis_reader(filename);
    // time is currently always 0.0
-   return d_basis_reader.getDim("snapshot", 0.0);
+   return d_basis_reader.getDim("snapshot");
 }
 
 void SampleGenerator::SaveSV(CAROM::BasisGenerator *basis_generator, const std::string& prefix, const int& ref_num_basis)

--- a/src/steady_ns_solver.cpp
+++ b/src/steady_ns_solver.cpp
@@ -895,7 +895,7 @@ void SteadyNSSolver::SetupEQPOperators()
          }
       assert((midx >= 0) && (midx < numSub));
 
-      comp_fes = ufes[midx];
+      comp_fes[c] = ufes[midx];
    }
 
    DenseMatrix *basis;

--- a/src/steady_ns_solver.cpp
+++ b/src/steady_ns_solver.cpp
@@ -500,6 +500,9 @@ void SteadyNSSolver::BuildCompROMElement(Array<FiniteElementSpace *> &fes_comp)
 {
    StokesSolver::BuildCompROMElement(fes_comp);
 
+   if (rom_handler->GetNonlinearHandling() != NonlinearHandling::TENSOR)
+      return;
+
    DenseMatrix *basis = NULL;
    const int num_comp = topol_handler->GetNumComponents();
    comp_tensors.SetSize(num_comp);
@@ -517,6 +520,9 @@ void SteadyNSSolver::BuildCompROMElement(Array<FiniteElementSpace *> &fes_comp)
 void SteadyNSSolver::SaveCompBdrROMElement(hid_t &file_id)
 {
    MultiBlockSolver::SaveCompBdrROMElement(file_id);
+
+   if (rom_handler->GetNonlinearHandling() != NonlinearHandling::TENSOR)
+      return;
 
    const int num_comp = topol_handler->GetNumComponents();
    assert(comp_tensors.Size() == num_comp);
@@ -549,6 +555,9 @@ void SteadyNSSolver::SaveCompBdrROMElement(hid_t &file_id)
 void SteadyNSSolver::LoadCompBdrROMElement(hid_t &file_id)
 {
    MultiBlockSolver::LoadCompBdrROMElement(file_id);
+
+   if (rom_handler->GetNonlinearHandling() != NonlinearHandling::TENSOR)
+      return;
 
    const int num_comp = topol_handler->GetNumComponents();
    comp_tensors.SetSize(num_comp);
@@ -674,6 +683,9 @@ bool SteadyNSSolver::Solve()
 void SteadyNSSolver::ProjectOperatorOnReducedBasis()
 {
    StokesSolver::ProjectOperatorOnReducedBasis();
+
+   if (rom_handler->GetNonlinearHandling() != NonlinearHandling::TENSOR)
+      return;
 
    subdomain_tensors.SetSize(numSub);
    subdomain_tensors = NULL;

--- a/src/steady_ns_solver.cpp
+++ b/src/steady_ns_solver.cpp
@@ -122,7 +122,7 @@ Operator& SteadyNSOperator::GetGradient(const Vector &x) const
    mono_jac = system_jac->CreateMonolithic();
    if (direct_solve)
    {
-      jac_hypre = new HypreParMatrix(MPI_COMM_WORLD, sys_glob_size, sys_row_starts, mono_jac);
+      jac_hypre = new HypreParMatrix(MPI_COMM_SELF, sys_glob_size, sys_row_starts, mono_jac);
       return *jac_hypre;
    }  
    else
@@ -203,7 +203,7 @@ Operator& SteadyNSTensorROM::GetGradient(const Vector &x) const
    
    if (direct_solve)
    {
-      jac_hypre = new HypreParMatrix(MPI_COMM_WORLD, sys_glob_size, sys_row_starts, jac_mono);
+      jac_hypre = new HypreParMatrix(MPI_COMM_SELF, sys_glob_size, sys_row_starts, jac_mono);
       return *jac_hypre;
    }
    else
@@ -249,7 +249,7 @@ Operator& SteadyNSEQPROM::GetGradient(const Vector &x) const
    
    if (direct_solve)
    {
-      jac_hypre = new HypreParMatrix(MPI_COMM_WORLD, sys_glob_size, sys_row_starts, jac_mono);
+      jac_hypre = new HypreParMatrix(MPI_COMM_SELF, sys_glob_size, sys_row_starts, jac_mono);
       return *jac_hypre;
    }
    else

--- a/src/steady_ns_solver.cpp
+++ b/src/steady_ns_solver.cpp
@@ -748,6 +748,31 @@ void SteadyNSSolver::TrainEQP(SampleGenerator *sample_generator)
    }
 }
 
+void SteadyNSSolver::SaveEQP()
+{
+   std::string filename = config.GetRequiredOption<std::string>("model_reduction/save_operator/prefix");
+   filename += ".eqp.h5";
+
+   hid_t file_id;
+   herr_t errf = 0;
+   file_id = H5Fcreate(filename.c_str(), H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT);
+   assert(file_id >= 0);
+
+   const int num_comp = topol_handler->GetNumComponents();
+   assert(comp_eqps.Size() == num_comp);
+   std::string dset_name;
+   for (int c = 0; c < num_comp; c++)
+   {
+      assert(comp_eqps[c]);
+      dset_name = topol_handler->GetComponentName(c);
+      comp_eqps[c]->SaveEQPForDomainIntegrator(0, file_id, dset_name);
+   }
+
+   errf = H5Fclose(file_id);
+   assert(errf >= 0);
+   return;
+}
+
 DenseTensor* SteadyNSSolver::GetReducedTensor(DenseMatrix *basis, FiniteElementSpace *fespace)
 {
    assert(basis && fespace);

--- a/src/steady_ns_solver.cpp
+++ b/src/steady_ns_solver.cpp
@@ -130,13 +130,13 @@ Operator& SteadyNSOperator::GetGradient(const Vector &x) const
 }
 
 /*
-   SteadyNSTensorROM
+   SteadyNSROM
 */
 
-SteadyNSTensorROM::SteadyNSTensorROM(
-   SparseMatrix *linearOp_, Array<DenseTensor *> &hs_, const Array<int> &block_offsets_, const bool direct_solve_)
-   : Operator(linearOp_->Height(), linearOp_->Width()), linearOp(linearOp_), hs(hs_),
-     numSub(hs_.Size()), block_offsets(block_offsets_), direct_solve(direct_solve_)
+SteadyNSROM::SteadyNSROM(
+   SparseMatrix *linearOp_, const int numSub_, const Array<int> &block_offsets_, const bool direct_solve_)
+   : Operator(linearOp_->Height(), linearOp_->Width()), linearOp(linearOp_),
+     numSub(numSub_), block_offsets(block_offsets_), direct_solve(direct_solve_)
 {
    separate_variable = (block_offsets.Size() == num_var * numSub + 1);
    assert(separate_variable || (block_offsets.Size() == numSub + 1));
@@ -156,10 +156,14 @@ SteadyNSTensorROM::SteadyNSTensorROM(
    }
 }
 
-SteadyNSTensorROM::~SteadyNSTensorROM()
+SteadyNSROM::~SteadyNSROM()
 {
    DeletePointers(block_idxs);
 }
+
+/*
+   SteadyNSTensorROM
+*/
 
 void SteadyNSTensorROM::Mult(const Vector &x, Vector &y) const
 {

--- a/src/steady_ns_solver.cpp
+++ b/src/steady_ns_solver.cpp
@@ -783,7 +783,8 @@ void SteadyNSSolver::SaveEQP()
    {
       assert(comp_eqps[c]);
       dset_name = GetBasisTagForComponent(c, train_mode, topol_handler);
-      comp_eqps[c]->SaveEQPForDomainIntegrator(0, file_id, dset_name);
+      // only one integrator exists in each nonlinear form.
+      comp_eqps[c]->SaveEQPForIntegrator(IntegratorType::DOMAIN, 0, file_id, dset_name);
    }
 
    errf = H5Fclose(file_id);
@@ -812,7 +813,8 @@ void SteadyNSSolver::LoadEQP()
    {
       assert(comp_eqps[c]);
       dset_name = GetBasisTagForComponent(c, train_mode, topol_handler);
-      comp_eqps[c]->LoadEQPForDomainIntegrator(0, file_id, dset_name);
+      // only one integrator exists in each nonlinear form.
+      comp_eqps[c]->LoadEQPForIntegrator(IntegratorType::DOMAIN, 0, file_id, dset_name);
 
       if (comp_eqps[c]->PrecomputeMode())
          comp_eqps[c]->PrecomputeCoefficients();

--- a/src/stokes_solver.cpp
+++ b/src/stokes_solver.cpp
@@ -483,7 +483,7 @@ void StokesSolver::SetupMUMPSSolver()
    sys_glob_size = systemOp_mono->NumRows();
    sys_row_starts[0] = 0;
    sys_row_starts[1] = systemOp_mono->NumRows();
-   systemOp_hypre = new HypreParMatrix(MPI_COMM_WORLD, sys_glob_size, sys_row_starts, systemOp_mono);
+   systemOp_hypre = new HypreParMatrix(MPI_COMM_SELF, sys_glob_size, sys_row_starts, systemOp_mono);
 
    mumps = new MUMPSSolver();
    mumps->SetMatrixSymType(MUMPSSolver::MatType::SYMMETRIC_POSITIVE_DEFINITE);
@@ -751,7 +751,7 @@ bool StokesSolver::Solve()
       if (use_amg)
       {
          // velocity amg preconditioner
-         Mop = new HypreParMatrix(MPI_COMM_WORLD, glob_size, row_starts, M);
+         Mop = new HypreParMatrix(MPI_COMM_SELF, glob_size, row_starts, M);
          amg_prec = new HypreBoomerAMG(*Mop);
          amg_prec->SetPrintLevel(0);
          amg_prec->SetSystemsOptions(vdim[0], true);
@@ -844,7 +844,7 @@ void StokesSolver::Solve_obsolete()
    HYPRE_BigInt row_starts[2] = {0, M->NumRows()};
    if (use_amg)
    {
-      Mop = new HypreParMatrix(MPI_COMM_WORLD, glob_size, row_starts, M);
+      Mop = new HypreParMatrix(MPI_COMM_SELF, glob_size, row_starts, M);
       amg_prec = new HypreBoomerAMG(*Mop);
       amg_prec->SetPrintLevel(print_level);
    }

--- a/test/gmsh/stokes.component.yml
+++ b/test/gmsh/stokes.component.yml
@@ -94,6 +94,7 @@ model_reduction:
   rom_handler_type: mfem
   # individual/universal
   subdomain_training: universal
+  nonlinear_handling: tensor
   save_operator:
     level: component
     prefix: "test.rom_elem"

--- a/test/inputs/steady_ns.base.yml
+++ b/test/inputs/steady_ns.base.yml
@@ -63,6 +63,7 @@ model_reduction:
   rom_handler_type: mfem
   # individual/universal
   subdomain_training: individual
+  nonlinear_handling: tensor
   save_operator:
     level: global
     prefix: "proj_inv"

--- a/test/inputs/steady_ns.component.yml
+++ b/test/inputs/steady_ns.component.yml
@@ -87,6 +87,7 @@ model_reduction:
   rom_handler_type: mfem
   # individual/universal
   subdomain_training: universal
+  nonlinear_handling: tensor
   save_operator:
     level: component
     prefix: "test.rom_elem"

--- a/test/test_rom_nonlinearform.cpp
+++ b/test/test_rom_nonlinearform.cpp
@@ -293,12 +293,13 @@ TEST(ROMNonlinearForm, SetupEQPSystemForDomainIntegrator)
          snapshots(i, j) = 2.0 * UniformRandom() - 1.0;
 
    CAROM::Options options(ndofs, num_snap, 1, true);
+   options.static_svd_preserve_snapshot = true;
    CAROM::BasisGenerator basis_generator(options, false, "test_basis");
    Vector snapshot(ndofs);
    for (int s = 0; s < num_snap; s++)
    {
       snapshots.GetColumnReference(s, snapshot);
-      basis_generator.takeSample(snapshot.GetData(), 0.0, 0.01);
+      basis_generator.takeSample(snapshot.GetData());
    }
    basis_generator.endSamples();
    const CAROM::Matrix *carom_snapshots = basis_generator.getSnapshotMatrix();

--- a/test/test_workflow.cpp
+++ b/test/test_workflow.cpp
@@ -650,20 +650,16 @@ TEST(LinElast_Workflow, ComponentWiseWithDirectSolve)
 
 TEST(SteadyNS_Workflow, ComponentSeparateVariable_EQP)
 {
-   // config = InputParser("inputs/steady_ns.component.yml");
-   config = InputParser("inputs/steady_ns.base.yml");
+   config = InputParser("inputs/steady_ns.component.yml");
    config.dict_["domain-decomposition"]["type"] = "none";
-   // for (int k = 0; k < 4; k++)
-   //    config.dict_["basis"]["tags"][k]["name"] = "dom" + std::to_string(k);
+   config.dict_["discretization"]["order"] = 1;
    config.dict_["model_reduction"]["save_operator"]["level"] = "none";
 
-   config.dict_["model_reduction"]["separate_variable_basis"] = false;
    config.dict_["model_reduction"]["linear_solver_type"] = "direct";
    config.dict_["model_reduction"]["linear_system_type"] = "us";
    config.dict_["model_reduction"]["nonlinear_handling"] = "eqp";
    config.dict_["model_reduction"]["eqp"]["relative_tolerance"] = 1.0e-11;
-   config.dict_["model_reduction"]["eqp"]["precompute"] = false;
-   config.dict_["solver"]["print_level"] = 1;
+   config.dict_["model_reduction"]["eqp"]["precompute"] = true;
 
    printf("\nSample Generation \n\n");
    
@@ -681,9 +677,9 @@ TEST(SteadyNS_Workflow, ComponentSeparateVariable_EQP)
    config.dict_["main"]["mode"] = "single_run";
    double error = SingleRun(MPI_COMM_WORLD, "test_output.h5");
 
-   // // This reproductive case must have a very small error at the level of finite-precision.
-   // printf("Error: %.15E\n", error);
-   // EXPECT_TRUE(error < stokes_threshold);
+   // This reproductive case must have a very small error at the level of finite-precision.
+   printf("Error: %.15E\n", error);
+   EXPECT_TRUE(error < stokes_threshold);
 
    return;
 }

--- a/test/test_workflow.cpp
+++ b/test/test_workflow.cpp
@@ -648,7 +648,39 @@ TEST(LinElast_Workflow, ComponentWiseWithDirectSolve)
    return;
 }
 
-int main(int argc, char *argv[])
+TEST(SteadyNS_Workflow, ComponentSeparateVariable_EQP)
+{
+   config = InputParser("inputs/steady_ns.component.yml");
+   config.dict_["model_reduction"]["separate_variable_basis"] = true;
+   config.dict_["model_reduction"]["linear_solver_type"] = "direct";
+   config.dict_["model_reduction"]["linear_system_type"] = "us";
+   config.dict_["model_reduction"]["nonlinear_handling"] = "eqp";
+   config.dict_["model_reduction"]["eqp"]["relative_tolerance"] = 1.0e-11;
+
+   printf("\nSample Generation \n\n");
+   
+   config.dict_["main"]["mode"] = "sample_generation";
+   GenerateSamples(MPI_COMM_WORLD);
+
+   config.dict_["main"]["mode"] = "train_rom";
+   TrainROM(MPI_COMM_WORLD);
+
+   // printf("\nBuild ROM \n\n");
+
+   // config.dict_["main"]["mode"] = "build_rom";
+   // BuildROM(MPI_COMM_WORLD);
+
+   // config.dict_["main"]["mode"] = "single_run";
+   // double error = SingleRun(MPI_COMM_WORLD, "test_output.h5");
+
+   // // This reproductive case must have a very small error at the level of finite-precision.
+   // printf("Error: %.15E\n", error);
+   // EXPECT_TRUE(error < stokes_threshold);
+
+   return;
+}
+
+int main(int argc, char* argv[])
 {
    ::testing::InitGoogleTest(&argc, argv);
    MPI_Init(&argc, &argv);

--- a/test/test_workflow.cpp
+++ b/test/test_workflow.cpp
@@ -498,7 +498,7 @@ TEST(SteadyNS_Workflow, ComponentWiseTest)
 
 TEST(SteadyNS_Workflow, ComponentWiseWithDirectSolve)
 {
-   config = InputParser("inputs/stokes.component.yml");
+   config = InputParser("inputs/steady_ns.component.yml");
    config.dict_["model_reduction"]["linear_solver_type"] = "direct";
    config.dict_["model_reduction"]["linear_system_type"] = "us";
 
@@ -527,7 +527,7 @@ TEST(SteadyNS_Workflow, ComponentWiseWithDirectSolve)
 
 TEST(SteadyNS_Workflow, ComponentSeparateVariable)
 {
-   config = InputParser("inputs/stokes.component.yml");
+   config = InputParser("inputs/steady_ns.component.yml");
    config.dict_["model_reduction"]["separate_variable_basis"] = true;
    config.dict_["model_reduction"]["linear_solver_type"] = "direct";
    config.dict_["model_reduction"]["linear_system_type"] = "us";

--- a/test/test_workflow.cpp
+++ b/test/test_workflow.cpp
@@ -665,10 +665,10 @@ TEST(SteadyNS_Workflow, ComponentSeparateVariable_EQP)
    config.dict_["main"]["mode"] = "train_rom";
    TrainROM(MPI_COMM_WORLD);
 
-   // printf("\nBuild ROM \n\n");
+   printf("\nBuild ROM \n\n");
 
-   // config.dict_["main"]["mode"] = "build_rom";
-   // BuildROM(MPI_COMM_WORLD);
+   config.dict_["main"]["mode"] = "build_rom";
+   BuildROM(MPI_COMM_WORLD);
 
    // config.dict_["main"]["mode"] = "single_run";
    // double error = SingleRun(MPI_COMM_WORLD, "test_output.h5");

--- a/test/test_workflow.cpp
+++ b/test/test_workflow.cpp
@@ -650,12 +650,20 @@ TEST(LinElast_Workflow, ComponentWiseWithDirectSolve)
 
 TEST(SteadyNS_Workflow, ComponentSeparateVariable_EQP)
 {
-   config = InputParser("inputs/steady_ns.component.yml");
-   config.dict_["model_reduction"]["separate_variable_basis"] = true;
+   // config = InputParser("inputs/steady_ns.component.yml");
+   config = InputParser("inputs/steady_ns.base.yml");
+   config.dict_["domain-decomposition"]["type"] = "none";
+   // for (int k = 0; k < 4; k++)
+   //    config.dict_["basis"]["tags"][k]["name"] = "dom" + std::to_string(k);
+   config.dict_["model_reduction"]["save_operator"]["level"] = "none";
+
+   config.dict_["model_reduction"]["separate_variable_basis"] = false;
    config.dict_["model_reduction"]["linear_solver_type"] = "direct";
    config.dict_["model_reduction"]["linear_system_type"] = "us";
    config.dict_["model_reduction"]["nonlinear_handling"] = "eqp";
    config.dict_["model_reduction"]["eqp"]["relative_tolerance"] = 1.0e-11;
+   config.dict_["model_reduction"]["eqp"]["precompute"] = false;
+   config.dict_["solver"]["print_level"] = 1;
 
    printf("\nSample Generation \n\n");
    
@@ -670,8 +678,8 @@ TEST(SteadyNS_Workflow, ComponentSeparateVariable_EQP)
    config.dict_["main"]["mode"] = "build_rom";
    BuildROM(MPI_COMM_WORLD);
 
-   // config.dict_["main"]["mode"] = "single_run";
-   // double error = SingleRun(MPI_COMM_WORLD, "test_output.h5");
+   config.dict_["main"]["mode"] = "single_run";
+   double error = SingleRun(MPI_COMM_WORLD, "test_output.h5");
 
    // // This reproductive case must have a very small error at the level of finite-precision.
    // printf("Error: %.15E\n", error);

--- a/test/test_workflow.cpp
+++ b/test/test_workflow.cpp
@@ -651,10 +651,7 @@ TEST(LinElast_Workflow, ComponentWiseWithDirectSolve)
 TEST(SteadyNS_Workflow, ComponentSeparateVariable_EQP)
 {
    config = InputParser("inputs/steady_ns.component.yml");
-   config.dict_["domain-decomposition"]["type"] = "none";
-   config.dict_["discretization"]["order"] = 1;
-   config.dict_["model_reduction"]["save_operator"]["level"] = "none";
-
+   config.dict_["model_reduction"]["separate_variable_basis"] = true;
    config.dict_["model_reduction"]["linear_solver_type"] = "direct";
    config.dict_["model_reduction"]["linear_system_type"] = "us";
    config.dict_["model_reduction"]["nonlinear_handling"] = "eqp";


### PR DESCRIPTION
`ROMNonlinearForm` now supports EQP training procedure for general `HyperreductionIntegrator`.
- This only supports the single-mesh integrators. EQP routines for mesh interfaces will be implemented in `InterfaceForm` in future.
- `struct SampleInfo` contains the information for each sample EQP.
- `ROMNonlinearForm::TrainEQP` performs EQP NNLS for each integrator, obtaining multiple EQP sets for individual integrators.

The overall workflow with EQP is verified with `SteadyNSSolver` application.
- EQP training procedure is executed within `AuxiliaryTrainROM` as part of `TrainROM`.
- `SteadyNSEQPROM` is the proxy nonlinear operator with `ROMNonlinearForm` for each subdomain.

This PR also reflects the interface change of libROM classes due to the recent [PR](https://github.com/LLNL/libROM/pull/274).