### PR TITLE
Enable various boundary conditions for the same global configuration.

### DIFF
--- a/include/component_topology_handler.hpp
+++ b/include/component_topology_handler.hpp
@@ -167,7 +167,7 @@ protected:
    void ReadPortsFromFile(const std::string filename);
    YAML::Node* ReadPortDict(hid_t grp_id, const std::string& port_name);
    // Read boundary attribute map between components and global.
-   void ReadBoundariesFromFile(const std::string filename);
+   bool ReadBoundariesFromFile(const std::string filename);
 
    // Reference port data
    void ReadPortDatasFromFile(const std::string filename);


### PR DESCRIPTION
`ComponentTopologyHandler` used to read boundary configuration only from the global configuration file. Now it supports reading the boundary configuration from a separate hdf5 file. This enables using various boundary conditions for the same global configuration.

- By default, `ComponentTopologyHandler` attempts to read the boundary from the global config file in the input `mesh/component-wise/global_config`
- If the global config file does not specify the boundary, then it attempts to read a separate boundary config file in the input `mesh/component-wise/bdr_config`
- If the step above fails, then an error will be returned.