### PR TITLE
Sorting out boundary conditions

### DIFF
--- a/include/linelast_solver.hpp
+++ b/include/linelast_solver.hpp
@@ -52,9 +52,6 @@ protected:
    // Initial positions
    VectorFunctionCoefficient *init_x = NULL;
 
-   // Boundary condition types
-   Array<ParameterizedProblem::BoundaryType> type_idx;
-
 public:
    LinElastSolver();
 

--- a/include/linelast_solver.hpp
+++ b/include/linelast_solver.hpp
@@ -53,7 +53,7 @@ protected:
    VectorFunctionCoefficient *init_x = NULL;
 
    // Boundary condition types
-   Array<LinElastProblem::BoundaryType> type_idx;
+   Array<ParameterizedProblem::BoundaryType> type_idx;
 
 public:
    LinElastSolver();

--- a/include/multiblock_solver.hpp
+++ b/include/multiblock_solver.hpp
@@ -68,6 +68,7 @@ protected:
    int max_bdr_attr;
    int numBdr;
    Array<Array<int> *> bdr_markers;
+   Array<ParameterizedProblem::BoundaryType> bdr_type; // Boundary condition types of (numBdr) array
 
    // MFEM solver options
    bool use_amg;
@@ -235,7 +236,7 @@ public:
    virtual void SaveBasisVisualization()
    { rom_handler->SaveBasisVisualization(fes, var_names); }
 
-   virtual void SetParameterizedProblem(ParameterizedProblem *problem) = 0;
+   virtual void SetParameterizedProblem(ParameterizedProblem *problem);
 
    void ComputeSubdomainErrorAndNorm(GridFunction *fom_sol, GridFunction *rom_sol, double &error, double &norm);
    void ComputeRelativeError(Array<GridFunction *> fom_sols, Array<GridFunction *> rom_sols, Vector &error);

--- a/include/multiblock_solver.hpp
+++ b/include/multiblock_solver.hpp
@@ -154,6 +154,7 @@ public:
    virtual void BuildRHSOperators() = 0;
    virtual void BuildDomainOperators() = 0;
    
+   void SetBdrType(const ParameterizedProblem::BoundaryType type, const int &global_battr_idx=-1);
    virtual bool BCExistsOnBdr(const int &global_battr_idx) = 0;
    virtual void SetupBCOperators() = 0;
    virtual void SetupRHSBCOperators() = 0;

--- a/include/multiblock_solver.hpp
+++ b/include/multiblock_solver.hpp
@@ -68,7 +68,7 @@ protected:
    int max_bdr_attr;
    int numBdr;
    Array<Array<int> *> bdr_markers;
-   Array<ParameterizedProblem::BoundaryType> bdr_type; // Boundary condition types of (numBdr) array
+   Array<BoundaryType> bdr_type; // Boundary condition types of (numBdr) array
 
    // MFEM solver options
    bool use_amg;
@@ -154,7 +154,7 @@ public:
    virtual void BuildRHSOperators() = 0;
    virtual void BuildDomainOperators() = 0;
    
-   void SetBdrType(const ParameterizedProblem::BoundaryType type, const int &global_battr_idx=-1);
+   void SetBdrType(const BoundaryType type, const int &global_battr_idx=-1);
    virtual bool BCExistsOnBdr(const int &global_battr_idx) = 0;
    virtual void SetupBCOperators() = 0;
    virtual void SetupRHSBCOperators() = 0;

--- a/include/parameterized_problem.hpp
+++ b/include/parameterized_problem.hpp
@@ -99,6 +99,10 @@ class ParameterizedProblem
 friend class SampleGenerator;
 friend class RandomSampleGenerator;
 
+public:
+   enum BoundaryType
+   { ZERO, DIRICHLET, NEUMANN, NUM_BDR_TYPE };
+
 protected:
    std::string problem_name;
 
@@ -128,7 +132,7 @@ public:
    function_factory::GeneralVectorFunction *vector_rhs_ptr = NULL;
    Array<function_factory::GeneralVectorFunction *> vector_bdr_ptr;
    Array<int> battr;
-   Array<int> bdr_type; // abstract boundary type
+   Array<BoundaryType> bdr_type; // abstract boundary type
 
    Array<function_factory::GeneralScalarFunction *> general_scalar_ptr;
    Array<function_factory::GeneralVectorFunction *> general_vector_ptr;
