### PR TITLE
ROMHandler::SaveRomSystem.

### DIFF
--- a/include/rom_handler.hpp
+++ b/include/rom_handler.hpp
@@ -95,9 +95,6 @@ protected:
    */
    Array<int> rom_varblock_offsets;
    
-   CAROM::Vector *reduced_rhs = NULL;
-   CAROM::Vector *reduced_sol = NULL;
-   
    CAROM::Options* rom_options;
    CAROM::BasisGenerator *basis_generator;
    CAROM::BasisReader *basis_reader;
@@ -169,6 +166,7 @@ public:
    virtual void SaveOperator(const std::string input_prefix="") = 0;
    virtual void LoadOperatorFromFile(const std::string input_prefix="") = 0;
    virtual void SetRomMat(BlockMatrix *input_mat) = 0;
+   virtual void SaveRomSystem(const std::string &input_prefix, const std::string type="mm") = 0;
 
    virtual void SaveBasisVisualization(const Array<FiniteElementSpace *> &fes, const std::vector<std::string> &var_names) = 0;
 
@@ -254,6 +252,7 @@ public:
    virtual void SaveOperator(const std::string input_prefix="");
    virtual void LoadOperatorFromFile(const std::string input_prefix="");
    virtual void SetRomMat(BlockMatrix *input_mat);
+   virtual void SaveRomSystem(const std::string &input_prefix, const std::string type="mm");
 
    virtual void SaveBasisVisualization(const Array<FiniteElementSpace *> &fes, const std::vector<std::string> &var_names);
 

--- a/src/main_workflow.cpp
+++ b/src/main_workflow.cpp
@@ -500,6 +500,14 @@ double SingleRun(MPI_Comm comm, const std::string output_file)
    else
       fom_solve = solveTimer.RealTime();
 
+   /* save the ROM system for analysis/debug */
+   bool save_rom = config.GetOption<bool>("model_reduction/save_linear_system/enabled", false);
+   if (save_rom)
+   {
+      std::string rom_prefix = config.GetRequiredOption<std::string>("model_reduction/save_linear_system/prefix");
+      rom->SaveRomSystem(rom_prefix);
+   }
+
    bool compare_sol = config.GetOption<bool>("model_reduction/compare_solution/enabled", false);
    bool load_sol = config.GetOption<bool>("model_reduction/compare_solution/load_solution", false);
    if (test->UseRom() && compare_sol)

--- a/src/rom_handler.cpp
+++ b/src/rom_handler.cpp
@@ -104,8 +104,7 @@ ROMHandlerBase::ROMHandlerBase(
 
 ROMHandlerBase::~ROMHandlerBase()
 {
-   delete reduced_rhs;
-   delete reduced_sol;
+   DeletePointers(carom_ref_basis);
 }
 
 void ROMHandlerBase::ParseInputs()
@@ -907,6 +906,29 @@ void MFEMROMHandler::SetRomMat(BlockMatrix *input_mat)
 
    if (linsol_type == SolverType::DIRECT) SetupDirectSolver();
    operator_loaded = true;
+}
+
+void MFEMROMHandler::SaveRomSystem(const std::string &input_prefix, const std::string type)
+{
+   if (!romMat_mono)
+   {
+      assert(romMat);
+      romMat_mono = romMat->CreateMonolithic();
+   }
+   assert(reduced_rhs);
+   assert(reduced_sol);
+
+   PrintVector(*reduced_rhs, input_prefix + "_rhs.txt");
+   PrintVector(*reduced_sol, input_prefix + "_sol.txt");
+
+   std::string matfile = input_prefix + "_mat." + type;
+   std::ofstream file(matfile.c_str());
+   if (type == "mm")
+      romMat_mono->PrintMM(file);
+   else if (type == "matlab")
+      romMat_mono->PrintMatlab(file);
+   else
+      mfem_error("MFEMROMHandler::SaveRomSystem - unknown matrix format type!\n");
 }
 
 void MFEMROMHandler::SaveBasisVisualization(


### PR DESCRIPTION
With input option `model_reduction/save_linear_system`, the linear ROM matrix-vector system can be saved into files for analysis/debug in the `SingleRun`. Vectors will be saved in `.txt`, and matrix can be saved in either Matrix-Market (MM) sparse format or matlab format.