### PR TITLE
error visualization

### DIFF
--- a/include/multiblock_solver.hpp
+++ b/include/multiblock_solver.hpp
@@ -90,6 +90,10 @@ protected:
    Array<FiniteElementSpace *> global_fes;
    Array<GridFunction *> global_us_visual;
 
+   bool visualize_error = false;
+   Array<GridFunction *> error_visual;    // Size(num_var * numSub)
+   Array<GridFunction *> global_error_visual;   // point-wise error visualization
+
    // rom variables.
    ROMHandlerBase *rom_handler = NULL;
    TrainMode train_mode = NUM_TRAINMODE;


### PR DESCRIPTION
This PR supports point-wise error visualization. Turning on `visualization/visualize_error` will store the point-wise error of the ROM solution in paraview files.