@@ -144,10 +148,6 @@ public:
 class PoissonProblem : public ParameterizedProblem
 {
 friend class PoissonSolver;
-
-protected:
-   enum BoundaryType
-   { ZERO, DIRICHLET, NEUMANN, NUM_BDR_TYPE };
 
 public:
    virtual ~PoissonProblem() {};
@@ -182,10 +182,6 @@ public:
 class StokesProblem : public ParameterizedProblem
 {
 friend class StokesSolver;
-
-protected:
-   enum BoundaryType
-   { ZERO, DIRICHLET, NEUMANN, NUM_BDR_TYPE };
 
 public:
    virtual ~StokesProblem() {};
@@ -222,8 +218,6 @@ class LinElastProblem : public ParameterizedProblem
 friend class LinElastSolver;
 
 protected:
-   enum BoundaryType
-   { ZERO, DIRICHLET, NEUMANN, NUM_BDR_TYPE };
    Vector lambda, mu;
 
 public:

--- a/include/parameterized_problem.hpp
+++ b/include/parameterized_problem.hpp
@@ -94,14 +94,18 @@ void tip_force(const Vector &x, Vector &u);
 
 }
 
+enum BoundaryType
+{ 
+   ZERO,
+   DIRICHLET,
+   NEUMANN,
+   NUM_BDR_TYPE
+};
+
 class ParameterizedProblem
 {
 friend class SampleGenerator;
 friend class RandomSampleGenerator;
-
-public:
-   enum BoundaryType
-   { ZERO, DIRICHLET, NEUMANN, NUM_BDR_TYPE };
 
 protected:
    std::string problem_name;

--- a/src/linelast_solver.cpp
+++ b/src/linelast_solver.cpp
@@ -463,16 +463,13 @@ void LinElastSolver::SetParameterizedProblem(ParameterizedProblem *problem)
    // Set BCs, the switch on BC type is done inside SetupRHSBCOperators
    for (int b = 0; b < problem->battr.Size(); b++)
    {
-      switch (problem->bdr_type[b])
-      {
-         case BoundaryType::DIRICHLET:
-         case BoundaryType::NEUMANN:
-            assert(problem->vector_bdr_ptr[b]);
-            AddBCFunction(*(problem->vector_bdr_ptr[b]), problem->battr[b]);
-            break;
-         default:
-            break;
-      }
+      /* Dirichlet bc requires a function specified, even for zero. */
+      if (problem->bdr_type[b] == BoundaryType::DIRICHLET)
+         assert(problem->vector_bdr_ptr[b]);
+      
+      /* Neumann bc does not require a function specified for zero */
+      if (problem->vector_bdr_ptr[b])
+         AddBCFunction(*(problem->vector_bdr_ptr[b]), problem->battr[b]);
    }
 
    // Set RHS

--- a/src/linelast_solver.cpp
+++ b/src/linelast_solver.cpp
@@ -179,11 +179,11 @@ void LinElastSolver::SetupRHSBCOperators()
 
          switch (bdr_type[b])
          {
-            case ParameterizedProblem::BoundaryType::DIRICHLET:
+            case BoundaryType::DIRICHLET:
                bs[m]->AddBdrFaceIntegrator(new DGElasticityDirichletLFIntegrator(
                   *bdr_coeffs[b], *lambda_c[m], *mu_c[m], alpha, kappa), *bdr_markers[b]);
                break;
-            case ParameterizedProblem::BoundaryType::NEUMANN:
+            case BoundaryType::NEUMANN:
                bs[m]->AddBdrFaceIntegrator(new VectorBoundaryLFIntegrator(*bdr_coeffs[b]), *bdr_markers[b]);
                break;
             default:
@@ -429,7 +429,7 @@ void LinElastSolver::SetupDomainBCOperators()
             if (!BCExistsOnBdr(b))
                continue;
 
-            if (bdr_type[b] == ParameterizedProblem::BoundaryType::DIRICHLET)
+            if (bdr_type[b] == BoundaryType::DIRICHLET)
                as[m]->AddBdrFaceIntegrator(new DGElasticityIntegrator(
                   *(lambda_c[m]), *(mu_c[m]), alpha, kappa), *(bdr_markers[b]));
          }
@@ -465,8 +465,8 @@ void LinElastSolver::SetParameterizedProblem(ParameterizedProblem *problem)
    {
       switch (problem->bdr_type[b])
       {
-         case ParameterizedProblem::BoundaryType::DIRICHLET:
-         case ParameterizedProblem::BoundaryType::NEUMANN:
+         case BoundaryType::DIRICHLET:
+         case BoundaryType::NEUMANN:
             assert(problem->vector_bdr_ptr[b]);
             AddBCFunction(*(problem->vector_bdr_ptr[b]), problem->battr[b]);
             break;

--- a/src/linelast_solver.cpp
+++ b/src/linelast_solver.cpp
@@ -460,8 +460,8 @@ void LinElastSolver::SetParameterizedProblem(ParameterizedProblem *problem)
 
       if (ti >=0)
       {
-         type_idx[b] = (LinElastProblem::BoundaryType)problem->bdr_type[ti];
-         if (problem->bdr_type[ti] == LinElastProblem::BoundaryType::DIRICHLET || problem->bdr_type[ti] == LinElastProblem::BoundaryType::NEUMANN)
+         type_idx[b] = problem->bdr_type[ti];
+         if (problem->bdr_type[ti] == ParameterizedProblem::BoundaryType::DIRICHLET || problem->bdr_type[ti] == ParameterizedProblem::BoundaryType::NEUMANN)
          {
             assert(problem->vector_bdr_ptr[ti]);
             AddBCFunction(*(problem->vector_bdr_ptr[ti]), problem->battr[ti]);

--- a/src/multiblock_solver.cpp
+++ b/src/multiblock_solver.cpp
@@ -218,6 +218,9 @@ void MultiBlockSolver::SetupBCVariables()
       (*bdr_markers[k]) = 0;
       (*bdr_markers[k])[bdr_attr-1] = 1;
    }
+
+   bdr_type.SetSize(global_bdr_attributes.Size());
+   bdr_type = ParameterizedProblem::BoundaryType::NUM_BDR_TYPE;
 }
 
 void MultiBlockSolver::GetComponentFESpaces(Array<FiniteElementSpace *> &comp_fes)
@@ -684,6 +687,18 @@ void MultiBlockSolver::SaveVisualization()
       paraviewColls[m]->Save();
    }
 };
+
+void MultiBlockSolver::SetParameterizedProblem(ParameterizedProblem *problem)
+{
+   assert(bdr_type.Size() == global_bdr_attributes.Size());
+   for (int b = 0; b < global_bdr_attributes.Size(); b++)
+   {
+      int idx = problem->battr.Find(global_bdr_attributes[b]);
+      if (idx < 0) continue;
+
+      bdr_type[b] = problem->bdr_type[idx];
+   }
+}
 
 void MultiBlockSolver::SaveSolution(std::string filename)
 {

--- a/src/multiblock_solver.cpp
+++ b/src/multiblock_solver.cpp
@@ -220,10 +220,10 @@ void MultiBlockSolver::SetupBCVariables()
    }
 
    bdr_type.SetSize(global_bdr_attributes.Size());
-   bdr_type = ParameterizedProblem::BoundaryType::NUM_BDR_TYPE;
+   bdr_type = BoundaryType::NUM_BDR_TYPE;
 }
 
-void MultiBlockSolver::SetBdrType(const ParameterizedProblem::BoundaryType type, const int &global_battr_idx)
+void MultiBlockSolver::SetBdrType(const BoundaryType type, const int &global_battr_idx)
 {
    assert(bdr_type.Size() == global_bdr_attributes.Size());
    if (global_battr_idx < 0)
@@ -558,7 +558,7 @@ void MultiBlockSolver::AssembleROM()
          if (!BCExistsOnBdr(global_idx)) continue;
 
          /* we assume only Neumann condition would not add an operator. */
-         if (bdr_type[global_idx] == ParameterizedProblem::BoundaryType::NEUMANN)
+         if (bdr_type[global_idx] == BoundaryType::NEUMANN)
             continue;
 
          MatrixBlocks *bdr_mat = (*bdr_mats[c_type])[b];

--- a/src/multiblock_solver.cpp
+++ b/src/multiblock_solver.cpp
@@ -223,6 +223,18 @@ void MultiBlockSolver::SetupBCVariables()
    bdr_type = ParameterizedProblem::BoundaryType::NUM_BDR_TYPE;
 }
 
+void MultiBlockSolver::SetBdrType(const ParameterizedProblem::BoundaryType type, const int &global_battr_idx)
+{
+   assert(bdr_type.Size() == global_bdr_attributes.Size());
+   if (global_battr_idx < 0)
+      bdr_type = type;
+   else
+   {
+      assert(global_battr_idx < global_bdr_attributes.Size());
+      bdr_type[global_battr_idx] = type;
+   }
+}
+
 void MultiBlockSolver::GetComponentFESpaces(Array<FiniteElementSpace *> &comp_fes)
 {
    assert(fec.Size() == num_var);
@@ -544,6 +556,10 @@ void MultiBlockSolver::AssembleROM()
          int global_idx = global_bdr_attributes.Find((*bdr_c2g)[b]);
          if (global_idx < 0) continue;
          if (!BCExistsOnBdr(global_idx)) continue;
+
+         /* we assume only Neumann condition would not add an operator. */
+         if (bdr_type[global_idx] == ParameterizedProblem::BoundaryType::NEUMANN)
+            continue;
 
          MatrixBlocks *bdr_mat = (*bdr_mats[c_type])[b];
          AddToBlockMatrix(midx, midx, *bdr_mat, *romMat);

--- a/src/parameterized_problem.cpp
+++ b/src/parameterized_problem.cpp
@@ -645,8 +645,9 @@ LinElastDispLCantilever::LinElastDispLCantilever()
       vector_bdr_ptr[i] = &(function_factory::linelast_disp::init_disp_lcantilever);
    }
 
+   /* homogeneous Neumann bc */
    battr[2] = 3;
-   bdr_type[2] = BoundaryType::ZERO;
+   bdr_type[2] = BoundaryType::NEUMANN;
    vector_bdr_ptr[2] = NULL;
    
    // Set materials
@@ -686,8 +687,9 @@ LinElastDispLattice::LinElastDispLattice()
       vector_bdr_ptr[i] = &(function_factory::linelast_disp::init_disp);
    }
 
