### PR TITLE
EQP training routines in `ROMNonlinearForm` and its application to `S…

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,14 +11,17 @@ scaleupROM is mainly built upon [MFEM](https://mfem.org/) and [libROM](https://w
 
 - Discontinuous Galerkin domain decomposition
 - Projection-based reduced order model
+- EQP for nonlinear partial differential equations
 - Supporting physics equations:
   - Poisson equation
   - Stokes flow
+  - Steady Navier-Stokes flow
 
 ## Features to be added
 
-- Steady Navier-Stokes flow
-- EQP for nonlinear partial differential equations
+- Linear elasticity
+- Nonlinear elasticity
+- Time-dependent Navier-Stokes flow
 
 # Installation
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -50,7 +50,9 @@ ENV YAML_DIR=$LIB_DIR/yaml-cpp
 # install libROM for scaleupROM
 WORKDIR $LIB_DIR
 RUN sudo git clone https://github.com/LLNL/libROM.git
-WORKDIR ./libROM/build
+WORKDIR ./libROM
+RUN sudo git pull && sudo git checkout mpi-io
+WORKDIR ./build
 # libROM is using the MFEM without MUMPS right now.
 RUN sudo cmake .. -DCMAKE_TOOLCHAIN_FILE=${TOOLCHAIN_FILE} -DCMAKE_BUILD_TYPE=${BUILD_TYPE} -DUSE_MFEM=${USE_MFEM} -DMFEM_USE_GSLIB=${MFEM_USE_GSLIB}
 RUN sudo make -j 16

--- a/include/main_workflow.hpp
+++ b/include/main_workflow.hpp
@@ -21,7 +21,9 @@ void GenerateSamples(MPI_Comm comm);
 void BuildROM(MPI_Comm comm);
 void TrainROM(MPI_Comm comm);
 // supremizer-enrichment, hypre-reduction optimization, etc..
-void AuxiliaryTrainROM(MPI_Comm comm);
+void AuxiliaryTrainROM(MPI_Comm comm, SampleGenerator *sample_generator);
+// Input parsing routine to list out all snapshot files for training a basis.
+void FindSnapshotFilesForBasis(const std::string &basis_tag, const std::string &default_filename, std::vector<std::string> &file_list);
 // return relative error if comparing solution.
 double SingleRun(MPI_Comm comm, const std::string output_file = "");
 

--- a/include/multiblock_solver.hpp
+++ b/include/multiblock_solver.hpp
@@ -12,6 +12,7 @@
 #include "parameterized_problem.hpp"
 #include "rom_handler.hpp"
 #include "hdf5_utils.hpp"
+#include "sample_generator.hpp"
 
 // By convention we only use mfem namespace as default, not CAROM.
 using namespace mfem;
@@ -29,6 +30,7 @@ protected:
 
    bool full_dg = true;
    int skip_zeros = 1;
+   bool nonlinear_mode = false;
 
    TopologyHandlerMode topol_mode = NUM_TOPOL_MODE;
    TopologyHandler *topol_handler = NULL;
@@ -114,6 +116,7 @@ public:
    Mesh* GetMesh(const int k) { return &(*meshes[k]); }
    GridFunction* GetGridFunction(const int k) { return us[k]; }
    const int GetDiscretizationOrder() const { return order; }
+   const bool IsNonlinear() const { return nonlinear_mode; }
    const bool UseRom() const { return use_rom; }
    ROMHandlerBase* GetROMHandler() const { return rom_handler; }
    const TrainMode GetTrainMode() { return train_mode; }
@@ -209,6 +212,13 @@ public:
    void SaveSolution(std::string filename = "");
    void LoadSolution(const std::string &filename);
    void CopySolution(BlockVector *input_sol);
+
+   virtual void TrainEQP(SampleGenerator *sample_generator)
+   { mfem_error("Abstract method MultiBlockSolver::TrainEQP!\n"); }
+   virtual void SaveEQP()
+   { mfem_error("Abstract method MultiBlockSolver::TrainEQP!\n"); }
+   virtual void LoadEQP()
+   { mfem_error("Abstract method MultiBlockSolver::TrainEQP!\n"); }
 
    void InitROMHandler();
    void GetBasisTags(std::vector<std::string> &basis_tags);

--- a/include/sample_generator.hpp
+++ b/include/sample_generator.hpp
@@ -8,7 +8,7 @@
 #include "mfem.hpp"
 #include "parameter.hpp"
 #include "linalg/BasisGenerator.h"
-#include "multiblock_solver.hpp"
+#include "linalg_utils.hpp"
 
 using namespace mfem;
 
@@ -92,6 +92,7 @@ public:
    void SaveSnapshot(BlockVector *U_snapshots, std::vector<std::string> &snapshot_basis_tags);
    void AddSnapshotGenerator(const int &fom_vdofs, const std::string &prefix, const std::string &basis_tag);
    void WriteSnapshots();
+   const CAROM::Matrix* LookUpSnapshot(const std::string &basis_tag);
 
    void ReportStatus(const int &sample_idx);
 

--- a/include/steady_ns_solver.hpp
+++ b/include/steady_ns_solver.hpp
@@ -6,6 +6,7 @@
 #define SCALEUPROM_STEADY_NS_SOLVER_HPP
 
 #include "stokes_solver.hpp"
+#include "rom_nonlinearform.hpp"
 
 // By convention we only use mfem namespace as default, not CAROM.
 using namespace mfem;
@@ -49,7 +50,7 @@ public:
 };
 
 // A proxy Operator used for ROM Newton Solver.
-class SteadyNSTensorROM : public Operator
+class SteadyNSROM : public Operator
 {
 protected:
    bool direct_solve;
@@ -60,7 +61,6 @@ protected:
 
    Array<int> block_offsets;
    Array<Array<int> *> block_idxs;
-   Array<DenseTensor *> hs;
    SparseMatrix *linearOp = NULL;
 
    mutable Vector x_comp, y_comp;
@@ -70,9 +70,39 @@ protected:
    HYPRE_BigInt sys_glob_size;
    mutable HYPRE_BigInt sys_row_starts[2];
 public:
-   SteadyNSTensorROM(SparseMatrix *linearOp_, Array<DenseTensor *> &hs_, const Array<int> &block_offsets_, const bool direct_solve_=true);
+   SteadyNSROM(SparseMatrix *linearOp_, const int numSub_, const Array<int> &block_offsets_, const bool direct_solve_=true);
 
-   virtual ~SteadyNSTensorROM();
+   virtual ~SteadyNSROM();
+
+   virtual void Mult(const Vector &x, Vector &y) const = 0;
+   virtual Operator &GetGradient(const Vector &x) const = 0;
+};
+
+class SteadyNSTensorROM : public SteadyNSROM
+{
+protected:
+   Array<DenseTensor *> hs; // not owned by SteadyNSTensorROM.
+
+public:
+   SteadyNSTensorROM(SparseMatrix *linearOp_, Array<DenseTensor *> &hs_, const Array<int> &block_offsets_, const bool direct_solve_=true)
+      : SteadyNSROM(linearOp_, hs_.Size(), block_offsets_, direct_solve_), hs(hs_) {}
+
+   virtual ~SteadyNSTensorROM() {}
+
+   virtual void Mult(const Vector &x, Vector &y) const;
+   virtual Operator &GetGradient(const Vector &x) const;
+};
+
+class SteadyNSEQPROM : public SteadyNSROM
+{
+protected:
+   Array<ROMNonlinearForm *> hs; // not owned by SteadyNSEQPROM.
+
+public:
+   SteadyNSEQPROM(SparseMatrix *linearOp_, Array<ROMNonlinearForm *> &hs_, const Array<int> &block_offsets_, const bool direct_solve_=true)
+      : SteadyNSROM(linearOp_, hs_.Size(), block_offsets_, direct_solve_), hs(hs_) {}
+
+   virtual ~SteadyNSEQPROM() {}
 
    virtual void Mult(const Vector &x, Vector &y) const;
    virtual Operator &GetGradient(const Vector &x) const;
@@ -106,6 +136,8 @@ protected:
 
    // component ROM element for nonlinear convection.
    Array<DenseTensor *> comp_tensors, subdomain_tensors;
+   Array<ROMNonlinearForm *> comp_eqps, subdomain_eqps;
+   Array<FiniteElementSpace *> comp_fes;  // pointers to existing fespace, no need to delete
 
    Solver *J_solver = NULL;
    GMRESSolver *J_gmres = NULL;
@@ -144,8 +176,13 @@ public:
 
    virtual void SolveROM() override;
 
+   virtual void TrainEQP(SampleGenerator *sample_generator) override;
+   virtual void SaveEQP() override;
+   virtual void LoadEQP() override;
+
 private:
    DenseTensor* GetReducedTensor(DenseMatrix *basis, FiniteElementSpace *fespace);
+   void SetupEQPOperators();
 };
 
 #endif

--- a/sketches/librom_svd.cpp
+++ b/sketches/librom_svd.cpp
@@ -31,12 +31,13 @@ int main(int argc, char *argv[])
       bool addSample;
 
       rom_options = new CAROM::Options(dim, max_num_snapshots, 1, update_right_SV);
+      rom_options->static_svd_preserve_snapshot = true;
       basis_generator = new CAROM::BasisGenerator(*rom_options, incremental, filename);
-      addSample = basis_generator->takeSample(sample1, 0.0, 0.01);
+      addSample = basis_generator->takeSample(sample1);
       // basis_generator->writeSnapshot();
-      addSample = basis_generator->takeSample(sample2, 0.0, 0.01);
+      addSample = basis_generator->takeSample(sample2);
       // basis_generator->writeSnapshot();
-      addSample = basis_generator->takeSample(sample3, 0.0, 0.01);
+      addSample = basis_generator->takeSample(sample3);
       // basis_generator->writeSnapshot();
 
       basis_generator->endSamples();

--- a/sketches/linalg_interface.cpp
+++ b/sketches/linalg_interface.cpp
@@ -42,11 +42,12 @@ int main(int argc, char *argv[])
    // librom svd
    // SVD class constructors are protected, so using BasisGenerator.
    CAROM::Options options(fes->GetTrueVSize(), 100, 1, true);
+   options.static_svd_preserve_snapshot = true;
    std::string filename("test");
    CAROM::BasisGenerator *generator = new CAROM::BasisGenerator(options, false, filename);
    for (int s = 0; s < nsample; s++)
    {
-      bool addSample = generator->takeSample(snapshots[s]->getData(), 0.0, 0.01);
+      bool addSample = generator->takeSample(snapshots[s]->getData());
    }
 
    // librom snapshot matrix.
@@ -175,7 +176,7 @@ int main(int argc, char *argv[])
    generator = new CAROM::BasisGenerator(options, false, filename);
    for (int s = 0; s < nsample; s++)
    {
-      bool addSample = generator->takeSample(transformed_snapshots[s]->GetData(), 0.0, 0.01);
+      bool addSample = generator->takeSample(transformed_snapshots[s]->GetData());
    }
 
    // librom pod basis.
@@ -248,7 +249,7 @@ int main(int argc, char *argv[])
       generator = new CAROM::BasisGenerator(options, false, filename);
       for (int s = 0; s < nsample; s++)
       {
-         bool addSample = generator->takeSample(snapshots[s]->getData(), 0.0, 0.01);
+         bool addSample = generator->takeSample(snapshots[s]->getData());
       }
 
       basis = generator->getSpatialBasis();

--- a/src/poisson_solver.cpp
+++ b/src/poisson_solver.cpp
@@ -326,7 +326,7 @@ void PoissonSolver::AssembleOperator()
       sys_glob_size = globalMat_mono->NumRows();
       sys_row_starts[0] = 0;
       sys_row_starts[1] = globalMat_mono->NumRows();
-      globalMat_hypre = new HypreParMatrix(MPI_COMM_WORLD, sys_glob_size, sys_row_starts, globalMat_mono);
+      globalMat_hypre = new HypreParMatrix(MPI_COMM_SELF, sys_glob_size, sys_row_starts, globalMat_mono);
 
       mumps = new MUMPSSolver();
       mumps->SetMatrixSymType(MUMPSSolver::MatType::SYMMETRIC_POSITIVE_DEFINITE);
@@ -463,7 +463,7 @@ bool PoissonSolver::Solve()
          // Initializating HypreParMatrix needs the monolithic sparse matrix.
          assert(globalMat_mono != NULL);
 
-         solver = new CGSolver(MPI_COMM_WORLD);
+         solver = new CGSolver(MPI_COMM_SELF);
 
          M = new HypreBoomerAMG(*globalMat_hypre);
          M->SetPrintLevel(print_level);

--- a/src/rom_nonlinearform.cpp
+++ b/src/rom_nonlinearform.cpp
@@ -21,6 +21,7 @@ ROMNonlinearForm::ROMNonlinearForm(const int num_basis, FiniteElementSpace *f)
 ROMNonlinearForm::~ROMNonlinearForm()
 {
    delete Grad;
+   delete basis;
 
    for (int i = 0; i <  dnfi.Size(); i++)
    {
@@ -651,6 +652,621 @@ void ROMNonlinearForm::PrecomputeCoefficients()
          }  // for (int i = 0; i < sample_info->Size(); i++, sample++)
       }  // for (int k = 0; k < bfnfi.Size(); k++)
    }  // if (bfnfi.Size())
+}
+
+void ROMNonlinearForm::SetBasis(DenseMatrix &basis_, const int offset)
+{
+   assert(basis_.NumCols() == height);
+   assert(basis_.NumRows() >= fes->GetTrueVSize() + offset);
+   if (basis) delete basis;
+
+   const int nrow = fes->GetTrueVSize();
+   basis = new DenseMatrix(nrow, height);
+   basis_.GetSubMatrix(offset, offset+nrow, 0, height, *basis);
+}
+
+void ROMNonlinearForm::TrainEQP(const CAROM::Matrix &snapshots, const double eqp_tol)
+{
+   // NOTE(kevin): these will be resized within the routines as needed.
+   // just initializing with distribute option.
+   CAROM::Matrix Gt(1,1, true);
+   CAROM::Vector rhs_Gw(1, false);
+
+   Array<int> el, qp;
+   Array<double> qw;
+   Array<int> fidxs;
+   Mesh *mesh = fes->GetMesh();
+
+   for (int k = 0; k < dnfi.Size(); k++)
+   {
+      SetupEQPSystemForDomainIntegrator(snapshots, dnfi[k], Gt, rhs_Gw);
+      TrainEQPForIntegrator(dnfi[k], Gt, rhs_Gw, eqp_tol, el, qp, qw);
+      UpdateDomainIntegratorSampling(k, el, qp, qw);
+   }
+
+   for (int k = 0; k < fnfi.Size(); k++)
+   {
+      SetupEQPSystemForInteriorFaceIntegrator(snapshots, fnfi[k], Gt, rhs_Gw, fidxs);
+      TrainEQPForIntegrator(fnfi[k], Gt, rhs_Gw, eqp_tol, el, qp, qw);
+      for (int s = 0; s < el.Size(); s++)
+         el[s] = fidxs[el[s]];
+      UpdateInteriorFaceIntegratorSampling(k, el, qp, qw);
+   }
+
+   // Which boundary attributes need to be processed?
+   Array<int> bdr_attr_marker(mesh->bdr_attributes.Size() ?
+                              mesh->bdr_attributes.Max() : 0);
+
+   for (int k = 0; k < bfnfi.Size(); k++)
+   {
+      // Determine the boundary attributes to process for k-th boundary face integrator.
+      bdr_attr_marker = 0;
+      if (bfnfi_marker[k] == NULL)
+         bdr_attr_marker = 1;
+      Array<int> &bdr_marker = *bfnfi_marker[k];
+      MFEM_ASSERT(bdr_marker.Size() == bdr_attr_marker.Size(),
+                  "invalid boundary marker for boundary face integrator #"
+                  << k << ", counting from zero");
+      for (int i = 0; i < bdr_attr_marker.Size(); i++)
+      {
+         bdr_attr_marker[i] |= bdr_marker[i];
+      }
+
+      SetupEQPSystemForBdrFaceIntegrator(snapshots, bfnfi[k], bdr_attr_marker, Gt, rhs_Gw, fidxs);
+      TrainEQPForIntegrator(bfnfi[k], Gt, rhs_Gw, eqp_tol, el, qp, qw);
+      for (int s = 0; s < el.Size(); s++)
+         el[s] = fidxs[el[s]];
+      UpdateBdrFaceIntegratorSampling(k, el, qp, qw);
+   }
+}
+
+void ROMNonlinearForm::TrainEQPForIntegrator(
+   HyperReductionIntegrator *nlfi, const CAROM::Matrix &Gt, const CAROM::Vector &rhs_Gw,
+   const double eqp_tol, Array<int> &sample_el, Array<int> &sample_qp, Array<double> &sample_qw)
+{
+   const IntegrationRule *ir = nlfi->GetIntegrationRule();
+
+   // TODO(kevin): extension for mixed mesh elements.
+   const int vdim = fes->GetVDim();
+   const int nqe = ir->GetNPoints();
+
+   //    void SolveNNLS(const int rank, const double nnls_tol, const int maxNNLSnnz,
+   // CAROM::Vector const& w, CAROM::Matrix & Gt,
+   // CAROM::Vector & sol)
+   double nnls_tol = 1.0e-11;
+   int maxNNLSnnz = 0;
+   CAROM::Vector eqpSol(Gt.numRows(), true);
+   int nnz = 0;
+   {
+      CAROM::NNLSSolver nnls(nnls_tol, 0, maxNNLSnnz, 2);
+
+      CAROM::Vector rhs_ub(rhs_Gw);
+      CAROM::Vector rhs_lb(rhs_Gw);
+
+      double delta;
+      for (int i = 0; i < rhs_ub.dim(); ++i)
+      {
+         delta = eqp_tol * abs(rhs_Gw(i));
+         rhs_lb(i) -= delta;
+         rhs_ub(i) += delta;
+      }
+
+      /*
+         NOTE(kevin): turn off the normalization now.
+         The termination criterion of solve_parallel_with_scalapack
+         is currently unnecessarily complicated and redundant.
+      */
+      // nnls.normalize_constraints(Gt, rhs_lb, rhs_ub);
+
+      /*
+         The optimization will continue until
+            max_i || rhs_Gw(i) - eqp_Gw(i) || / || rhs_Gw(i) || < eqp_tol
+      */
+      nnls.solve_parallel_with_scalapack(Gt, rhs_lb, rhs_ub, eqpSol);
+
+      nnz = 0;
+      for (int i = 0; i < eqpSol.dim(); ++i)
+      {
+         if (eqpSol(i) != 0.0)
+            nnz++;
+      }
+
+      // TODO(kevin): parallel case.
+      // std::cout << rank << ": Number of nonzeros in NNLS solution: " << nnz
+      //       << ", out of " << eqpSol.dim() << std::endl;
+
+      // MPI_Allreduce(MPI_IN_PLACE, &nnz, 1, MPI_INT, MPI_SUM, MPI_COMM_WORLD);
+
+      // if (rank == 0)
+      std::cout << "Global number of nonzeros in NNLS solution: " << nnz << std::endl;
+
+      // Check residual of NNLS solution
+      CAROM::Vector res(Gt.numColumns(), false);
+      Gt.transposeMult(eqpSol, res);
+
+      const double normGsol = res.norm();
+      const double normRHS = rhs_Gw.norm();
+
+      res -= rhs_Gw;
+      const double relNorm = res.norm() / std::max(normGsol, normRHS);
+      // cout << rank << ": relative residual norm for NNLS solution of Gs = Gw: " <<
+      //       relNorm << endl;
+      std::cout << "Relative residual norm for NNLS solution of Gs = Gw: " <<
+                  relNorm << std::endl;
+   }
+
+   sample_el.SetSize(0);
+   sample_qp.SetSize(0);
+   sample_qw.SetSize(0);
+   for (int i = 0; i < eqpSol.dim(); ++i)
+   {
+      if (eqpSol(i) > 1.0e-12)
+      {
+         const int e = i / nqe;  // Element index
+         sample_el.Append(i / nqe);
+         sample_qp.Append(i % nqe);
+         sample_qw.Append(eqpSol(i));
+      }
+   }
+   printf("Size of sampled qp: %d\n", sample_el.Size());
+   if (nnz != sample_el.Size())
+      printf("Sample quadrature points with weight < 1.0e-12 are neglected.\n");
+}
+
+void ROMNonlinearForm::SetupEQPSystemForDomainIntegrator(
+   const CAROM::Matrix &snapshots, HyperReductionIntegrator *nlfi, 
+   CAROM::Matrix &Gt, CAROM::Vector &rhs_Gw)
+{
+   assert(basis);
+   assert(snapshots.numRows() >= fes->GetTrueVSize());
+   if (snapshots.numRows() > fes->GetTrueVSize())
+      mfem_warning("ROMNonlinearForm::SetupEQPSystemForDomainIntegrator- snapshot vector has a larger dimension than finite element space vector dimension. Neglecting the rest of snapshot.\n");
+
+   const IntegrationRule *ir = nlfi->GetIntegrationRule();
+
+   // TODO(kevin): extension for mixed mesh elements.
+   const int vdim = fes->GetVDim();
+   const int nqe = ir->GetNPoints();
+   const int NB = basis->NumCols();
+   const int nsnap = snapshots.numColumns();
+   const int ne = fes->GetNE();
+   const int NQ = ne * nqe;
+
+   // Compute G of size (NB * nsnap) x NQ, but only store its transpose Gt.
+   Gt.setSize(NQ, NB * nsnap);
+   assert(Gt.distributed());
+   // For 0 <= j < NB, 0 <= i < nsnap, 0 <= e < ne, 0 <= m < nqe,
+   // G(j + (i*NB), (e*nqe) + m)
+   // is the coefficient of v_j^T M(p_i) V v_i at point m of element e,
+   // with respect to the integration rule weight at that point,
+   // where the "exact" quadrature solution is ir0->GetWeights().
+
+   Vector v_i(fes->GetTrueVSize());
+   Vector r(nqe);
+
+   Array<int> vdofs;
+   Vector el_x, el_tr;
+   DenseMatrix el_quad;
+   const FiniteElement *fe;
+   ElementTransformation *T;
+   DofTransformation *doftrans;
+
+   /* fill out quadrature evaluation of all snapshot-basis weak forms */
+   for (int i = 0; i < nsnap; ++i)
+   {
+      // NOTE(kevin): have to copy the vector since libROM matrix is row-major.
+      for (int k = 0; k < fes->GetTrueVSize(); ++k)
+         v_i[k] = snapshots(k, i);
+
+      for (int e = 0; e < ne; ++e)
+      {
+         fe = fes->GetFE(e);
+         doftrans = fes->GetElementVDofs(e, vdofs);
+         T = fes->GetElementTransformation(e);
+         v_i.GetSubVector(vdofs, el_x);
+
+         if (doftrans) { doftrans->InvTransformPrimal(el_x); }
+
+         const int nd = fe->GetDof();
+         el_quad.SetSize(nd * vdim, nqe);
+         for (int i = 0; i < ir->GetNPoints(); i++)
+         {
+            Vector EQ(el_quad.GetColumn(i), nd * vdim);
+
+            const IntegrationPoint &ip = ir->IntPoint(i);
+            nlfi->AssembleQuadratureVector(*fe, *T, ip, 1.0, el_x, EQ);
+            if (doftrans) { doftrans->TransformDual(EQ); }
+         }
+         // nlfi->AssembleElementQuadrature(*fe, *T, el_x, el_quad);
+
+         for (int j = 0; j < NB; ++j)
+         {
+            Vector v_j(basis->GetColumn(j), fes->GetVSize());
+            v_j.GetSubVector(vdofs, el_tr);
+
+            el_quad.MultTranspose(el_tr, r);
+
+            for (int m = 0; m < nqe; ++m)
+               Gt(m + (e * nqe), j + (i * NB)) = r[m];
+         }  // for (int j = 0; j < NB; ++j)
+      }  // for (int e = 0; e < ne; ++e)
+
+      // if (precondition)
+      // {
+         // // Preconditioning is done by (V^T M(p_i) V)^{-1} (of size NB x NB).
+         // PreconditionNNLS(fespace_R, new VectorFEMassIntegrator(a_coeff), BR, i, Gt);
+      // }
+   }  // for (int i = 0; i < nsnap; ++i)
+
+   /* Fill out FOM quadrature weights */
+   Array<double> const& w_el = ir->GetWeights();
+   CAROM::Vector w(ne * nqe, true);
+   for (int i = 0; i < ne; ++i)
+      for (int j = 0; j < nqe; ++j)
+         w(j + (i * nqe)) = w_el[j];
+
+   rhs_Gw.setSize(Gt.numColumns());
+   assert(!rhs_Gw.distributed());
+   // rhs = Gw. Note that by using Gt and multTranspose, we do parallel communication.
+   Gt.transposeMult(w, rhs_Gw);
+
+   return;
+}
+
+void ROMNonlinearForm::SetupEQPSystemForInteriorFaceIntegrator(
+   const CAROM::Matrix &snapshots, HyperReductionIntegrator *nlfi, 
+   CAROM::Matrix &Gt, CAROM::Vector &rhs_Gw, Array<int> &fidxs)
+{
+   mfem_warning("ROMNonlinearForm::SetupEQPSystemForInteriorFaceIntegrator- this routine is not tested. Set up a test routine in test/test_rom_nonlinearform.cpp.\n");
+
+   assert(basis);
+   assert(snapshots.numRows() >= fes->GetTrueVSize());
+   if (snapshots.numRows() > fes->GetTrueVSize())
+      mfem_warning("ROMNonlinearForm::SetupEQPSystemForDomainIntegrator- snapshot vector has a larger dimension than finite element space vector dimension. Neglecting the rest of snapshot.\n");
+
+   const IntegrationRule *ir = nlfi->GetIntegrationRule();
+   Mesh *mesh = fes->GetMesh();
+
+   // TODO(kevin): extension for mixed mesh elements.
+   const int vdim = fes->GetVDim();
+   const int nqe = ir->GetNPoints();
+   const int NB = basis->NumCols();
+   const int nsnap = snapshots.numColumns();
+
+   /* get faces with non-trivial interfaces. */
+   fidxs.SetSize(0);
+   FaceElementTransformations *tr;
+   for (int f = 0; f < mesh->GetNumFaces(); f++)
+   {
+      tr = mesh->GetInteriorFaceTransformations(f);
+      if (tr != NULL) fidxs.Append(f);
+   }
+   const int ne = fidxs.Size();
+   const int NQ = ne * nqe;
+
+   // Compute G of size (NB * nsnap) x NQ, but only store its transpose Gt.
+   Gt.setSize(NQ, NB * nsnap);
+   assert(Gt.distributed());
+   // For 0 <= j < NB, 0 <= i < nsnap, 0 <= e < ne, 0 <= m < nqe,
+   // G(j + (i*NB), (e*nqe) + m)
+   // is the coefficient of v_j^T M(p_i) V v_i at point m of element e,
+   // with respect to the integration rule weight at that point,
+   // where the "exact" quadrature solution is ir0->GetWeights().
+
+   Vector v_i(fes->GetTrueVSize());
+   Vector r(nqe);
+
+   Array<int> vdofs, vdofs2;
+   Vector el_x, el_tr;
+   DenseMatrix el_quad;
+   
+   const FiniteElement *fe1, *fe2;
+
+   /* fill out quadrature evaluation of all snapshot-basis weak forms */
+   for (int i = 0; i < nsnap; ++i)
+   {
+      // NOTE(kevin): have to copy the vector since libROM matrix is row-major.
+      for (int k = 0; k < fes->GetTrueVSize(); ++k)
+         v_i[k] = snapshots(k, i);
+
+      for (int e = 0; e < ne; ++e)
+      {
+         tr = mesh->GetInteriorFaceTransformations(fidxs[e]);
+         assert(tr != NULL);
+
+         fes->GetElementVDofs(tr->Elem1No, vdofs);
+         fes->GetElementVDofs(tr->Elem2No, vdofs2);
+         vdofs.Append (vdofs2);
+
+         v_i.GetSubVector(vdofs, el_x);
+
+         fe1 = fes->GetFE(tr->Elem1No);
+         fe2 = fes->GetFE(tr->Elem2No);
+
+         const int nd = fe1->GetDof() + fe2->GetDof();
+         el_quad.SetSize(nd * vdim, nqe);
+         for (int i = 0; i < ir->GetNPoints(); i++)
+         {
+            Vector EQ(el_quad.GetColumn(i), nd * vdim);
+
+            const IntegrationPoint &ip = ir->IntPoint(i);
+            nlfi->AssembleQuadratureVector(*fe1, *fe2, *tr, ip, 1.0, el_x, EQ);
+         }
+
+         for (int j = 0; j < NB; ++j)
+         {
+            Vector v_j(basis->GetColumn(j), fes->GetVSize());
+            v_j.GetSubVector(vdofs, el_tr);
+
+            el_quad.MultTranspose(el_tr, r);
+
+            for (int m = 0; m < nqe; ++m)
+               Gt(m + (e * nqe), j + (i * NB)) = r[m];
+         }  // for (int j = 0; j < NB; ++j)
+      }  // for (int e = 0; e < ne; ++e)
+
+      // if (precondition)
+      // {
+         // // Preconditioning is done by (V^T M(p_i) V)^{-1} (of size NB x NB).
+         // PreconditionNNLS(fespace_R, new VectorFEMassIntegrator(a_coeff), BR, i, Gt);
+      // }
+   }  // for (int i = 0; i < nsnap; ++i)
+
+   /* Fill out FOM quadrature weights */
+   Array<double> const& w_el = ir->GetWeights();
+   CAROM::Vector w(ne * nqe, true);
+   for (int i = 0; i < ne; ++i)
+      for (int j = 0; j < nqe; ++j)
+         w(j + (i * nqe)) = w_el[j];
+
+   rhs_Gw.setSize(Gt.numColumns());
+   assert(!rhs_Gw.distributed());
+   // rhs = Gw. Note that by using Gt and multTranspose, we do parallel communication.
+   Gt.transposeMult(w, rhs_Gw);
+
+   return;
+}
+
+void ROMNonlinearForm::SetupEQPSystemForBdrFaceIntegrator(
+   const CAROM::Matrix &snapshots, HyperReductionIntegrator *nlfi, const Array<int> &bdr_attr_marker,
+   CAROM::Matrix &Gt, CAROM::Vector &rhs_Gw, Array<int> &bidxs)
+{
+   mfem_warning("ROMNonlinearForm::SetupEQPSystemForBdrFaceIntegrator- this routine is not tested. Set up a test routine in test/test_rom_nonlinearform.cpp.\n");
+
+   assert(basis);
+   assert(snapshots.numRows() >= fes->GetTrueVSize());
+   if (snapshots.numRows() > fes->GetTrueVSize())
+      mfem_warning("ROMNonlinearForm::SetupEQPSystemForDomainIntegrator- snapshot vector has a larger dimension than finite element space vector dimension. Neglecting the rest of snapshot.\n");
+
+   const IntegrationRule *ir = nlfi->GetIntegrationRule();
+   Mesh *mesh = fes->GetMesh();
+
+   // TODO(kevin): extension for mixed mesh elements.
+   const int vdim = fes->GetVDim();
+   const int nqe = ir->GetNPoints();
+   const int NB = basis->NumCols();
+   const int nsnap = snapshots.numColumns();
+
+   /* get BEs with non-trivial boundary face. */
+   bidxs.SetSize(0);
+   FaceElementTransformations *tr;
+   for (int b = 0; b < fes->GetNBE(); b++)
+   {
+      const int bdr_attr = mesh->GetBdrAttribute(b);
+      if (bdr_attr_marker[bdr_attr-1] == 0) { continue; }
+
+      tr = mesh->GetBdrFaceTransformations (b);
+      if (tr != NULL) bidxs.Append(b);
+   }
+   const int ne = bidxs.Size();
+   const int NQ = ne * nqe;
+
+   // Compute G of size (NB * nsnap) x NQ, but only store its transpose Gt.
+   Gt.setSize(NQ, NB * nsnap);
+   assert(Gt.distributed());
+   // For 0 <= j < NB, 0 <= i < nsnap, 0 <= e < ne, 0 <= m < nqe,
+   // G(j + (i*NB), (e*nqe) + m)
+   // is the coefficient of v_j^T M(p_i) V v_i at point m of element e,
+   // with respect to the integration rule weight at that point,
+   // where the "exact" quadrature solution is ir0->GetWeights().
+
+   Vector v_i(fes->GetTrueVSize());
+   Vector r(nqe);
+
+   Array<int> vdofs, vdofs2;
+   Vector el_x, el_tr;
+   DenseMatrix el_quad;
+   
+   const FiniteElement *fe1, *fe2;
+
+   /* fill out quadrature evaluation of all snapshot-basis weak forms */
+   for (int i = 0; i < nsnap; ++i)
+   {
+      // NOTE(kevin): have to copy the vector since libROM matrix is row-major.
+      for (int k = 0; k < fes->GetTrueVSize(); ++k)
+         v_i[k] = snapshots(k, i);
+
+      for (int e = 0; e < ne; ++e)
+      {
+         const int bdr_attr = mesh->GetBdrAttribute(bidxs[e]);
+         tr = mesh->GetBdrFaceTransformations(bidxs[e]);
+         assert(tr != NULL);
+         assert(bdr_attr_marker[bdr_attr-1] != 0);
+
+         fes->GetElementVDofs(tr->Elem1No, vdofs);
+
+         v_i.GetSubVector(vdofs, el_x);
+
+         fe1 = fes->GetFE(tr->Elem1No);
+         // The fe2 object is really a dummy and not used on the boundaries,
+         // but we can't dereference a NULL pointer, and we don't want to
+         // actually make a fake element.
+         fe2 = fe1;
+
+         const int nd = fe1->GetDof();
+         el_quad.SetSize(nd * vdim, nqe);
+         for (int i = 0; i < ir->GetNPoints(); i++)
+         {
+            Vector EQ(el_quad.GetColumn(i), nd * vdim);
+
+            const IntegrationPoint &ip = ir->IntPoint(i);
+            nlfi->AssembleQuadratureVector(*fe1, *fe2, *tr, ip, 1.0, el_x, EQ);
+         }
+
+         for (int j = 0; j < NB; ++j)
+         {
+            Vector v_j(basis->GetColumn(j), fes->GetVSize());
+            v_j.GetSubVector(vdofs, el_tr);
+
+            el_quad.MultTranspose(el_tr, r);
+
+            for (int m = 0; m < nqe; ++m)
+               Gt(m + (e * nqe), j + (i * NB)) = r[m];
+         }  // for (int j = 0; j < NB; ++j)
+      }  // for (int e = 0; e < ne; ++e)
+
+      // if (precondition)
+      // {
+         // // Preconditioning is done by (V^T M(p_i) V)^{-1} (of size NB x NB).
+         // PreconditionNNLS(fespace_R, new VectorFEMassIntegrator(a_coeff), BR, i, Gt);
+      // }
+   }  // for (int i = 0; i < nsnap; ++i)
+
+   /* Fill out FOM quadrature weights */
+   Array<double> const& w_el = ir->GetWeights();
+   CAROM::Vector w(ne * nqe, true);
+   for (int i = 0; i < ne; ++i)
+      for (int j = 0; j < nqe; ++j)
+         w(j + (i * nqe)) = w_el[j];
+
+   rhs_Gw.setSize(Gt.numColumns());
+   assert(!rhs_Gw.distributed());
+   // rhs = Gw. Note that by using Gt and multTranspose, we do parallel communication.
+   Gt.transposeMult(w, rhs_Gw);
+
+   return;
+}
+
+void ROMNonlinearForm::GetEQPForIntegrator(
+   const IntegratorType type, const int k, Array<int> &el, Array<int> &qp, Array<double> &qw)
+{
+   Array<SampleInfo> *sample = NULL;
+   switch (type)
+   {
+      case IntegratorType::DOMAIN:
+      {
+         assert((k >= 0) && (k < dnfi.Size()));
+         assert(dnfi.Size() == dnfi_sample.Size());
+         sample = dnfi_sample[k];
+      }
+      break;
+      case IntegratorType::INTERIORFACE:
+      {
+         assert((k >= 0) && (k < fnfi.Size()));
+         assert(fnfi.Size() == fnfi_sample.Size());
+         sample = fnfi_sample[k];
+      }
+      break;
+      case IntegratorType::BDRFACE:
+      {
+         assert((k >= 0) && (k < bfnfi.Size()));
+         assert(bfnfi.Size() == bfnfi_sample.Size());
+         sample = bfnfi_sample[k];
+      }
+      break;
+      default:
+         mfem_error("Unknown Integrator type!\n");
+   }
+
+   el.SetSize(0);
+   qp.SetSize(0);
+   qw.SetSize(0);
+
+   for (int s = 0; s < sample->Size(); s++)
+   {
+      switch (type)
+      {
+         case IntegratorType::DOMAIN:        el.Append((*sample)[s].el); break;
+         case IntegratorType::INTERIORFACE:  el.Append((*sample)[s].face); break;
+         case IntegratorType::BDRFACE:       el.Append((*sample)[s].be); break;
+      }
+      qp.Append((*sample)[s].qp);
+      qw.Append((*sample)[s].qw);
+   }
+}
+
+void ROMNonlinearForm::SaveEQPForIntegrator(
+   const IntegratorType type, const int k, hid_t file_id, const std::string &dsetname)
+{
+   std::string eldset;
+   switch (type)
+   {
+      case IntegratorType::DOMAIN:        eldset = "elem"; break;
+      case IntegratorType::INTERIORFACE:  eldset = "face"; break;
+      case IntegratorType::BDRFACE:       eldset = "be"; break;
+      default:
+         mfem_error("ROMNonlinearForm::SaveEQPForIntegrator- Unknown IntegratorType!\n");
+   }
+
+   Array<int> el, qp;
+   Array<double> qw;
+   GetEQPForIntegrator(type, k, el, qp, qw);
+
+   assert(file_id >= 0);
+   hid_t grp_id;
+   herr_t errf;
+
+   grp_id = H5Gcreate(file_id, dsetname.c_str(), H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
+   assert(grp_id >= 0);
+
+   hdf5_utils::WriteDataset(grp_id, eldset, el);
+   hdf5_utils::WriteDataset(grp_id, "quad-pt", qp);
+   hdf5_utils::WriteDataset(grp_id, "quad-wt", qw);
+
+   errf = H5Gclose(grp_id);
+   assert(errf >= 0);
+   return;
+}
+
+void ROMNonlinearForm::LoadEQPForIntegrator(
+   const IntegratorType type, const int k, hid_t file_id, const std::string &dsetname)
+{
+   std::string eldset;
+   switch (type)
+   {
+      case IntegratorType::DOMAIN:        eldset = "elem"; break;
+      case IntegratorType::INTERIORFACE:  eldset = "face"; break;
+      case IntegratorType::BDRFACE:       eldset = "be"; break;
+      default:
+         mfem_error("ROMNonlinearForm::LoadEQPForIntegrator- Unknown IntegratorType!\n");
+   }
+
+   Array<int> el, qp;
+   Array<double> qw;
+
+   assert(file_id >= 0);
+   hid_t grp_id;
+   herr_t errf;
+
+   grp_id = H5Gopen2(file_id, dsetname.c_str(), H5P_DEFAULT);
+   assert(grp_id >= 0);
+
+   hdf5_utils::ReadDataset(grp_id, eldset, el);
+   hdf5_utils::ReadDataset(grp_id, "quad-pt", qp);
+   hdf5_utils::ReadDataset(grp_id, "quad-wt", qw);
+
+   errf = H5Gclose(grp_id);
+   assert(errf >= 0);
+
+   switch (type)
+   {
+      case IntegratorType::DOMAIN:        UpdateDomainIntegratorSampling(k, el, qp, qw); break;
+      case IntegratorType::INTERIORFACE:  UpdateInteriorFaceIntegratorSampling(k, el, qp, qw); break;
+      case IntegratorType::BDRFACE:       UpdateBdrFaceIntegratorSampling(k, el, qp, qw); break;
+      default:
+         mfem_error("ROMNonlinearForm::LoadEQPForIntegrator- Unknown IntegratorType!\n");
+   }
+   return;
 }
 
 }

--- a/src/stokes_solver.cpp
+++ b/src/stokes_solver.cpp
@@ -483,7 +483,7 @@ void StokesSolver::SetupMUMPSSolver()
    sys_glob_size = systemOp_mono->NumRows();
    sys_row_starts[0] = 0;
    sys_row_starts[1] = systemOp_mono->NumRows();
-   systemOp_hypre = new HypreParMatrix(MPI_COMM_WORLD, sys_glob_size, sys_row_starts, systemOp_mono);
+   systemOp_hypre = new HypreParMatrix(MPI_COMM_SELF, sys_glob_size, sys_row_starts, systemOp_mono);
 
    mumps = new MUMPSSolver();
    mumps->SetMatrixSymType(MUMPSSolver::MatType::SYMMETRIC_POSITIVE_DEFINITE);
@@ -751,7 +751,7 @@ bool StokesSolver::Solve()
       if (use_amg)
       {
          // velocity amg preconditioner
-         Mop = new HypreParMatrix(MPI_COMM_WORLD, glob_size, row_starts, M);
+         Mop = new HypreParMatrix(MPI_COMM_SELF, glob_size, row_starts, M);
          amg_prec = new HypreBoomerAMG(*Mop);
          amg_prec->SetPrintLevel(0);
          amg_prec->SetSystemsOptions(vdim[0], true);
@@ -844,7 +844,7 @@ void StokesSolver::Solve_obsolete()
    HYPRE_BigInt row_starts[2] = {0, M->NumRows()};
    if (use_amg)
    {
-      Mop = new HypreParMatrix(MPI_COMM_WORLD, glob_size, row_starts, M);
+      Mop = new HypreParMatrix(MPI_COMM_SELF, glob_size, row_starts, M);
       amg_prec = new HypreBoomerAMG(*Mop);
       amg_prec->SetPrintLevel(print_level);
    }

--- a/test/gmsh/stokes.component.yml
+++ b/test/gmsh/stokes.component.yml
@@ -94,6 +94,7 @@ model_reduction:
   rom_handler_type: mfem
   # individual/universal
   subdomain_training: universal
+  nonlinear_handling: tensor
   save_operator:
     level: component
     prefix: "test.rom_elem"

--- a/test/inputs/steady_ns.base.yml
+++ b/test/inputs/steady_ns.base.yml
@@ -63,6 +63,7 @@ model_reduction:
   rom_handler_type: mfem
   # individual/universal
   subdomain_training: individual
+  nonlinear_handling: tensor
   save_operator:
     level: global
     prefix: "proj_inv"

--- a/test/inputs/steady_ns.component.yml
+++ b/test/inputs/steady_ns.component.yml
@@ -87,6 +87,7 @@ model_reduction:
   rom_handler_type: mfem
   # individual/universal
   subdomain_training: universal
+  nonlinear_handling: tensor
   save_operator:
     level: component
     prefix: "test.rom_elem"

--- a/test/test_rom_nonlinearform.cpp
+++ b/test/test_rom_nonlinearform.cpp
@@ -274,6 +274,109 @@ TEST(ROMNonlinearForm_fast, VectorConvectionTrilinearFormIntegrator)
    return;
 }
 
+TEST(ROMNonlinearForm, SetupEQPSystemForDomainIntegrator)
+{
+   Mesh *mesh = new Mesh("meshes/test.4x4.mesh");
+   const int dim = mesh->Dimension();
+   const int order = UniformRandom(1, 3);
+
+   FiniteElementCollection *h1_coll(new H1_FECollection(order, dim));
+   FiniteElementSpace *fes(new FiniteElementSpace(mesh, h1_coll, dim));
+   const int ndofs = fes->GetTrueVSize();
+   const int num_snap = UniformRandom(3, 5);
+   const int num_basis = num_snap;
+
+   // a fictitious snapshots.
+   DenseMatrix snapshots(ndofs, num_snap);
+   for (int i = 0; i < ndofs; i++)
+      for (int j = 0; j < num_snap; j++)
+         snapshots(i, j) = 2.0 * UniformRandom() - 1.0;
+
+   CAROM::Options options(ndofs, num_snap, 1, true);
+   options.static_svd_preserve_snapshot = true;
+   CAROM::BasisGenerator basis_generator(options, false, "test_basis");
+   Vector snapshot(ndofs);
+   for (int s = 0; s < num_snap; s++)
+   {
+      snapshots.GetColumnReference(s, snapshot);
+      basis_generator.takeSample(snapshot.GetData());
+   }
+   basis_generator.endSamples();
+   const CAROM::Matrix *carom_snapshots = basis_generator.getSnapshotMatrix();
+   const CAROM::Matrix *carom_basis = basis_generator.getSpatialBasis();
+   DenseMatrix basis(ndofs, num_basis);
+   CAROM::CopyMatrix(*carom_basis, basis);
+
+   IntegrationRule ir = IntRules.Get(fes->GetFE(0)->GetGeomType(),
+                                    (int)(ceil(1.5 * (2 * fes->GetMaxElementOrder() - 1))));
+   ConstantCoefficient pi(3.141592);
+   auto *integ1 = new VectorConvectionTrilinearFormIntegrator(pi);
+   integ1->SetIntRule(&ir);
+   auto *integ2 = new VectorConvectionTrilinearFormIntegrator(pi);
+   integ2->SetIntRule(&ir);
+
+   NonlinearForm *nform(new NonlinearForm(fes));
+   nform->AddDomainIntegrator(integ1);
+
+   ROMNonlinearForm *rform(new ROMNonlinearForm(num_basis, fes));
+   rform->AddDomainIntegrator(integ2);
+   rform->SetBasis(basis);
+   rform->SetPrecomputeMode(true);
+
+   CAROM::Vector rhs1(num_snap * num_basis, false);
+   CAROM::Vector rhs2(num_snap * num_basis, false);
+   CAROM::Matrix Gt(1, 1, true);
+
+   /* exact right-hand side by inner product of basis and fom vectors */
+   Vector rhs_vec(ndofs), basis_col(ndofs);
+   for (int s = 0; s < num_snap; s++)
+   {
+      snapshots.GetColumnReference(s, snapshot);
+
+      nform->Mult(snapshot, rhs_vec);
+      for (int b = 0; b < num_basis; b++)
+      {
+         basis.GetColumnReference(b, basis_col);
+         rhs1(b + s * num_basis) = basis_col * rhs_vec;
+      }
+   }
+
+   /* equivalent operation must happen within this routine */
+   rform->SetupEQPSystemForDomainIntegrator(*carom_snapshots, integ2, Gt, rhs2);
+
+   for (int k = 0; k < rhs1.dim(); k++)
+      EXPECT_NEAR(rhs1(k), rhs2(k), 1.0e-14);
+
+   double eqp_tol = 1.0e-10;
+   rform->TrainEQP(*carom_snapshots, eqp_tol);
+   if (rform->PrecomputeMode()) rform->PrecomputeCoefficients();
+
+   DenseMatrix rom_rhs1(num_basis, num_snap), rom_rhs2(num_basis, num_snap);
+   Vector rom_sol(num_basis), rom_rhs1_vec, rom_rhs2_vec;
+   for (int s = 0; s < num_snap; s++)
+   {
+      snapshots.GetColumnReference(s, snapshot);
+
+      nform->Mult(snapshot, rhs_vec);
+      rom_rhs1.GetColumnReference(s, rom_rhs1_vec);
+      basis.MultTranspose(rhs_vec, rom_rhs1_vec);
+
+      basis.MultTranspose(snapshot, rom_sol);
+      rom_rhs2.GetColumnReference(s, rom_rhs2_vec);
+      rform->Mult(rom_sol, rom_rhs2_vec);
+   }
+
+   for (int i = 0; i < num_basis; i++)
+      for (int j = 0; j < num_snap; j++)
+         EXPECT_NEAR(rom_rhs1(i, j), rom_rhs2(i, j), 1.0e-14);
+
+   delete mesh;
+   delete h1_coll;
+   delete fes;
+   delete nform;
+   delete rform;
+}
+
 int main(int argc, char* argv[])
 {
    MPI_Init(&argc, &argv);

--- a/test/test_workflow.cpp
+++ b/test/test_workflow.cpp
@@ -498,7 +498,7 @@ TEST(SteadyNS_Workflow, ComponentWiseTest)
 
 TEST(SteadyNS_Workflow, ComponentWiseWithDirectSolve)
 {
-   config = InputParser("inputs/stokes.component.yml");
+   config = InputParser("inputs/steady_ns.component.yml");
    config.dict_["model_reduction"]["linear_solver_type"] = "direct";
    config.dict_["model_reduction"]["linear_system_type"] = "us";
 
@@ -527,7 +527,7 @@ TEST(SteadyNS_Workflow, ComponentWiseWithDirectSolve)
 
 TEST(SteadyNS_Workflow, ComponentSeparateVariable)
 {
-   config = InputParser("inputs/stokes.component.yml");
+   config = InputParser("inputs/steady_ns.component.yml");
    config.dict_["model_reduction"]["separate_variable_basis"] = true;
    config.dict_["model_reduction"]["linear_solver_type"] = "direct";
    config.dict_["model_reduction"]["linear_system_type"] = "us";
@@ -648,7 +648,40 @@ TEST(LinElast_Workflow, ComponentWiseWithDirectSolve)
    return;
 }
 
-int main(int argc, char *argv[])
+TEST(SteadyNS_Workflow, ComponentSeparateVariable_EQP)
+{
+   config = InputParser("inputs/steady_ns.component.yml");
+   config.dict_["model_reduction"]["separate_variable_basis"] = true;
+   config.dict_["model_reduction"]["linear_solver_type"] = "direct";
+   config.dict_["model_reduction"]["linear_system_type"] = "us";
+   config.dict_["model_reduction"]["nonlinear_handling"] = "eqp";
+   config.dict_["model_reduction"]["eqp"]["relative_tolerance"] = 1.0e-11;
+   config.dict_["model_reduction"]["eqp"]["precompute"] = true;
+
+   printf("\nSample Generation \n\n");
+   
+   config.dict_["main"]["mode"] = "sample_generation";
+   GenerateSamples(MPI_COMM_WORLD);
+
+   config.dict_["main"]["mode"] = "train_rom";
+   TrainROM(MPI_COMM_WORLD);
+
+   printf("\nBuild ROM \n\n");
+
+   config.dict_["main"]["mode"] = "build_rom";
+   BuildROM(MPI_COMM_WORLD);
+
+   config.dict_["main"]["mode"] = "single_run";
+   double error = SingleRun(MPI_COMM_WORLD, "test_output.h5");
+
+   // This reproductive case must have a very small error at the level of finite-precision.
+   printf("Error: %.15E\n", error);
+   EXPECT_TRUE(error < stokes_threshold);
+
+   return;
+}
+
+int main(int argc, char* argv[])
 {
    ::testing::InitGoogleTest(&argc, argv);
    MPI_Init(&argc, &argv);


### PR DESCRIPTION
…teadyNSSolver` (#14)

* base class for steady ns rom operator.

* SteadyNSEQPROM operator.

* ROMNonlinearForm::TrainEQP translated from sketches/ns_rom.

* ROMNonlinearForm::TrainEQPForIntegrator- adjusted bounds to properly reflect relative tolerance.

* FindSnapshotFilesForBasis routine for parsing snapshot file names.

* ROMHandler stores its reference basis tags.

* librom need the recent PR for basisWriter.

* SampleGenerator::LookUpSnapshot

* ROMHandler- removed GetBasisOnSubdomain. SeparateVariable and GetRefBasisTag added.

* ROMNonlinearForm - basis is now owned by the class. SetBasis copies the part of the input basis matrix.

* SteadyNSSolver::TrainEQP

* AuxiliaryTrainROM now has TrainEQP procedure.

* minor change in ROMNonlinearForm::TrainEQP.

* ROMNonlinearForm::SaveEQPForDomainIntegrator

* MultiBlockSolver::SaveEQP

* BuildROM does not need a particular procedure for EQP.

* add nonlinear handling option in input file.

* ROMNonlinearForm::LoadEQPForDomainIntegrator

* SingleRun with EQP needs debugging.

* test for ROMNonlinearFORM::TrainEQP. fix for libROM::StaticSVD::computeSVD is included.

* workflow of steady-ns solver with eqp verified.

* ROMNonlinearForm::TrainEQPForIntegrator - removed a redundant argument.

* docker fix the root to linux.

* minor test setup change.

* minor fix for ROMNonlinearFORM::TrainEQP.

* ROMNonlinearFORM::SetupEQPSystemForInterior/BdrFace. These are not yet tested.

* ROMNonlinearForm::Get/Save/LoadEQPForIntegrator with general integrator type.

* updates on README.

* bug fix on SteadyNSSolver::SetupEQPOperators.

* MultiBlockSolver communicators are set to MPI_COMM_SELF for now.

* patch for librom interface update.