+   /* homogeneous Neumann bc */
    battr[2] = 3;
-   bdr_type[2] = BoundaryType::ZERO;
+   bdr_type[2] = BoundaryType::NEUMANN;
    vector_bdr_ptr[2] = NULL;
 
    // Set materials
@@ -733,8 +735,9 @@ LinElastForceCantilever::LinElastForceCantilever()
    bdr_type[1] = BoundaryType::NEUMANN;
    vector_bdr_ptr[1] = &(function_factory::linelast_force::tip_force);
 
+   /* homogeneous Neumann bc */
    battr[2] = 3;
-   bdr_type[2] = BoundaryType::ZERO;
+   bdr_type[2] = BoundaryType::NEUMANN;
    vector_bdr_ptr[2] = NULL;
    
    // Set materials

--- a/src/parameterized_problem.cpp
+++ b/src/parameterized_problem.cpp
@@ -598,9 +598,9 @@ LinElastDisp::LinElastDisp()
    vector_bdr_ptr.SetSize(3);
    for (size_t i = 0; i < vector_bdr_ptr.Size(); i++)
    {
-   bdr_type[i] = BoundaryType::DIRICHLET;
-   battr[i] = i+1;
-   vector_bdr_ptr[i] = &(function_factory::linelast_disp::init_disp);
+      bdr_type[i] = BoundaryType::DIRICHLET;
+      battr[i] = i+1;
+      vector_bdr_ptr[i] = &(function_factory::linelast_disp::init_disp);
    }
 
    battr[2] = 3;

--- a/src/parameterized_problem.cpp
+++ b/src/parameterized_problem.cpp
@@ -206,7 +206,7 @@ ParameterizedProblem::ParameterizedProblem()
    : problem_name(config.GetRequiredOption<std::string>("parameterized_problem/name"))
 { 
    battr.SetSize(1); battr = -1;
-   bdr_type.SetSize(1); bdr_type = -1;
+   bdr_type.SetSize(1); bdr_type = BoundaryType::NUM_BDR_TYPE;
 
    scalar_bdr_ptr.SetSize(1);
    vector_bdr_ptr.SetSize(1);
@@ -320,7 +320,7 @@ Poisson0::Poisson0()
 {
    param_num = 2;
    battr = -1;
-   bdr_type = PoissonProblem::ZERO;
+   bdr_type = BoundaryType::ZERO;
 
    scalar_bdr_ptr.SetSize(1);
    vector_bdr_ptr.SetSize(1);
@@ -351,7 +351,7 @@ PoissonComponent::PoissonComponent()
    // k (max 3) + offset (1) + bdr_k (max 3) + bdr_offset(1) + bdr_idx(1)
    param_num = 9;
    battr = -1;
-   bdr_type = PoissonProblem::DIRICHLET;
+   bdr_type = BoundaryType::DIRICHLET;
 
    // pointer to static function.
    scalar_rhs_ptr = &(function_factory::poisson_component::rhs);
@@ -417,7 +417,7 @@ PoissonSpiral::PoissonSpiral()
 {
    param_num = 4;
    battr = -1;
-   bdr_type = PoissonProblem::ZERO;
+   bdr_type = BoundaryType::ZERO;
 
    // pointer to static function.
    scalar_bdr_ptr = NULL;
@@ -454,8 +454,8 @@ StokesChannel::StokesChannel()
    battr[2] = 4;
    battr[3] = 5;
    bdr_type.SetSize(4);
-   bdr_type = StokesProblem::ZERO;
-   bdr_type[2] = StokesProblem::DIRICHLET;
+   bdr_type = BoundaryType::ZERO;
+   bdr_type[2] = BoundaryType::DIRICHLET;
 
    // pointer to static function.
    vector_bdr_ptr.SetSize(4);
@@ -489,8 +489,8 @@ StokesComponent::StokesComponent()
    for (int b = 0; b < 5; b++)
       battr[b] = b+1;
    bdr_type.SetSize(5);
-   bdr_type = StokesProblem::DIRICHLET;
-   bdr_type[4] = StokesProblem::ZERO;
+   bdr_type = BoundaryType::DIRICHLET;
+   bdr_type[4] = BoundaryType::ZERO;
 
    // pointer to static function.
    vector_bdr_ptr.SetSize(5);
@@ -564,24 +564,24 @@ void StokesFlowPastArray::SetBattr()
 {
    if ((*u0)[0] > 0.0)
    {
-      bdr_type[3] = StokesProblem::DIRICHLET;
-      bdr_type[1] = StokesProblem::NEUMANN;
+      bdr_type[3] = BoundaryType::DIRICHLET;
+      bdr_type[1] = BoundaryType::NEUMANN;
    }
    else
    {
-      bdr_type[1] = StokesProblem::DIRICHLET;
-      bdr_type[3] = StokesProblem::NEUMANN;
+      bdr_type[1] = BoundaryType::DIRICHLET;
+      bdr_type[3] = BoundaryType::NEUMANN;
    }
 
    if ((*u0)[1] > 0.0)
    {
-      bdr_type[0] = StokesProblem::DIRICHLET;
-      bdr_type[2] = StokesProblem::NEUMANN;
+      bdr_type[0] = BoundaryType::DIRICHLET;
+      bdr_type[2] = BoundaryType::NEUMANN;
    }
    else
    {
-      bdr_type[2] = StokesProblem::DIRICHLET;
-      bdr_type[0] = StokesProblem::NEUMANN;
+      bdr_type[2] = BoundaryType::DIRICHLET;
+      bdr_type[0] = BoundaryType::NEUMANN;
    }
 }
 
@@ -598,13 +598,13 @@ LinElastDisp::LinElastDisp()
    vector_bdr_ptr.SetSize(3);
    for (size_t i = 0; i < vector_bdr_ptr.Size(); i++)
    {
-   bdr_type[i] = LinElastProblem::DIRICHLET;
+   bdr_type[i] = BoundaryType::DIRICHLET;
    battr[i] = i+1;
    vector_bdr_ptr[i] = &(function_factory::linelast_disp::init_disp);
    }
 
    battr[2] = 3;
-   bdr_type[2] = LinElastProblem::ZERO;
+   bdr_type[2] = BoundaryType::ZERO;
    vector_bdr_ptr[2] = NULL;
    
    // Set materials
@@ -641,12 +641,12 @@ LinElastDispLCantilever::LinElastDispLCantilever()
    for (size_t i = 0; i < 2; i++)
    {
       battr[i] = i+1;
-      bdr_type[i] = LinElastProblem::DIRICHLET;
+      bdr_type[i] = BoundaryType::DIRICHLET;
       vector_bdr_ptr[i] = &(function_factory::linelast_disp::init_disp_lcantilever);
    }
 
    battr[2] = 3;
-   bdr_type[2] = LinElastProblem::ZERO;
+   bdr_type[2] = BoundaryType::ZERO;
    vector_bdr_ptr[2] = NULL;
    
    // Set materials
@@ -682,12 +682,12 @@ LinElastDispLattice::LinElastDispLattice()
   for (size_t i = 0; i < 2; i++)
       {
       battr[i] = i+1;
-      bdr_type[i] = LinElastProblem::DIRICHLET;
+      bdr_type[i] = BoundaryType::DIRICHLET;
       vector_bdr_ptr[i] = &(function_factory::linelast_disp::init_disp);
    }
 
    battr[2] = 3;
-   bdr_type[2] = LinElastProblem::ZERO;
+   bdr_type[2] = BoundaryType::ZERO;
    vector_bdr_ptr[2] = NULL;
 
    // Set materials
@@ -725,16 +725,16 @@ LinElastForceCantilever::LinElastForceCantilever()
 
    // Fixed end of cantilever
    battr[0] = 1;
-   bdr_type[0] = LinElastProblem::DIRICHLET;
+   bdr_type[0] = BoundaryType::DIRICHLET;
    vector_bdr_ptr[0] = &(function_factory::linelast_disp::init_disp);
 
    // Free end of cantilever
    battr[1] = 2;
-   bdr_type[1] = LinElastProblem::NEUMANN;
+   bdr_type[1] = BoundaryType::NEUMANN;
    vector_bdr_ptr[1] = &(function_factory::linelast_force::tip_force);
 
    battr[2] = 3;
-   bdr_type[2] = LinElastProblem::ZERO;
+   bdr_type[2] = BoundaryType::ZERO;
    vector_bdr_ptr[2] = NULL;
    
    // Set materials

--- a/src/poisson_solver.cpp
+++ b/src/poisson_solver.cpp
@@ -225,7 +225,7 @@ void PoissonSolver::SetupRHSBCOperators()
          int idx = meshes[m]->bdr_attributes.Find(global_bdr_attributes[b]);
          if (idx < 0) continue;
          if (!BCExistsOnBdr(b)) continue;
-         if (bdr_type[b] == ParameterizedProblem::BoundaryType::NEUMANN)
+         if (bdr_type[b] == BoundaryType::NEUMANN)
             continue;
 
          bs[m]->AddBdrFaceIntegrator(new DGDirichletLFIntegrator(*bdr_coeffs[b], sigma, kappa), *bdr_markers[b]);
@@ -247,7 +247,7 @@ void PoissonSolver::SetupDomainBCOperators()
          int idx = meshes[m]->bdr_attributes.Find(global_bdr_attributes[b]);
          if (idx < 0) continue;
          if (!BCExistsOnBdr(b)) continue;
-         if (bdr_type[b] == ParameterizedProblem::BoundaryType::NEUMANN)
+         if (bdr_type[b] == BoundaryType::NEUMANN)
             continue;
 
          as[m]->AddBdrFaceIntegrator(new DGDiffusionIntegrator(sigma, kappa), *bdr_markers[b]);
@@ -569,15 +569,15 @@ void PoissonSolver::SetParameterizedProblem(ParameterizedProblem *problem)
    {
       switch (problem->bdr_type[b])
       {
-         case ParameterizedProblem::BoundaryType::DIRICHLET:
+         case BoundaryType::DIRICHLET:
          { 
             assert(problem->scalar_bdr_ptr[b]);
             AddBCFunction(*(problem->scalar_bdr_ptr[b]), problem->battr[b]);
             break;
          }
-         case ParameterizedProblem::BoundaryType::NEUMANN: break;
+         case BoundaryType::NEUMANN: break;
          default:
-         case ParameterizedProblem::BoundaryType::ZERO:
+         case BoundaryType::ZERO:
          { AddBCFunction(0.0, problem->battr[b]); break; }
       }
    }

--- a/src/poisson_solver.cpp
+++ b/src/poisson_solver.cpp
@@ -565,15 +565,15 @@ void PoissonSolver::SetParameterizedProblem(ParameterizedProblem *problem)
    {
       switch (problem->bdr_type[b])
       {
-         case PoissonProblem::BoundaryType::DIRICHLET:
+         case ParameterizedProblem::BoundaryType::DIRICHLET:
          { 
             assert(problem->scalar_bdr_ptr[b]);
             AddBCFunction(*(problem->scalar_bdr_ptr[b]), problem->battr[b]);
             break;
          }
-         case PoissonProblem::BoundaryType::NEUMANN: break;
+         case ParameterizedProblem::BoundaryType::NEUMANN: break;
          default:
-         case PoissonProblem::BoundaryType::ZERO:
+         case ParameterizedProblem::BoundaryType::ZERO:
          { AddBCFunction(0.0, problem->battr[b]); break; }
       }
    }

--- a/src/poisson_solver.cpp
+++ b/src/poisson_solver.cpp
@@ -225,6 +225,8 @@ void PoissonSolver::SetupRHSBCOperators()
          int idx = meshes[m]->bdr_attributes.Find(global_bdr_attributes[b]);
          if (idx < 0) continue;
          if (!BCExistsOnBdr(b)) continue;
+         if (bdr_type[b] == ParameterizedProblem::BoundaryType::NEUMANN)
+            continue;
 
          bs[m]->AddBdrFaceIntegrator(new DGDirichletLFIntegrator(*bdr_coeffs[b], sigma, kappa), *bdr_markers[b]);
       }
@@ -245,6 +247,8 @@ void PoissonSolver::SetupDomainBCOperators()
          int idx = meshes[m]->bdr_attributes.Find(global_bdr_attributes[b]);
          if (idx < 0) continue;
          if (!BCExistsOnBdr(b)) continue;
+         if (bdr_type[b] == ParameterizedProblem::BoundaryType::NEUMANN)
+            continue;
 
          as[m]->AddBdrFaceIntegrator(new DGDiffusionIntegrator(sigma, kappa), *bdr_markers[b]);
       }

--- a/src/steady_ns_solver.cpp
+++ b/src/steady_ns_solver.cpp
@@ -396,7 +396,7 @@ void SteadyNSSolver::SetupRHSBCOperators()
          if (idx < 0) continue;
          if (!BCExistsOnBdr(b)) continue;
          // TODO: Non-homogeneous Neumann stress bc
-         if (bdr_type[b] == ParameterizedProblem::BoundaryType::NEUMANN)
+         if (bdr_type[b] == BoundaryType::NEUMANN)
             continue;
 
          fs[m]->AddBdrFaceIntegrator(new DGBdrTemamLFIntegrator(*ud_coeffs[b], minus_half_zeta), *bdr_markers[b]);
@@ -420,7 +420,7 @@ void SteadyNSSolver::SetupDomainBCOperators()
          if (idx < 0) continue;
          
          // homogeneous Neumann boundary condition
-         if (!BCExistsOnBdr(b) && (bdr_type[b] == ParameterizedProblem::BoundaryType::NEUMANN))
+         if (!BCExistsOnBdr(b) && (bdr_type[b] == BoundaryType::NEUMANN))
             hs[m]->AddBdrFaceIntegrator(new DGTemamFluxIntegrator(*zeta_coeff), *bdr_markers[b]);
       }
    }

--- a/src/steady_ns_solver.cpp
+++ b/src/steady_ns_solver.cpp
@@ -394,8 +394,10 @@ void SteadyNSSolver::SetupRHSBCOperators()
       {
          int idx = meshes[m]->bdr_attributes.Find(global_bdr_attributes[b]);
          if (idx < 0) continue;
-         // TODO: Non-homogeneous Neumann stress bc
          if (!BCExistsOnBdr(b)) continue;
+         // TODO: Non-homogeneous Neumann stress bc
+         if (bdr_type[b] == ParameterizedProblem::BoundaryType::NEUMANN)
+            continue;
 
          fs[m]->AddBdrFaceIntegrator(new DGBdrTemamLFIntegrator(*ud_coeffs[b], minus_half_zeta), *bdr_markers[b]);
       }
@@ -418,7 +420,7 @@ void SteadyNSSolver::SetupDomainBCOperators()
          if (idx < 0) continue;
          
          // homogeneous Neumann boundary condition
-         if (!BCExistsOnBdr(b))
+         if (!BCExistsOnBdr(b) && (bdr_type[b] == ParameterizedProblem::BoundaryType::NEUMANN))
             hs[m]->AddBdrFaceIntegrator(new DGTemamFluxIntegrator(*zeta_coeff), *bdr_markers[b]);
       }
    }

--- a/src/stokes_solver.cpp
+++ b/src/stokes_solver.cpp
@@ -324,8 +324,11 @@ void StokesSolver::SetupRHSBCOperators()
       {
          int idx = meshes[m]->bdr_attributes.Find(global_bdr_attributes[b]);
          if (idx < 0) continue;
-         // TODO: Non-homogeneous Neumann stress bc
          if (!BCExistsOnBdr(b)) continue;
+
+         // TODO: Non-homogeneous Neumann stress bc
+         if (bdr_type[b] == ParameterizedProblem::BoundaryType::NEUMANN)
+            continue;
 
          fs[m]->AddBdrFaceIntegrator(new DGVectorDirichletLFIntegrator(*ud_coeffs[b], *nu_coeff, sigma, kappa), *bdr_markers[b]);
 
@@ -355,6 +358,10 @@ void StokesSolver::SetupDomainBCOperators()
          int idx = meshes[m]->bdr_attributes.Find(global_bdr_attributes[b]);
          if (idx < 0) continue;
          if (!BCExistsOnBdr(b)) continue;
+
+         // TODO: Non-homogeneous Neumann stress bc
+         if (bdr_type[b] == ParameterizedProblem::BoundaryType::NEUMANN)
+            continue;
 
          ms[m]->AddBdrFaceIntegrator(new DGVectorDiffusionIntegrator(*nu_coeff, sigma, kappa), *bdr_markers[b]);
          bs[m]->AddBdrFaceIntegrator(new DGNormalFluxIntegrator, *bdr_markers[b]);

--- a/src/stokes_solver.cpp
+++ b/src/stokes_solver.cpp
@@ -327,7 +327,7 @@ void StokesSolver::SetupRHSBCOperators()
          if (!BCExistsOnBdr(b)) continue;
 
          // TODO: Non-homogeneous Neumann stress bc
-         if (bdr_type[b] == ParameterizedProblem::BoundaryType::NEUMANN)
+         if (bdr_type[b] == BoundaryType::NEUMANN)
             continue;
 
          fs[m]->AddBdrFaceIntegrator(new DGVectorDirichletLFIntegrator(*ud_coeffs[b], *nu_coeff, sigma, kappa), *bdr_markers[b]);
@@ -360,7 +360,7 @@ void StokesSolver::SetupDomainBCOperators()
          if (!BCExistsOnBdr(b)) continue;
 
          // TODO: Non-homogeneous Neumann stress bc
-         if (bdr_type[b] == ParameterizedProblem::BoundaryType::NEUMANN)
+         if (bdr_type[b] == BoundaryType::NEUMANN)
             continue;
 
          ms[m]->AddBdrFaceIntegrator(new DGVectorDiffusionIntegrator(*nu_coeff, sigma, kappa), *bdr_markers[b]);
@@ -1100,15 +1100,15 @@ void StokesSolver::SetParameterizedProblem(ParameterizedProblem *problem)
    {
       switch (problem->bdr_type[b])
       {
-         case ParameterizedProblem::BoundaryType::DIRICHLET:
+         case BoundaryType::DIRICHLET:
          { 
             assert(problem->vector_bdr_ptr[b]);
             AddBCFunction(*(problem->vector_bdr_ptr[b]), problem->battr[b]);
             break;
          }
-         case ParameterizedProblem::BoundaryType::NEUMANN: break;
+         case BoundaryType::NEUMANN: break;
          default:
-         case ParameterizedProblem::BoundaryType::ZERO:
+         case BoundaryType::ZERO:
          { AddBCFunction(zero, problem->battr[b]); break; }
       }
    }
@@ -1127,7 +1127,7 @@ void StokesSolver::SetParameterizedProblem(ParameterizedProblem *problem)
       nz_dbcs = true;
       for (int b = 0; b < problem->battr.Size(); b++)
       {
-         if (problem->bdr_type[b] == ParameterizedProblem::BoundaryType::ZERO)
+         if (problem->bdr_type[b] == BoundaryType::ZERO)
          {
             if (problem->battr[b] == -1)
             { nz_dbcs = false; break; }

--- a/src/stokes_solver.cpp
+++ b/src/stokes_solver.cpp
@@ -1093,15 +1093,15 @@ void StokesSolver::SetParameterizedProblem(ParameterizedProblem *problem)
    {
       switch (problem->bdr_type[b])
       {
-         case StokesProblem::BoundaryType::DIRICHLET:
+         case ParameterizedProblem::BoundaryType::DIRICHLET:
          { 
             assert(problem->vector_bdr_ptr[b]);
             AddBCFunction(*(problem->vector_bdr_ptr[b]), problem->battr[b]);
             break;
          }
-         case StokesProblem::BoundaryType::NEUMANN: break;
+         case ParameterizedProblem::BoundaryType::NEUMANN: break;
          default:
-         case StokesProblem::BoundaryType::ZERO:
+         case ParameterizedProblem::BoundaryType::ZERO:
          { AddBCFunction(zero, problem->battr[b]); break; }
       }
    }
@@ -1120,7 +1120,7 @@ void StokesSolver::SetParameterizedProblem(ParameterizedProblem *problem)
       nz_dbcs = true;
       for (int b = 0; b < problem->battr.Size(); b++)
       {
-         if (problem->bdr_type[b] == StokesProblem::BoundaryType::ZERO)
+         if (problem->bdr_type[b] == ParameterizedProblem::BoundaryType::ZERO)
          {
             if (problem->battr[b] == -1)
             { nz_dbcs = false; break; }

--- a/test/mms_suite.cpp
+++ b/test/mms_suite.cpp
@@ -40,7 +40,7 @@ PoissonSolver *SolveWithRefinement(const int num_refinement)
    test->InitVisualization();
 
    test->AddBCFunction(ExactSolution);
-   test->SetBdrType(ParameterizedProblem::BoundaryType::DIRICHLET);
+   test->SetBdrType(BoundaryType::DIRICHLET);
    test->AddRHSFunction(ExactRHS);
 
    test->BuildOperators();
@@ -179,7 +179,7 @@ StokesSolver *SolveWithRefinement(const int num_refinement)
    test->InitVisualization();
 
    test->AddBCFunction(uFun_ex);
-   test->SetBdrType(ParameterizedProblem::BoundaryType::DIRICHLET);
+   test->SetBdrType(BoundaryType::DIRICHLET);
    test->AddRHSFunction(fFun);
    // NOTE(kevin): uFun_ex already satisfies zero divergence.
    //              no need to set complementary flux.
@@ -359,7 +359,7 @@ SteadyNSSolver *SolveWithRefinement(const int num_refinement)
    test->InitVisualization();
 
    test->AddBCFunction(uFun_ex);
-   test->SetBdrType(ParameterizedProblem::BoundaryType::DIRICHLET);
+   test->SetBdrType(BoundaryType::DIRICHLET);
    test->AddRHSFunction(fFun);
    // NOTE(kevin): uFun_ex already satisfies zero divergence.
    //              no need to set complementary flux.
@@ -519,7 +519,7 @@ namespace linelast
       test->AddBCFunction(ExactSolution, 1);
       test->AddBCFunction(ExactSolution, 2);
       test->AddBCFunction(ExactSolution, 3);
-      test->SetBdrType(ParameterizedProblem::BoundaryType::DIRICHLET);
+      test->SetBdrType(BoundaryType::DIRICHLET);
       test->AddRHSFunction(ExactRHS);
 
       test->BuildOperators();

--- a/test/mms_suite.cpp
+++ b/test/mms_suite.cpp
@@ -40,6 +40,7 @@ PoissonSolver *SolveWithRefinement(const int num_refinement)
    test->InitVisualization();
 
    test->AddBCFunction(ExactSolution);
+   test->SetBdrType(ParameterizedProblem::BoundaryType::DIRICHLET);
    test->AddRHSFunction(ExactRHS);
 
    test->BuildOperators();
@@ -178,6 +179,7 @@ StokesSolver *SolveWithRefinement(const int num_refinement)
    test->InitVisualization();
 
    test->AddBCFunction(uFun_ex);
+   test->SetBdrType(ParameterizedProblem::BoundaryType::DIRICHLET);
    test->AddRHSFunction(fFun);
    // NOTE(kevin): uFun_ex already satisfies zero divergence.
    //              no need to set complementary flux.
@@ -357,6 +359,7 @@ SteadyNSSolver *SolveWithRefinement(const int num_refinement)
    test->InitVisualization();
 
    test->AddBCFunction(uFun_ex);
+   test->SetBdrType(ParameterizedProblem::BoundaryType::DIRICHLET);
    test->AddRHSFunction(fFun);
    // NOTE(kevin): uFun_ex already satisfies zero divergence.
    //              no need to set complementary flux.
@@ -516,6 +519,7 @@ namespace linelast
       test->AddBCFunction(ExactSolution, 1);
       test->AddBCFunction(ExactSolution, 2);
       test->AddBCFunction(ExactSolution, 3);
+      test->SetBdrType(ParameterizedProblem::BoundaryType::DIRICHLET);
       test->AddRHSFunction(ExactRHS);
 
       test->BuildOperators();


### PR DESCRIPTION
- The enumeration `BoundaryType` is now independent, applicable to all problems.
  - `BoundaryType::ZERO` is reserved for zero Dirichlet boundary condition.
- `MultiBlockSolver` has `Array<BoundaryType> bdr_type`, indicating boundary types for all global boundary attributes.
- `MultiBlockSolver::SetParameterizedProblem` specifies `bdr_type` according to `problem`. Executed in all derived classes.
- All physics solvers' `SetupBCOperator` now supports various boundary conditions depending on Dirichlet/Neumann boundary types, specified by member variable `bdr_type`.
- `MultiBlockSolver::BCExistsOnBdr` still behaves the same as before, returning whether a boundary condition is specified.