### PR TITLE
libROM / MFEM v4.6 updates + Advection-diffusion

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -209,6 +209,9 @@ set(scaleupROMObj_SOURCES
   include/steady_ns_solver.hpp
   src/steady_ns_solver.cpp
 
+  include/advdiff_solver.hpp
+  src/advdiff_solver.cpp
+
   include/input_parser.hpp
   src/input_parser.cpp
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -29,6 +29,8 @@ WORKDIR /usr/lib
 RUN arch=$(uname -m) && sudo ln -s /usr/lib/${arch}-linux-gnu/libscalapack-openmpi.so.2.1.0 ./
 
 # re-install mfem with mumps, with cmake
+WORKDIR $LIB_DIR/mfem
+RUN sudo git checkout v4.6
 WORKDIR $LIB_DIR/mfem/build
 RUN sudo -E cmake .. -DBUILD_SHARED_LIBS=YES -DMFEM_USE_MPI=YES -DMFEM_USE_GSLIB=${MG} -DMFEM_USE_METIS=YES -DMFEM_USE_METIS_5=YES -DMFEM_USE_MUMPS=YES -DGSLIB_DIR="$LIB_DIR/gslib/build" -DMUMPS_DIR="$LIB_DIR/mumps/build/local"
 RUN sudo -E make -j 16
@@ -54,7 +56,7 @@ WORKDIR ./libROM
 RUN sudo git pull && sudo git checkout mpi-io
 WORKDIR ./build
 # libROM is using the MFEM without MUMPS right now.
-RUN sudo cmake .. -DCMAKE_TOOLCHAIN_FILE=${TOOLCHAIN_FILE} -DCMAKE_BUILD_TYPE=${BUILD_TYPE} -DUSE_MFEM=${USE_MFEM} -DMFEM_USE_GSLIB=${MFEM_USE_GSLIB}
+RUN sudo cmake .. -DCMAKE_TOOLCHAIN_FILE=${TOOLCHAIN_FILE} -DCMAKE_BUILD_TYPE=${BUILD_TYPE} -DUSE_MFEM=OFF -DMFEM_USE_GSLIB=${MFEM_USE_GSLIB}
 RUN sudo make -j 16
 
 ENV LIBROM_DIR=$LIB_DIR/libROM

--- a/include/advdiff_solver.hpp
+++ b/include/advdiff_solver.hpp
@@ -19,6 +19,15 @@ friend class ParameterizedProblem;
 protected:
    double Pe = 0.0;  // Peclet number
 
+   // coefficient for prescribed velocity field.
+   // can be analytic function or solution from Stokes/SteadyNS equation.
+   Array<VectorCoefficient *> flow_coeffs;
+
+   /*
+      flow solver to obtain the prescribed velocity field. both StokesSolver / SteadyNSSolver can be used.
+   */
+   StokesSolver *stokes_solver = NULL;
+
 public:
    AdvDiffSolver();
 
@@ -28,6 +37,10 @@ public:
 
    // Component-wise assembly
    void BuildCompROMElement(Array<FiniteElementSpace *> &fes_comp) override;
+
+   void SetFlowAtSubdomain(std::function<void(const Vector &, Vector &)> F, const int m=-1);
+
+   void SetParameterizedProblem(ParameterizedProblem *problem) override;
 
 protected:
    void SetMUMPSSolver() override;

--- a/include/advdiff_solver.hpp
+++ b/include/advdiff_solver.hpp
@@ -27,6 +27,9 @@ protected:
       flow solver to obtain the prescribed velocity field. both StokesSolver / SteadyNSSolver can be used.
    */
    StokesSolver *stokes_solver = NULL;
+   bool load_flow = false;
+   bool save_flow = false;
+   std::string flow_file = "";
 
 public:
    AdvDiffSolver();
@@ -46,6 +49,9 @@ public:
 
 protected:
    void SetMUMPSSolver() override;
+
+private:
+   void GetFlowField(ParameterizedProblem *flow_problem);
 };
 
 #endif

--- a/include/advdiff_solver.hpp
+++ b/include/advdiff_solver.hpp
@@ -31,6 +31,13 @@ protected:
    bool save_flow = false;
    std::string flow_file = "";
 
+   /* grid functions for visualizaing flow field */
+   /* NOTE(kevin): this will be set up at SaveVisualization. */
+   Array<FiniteElementSpace *> flow_fes;
+   Array<GridFunction *> flow_visual;
+   FiniteElementSpace *global_flow_fes = NULL;
+   Array<GridFunction *> global_flow_visual;
+
 public:
    AdvDiffSolver();
 
@@ -46,6 +53,8 @@ public:
    void SetFlowAtSubdomain(std::function<void(const Vector &, Vector &)> F, const int m=-1);
 
    void SetParameterizedProblem(ParameterizedProblem *problem) override;
+
+   void SaveVisualization() override;
 
 protected:
    void SetMUMPSSolver() override;

--- a/include/advdiff_solver.hpp
+++ b/include/advdiff_solver.hpp
@@ -38,6 +38,8 @@ public:
    // Component-wise assembly
    void BuildCompROMElement(Array<FiniteElementSpace *> &fes_comp) override;
 
+   bool Solve() override;
+
    void SetFlowAtSubdomain(std::function<void(const Vector &, Vector &)> F, const int m=-1);
 
    void SetParameterizedProblem(ParameterizedProblem *problem) override;

--- a/include/advdiff_solver.hpp
+++ b/include/advdiff_solver.hpp
@@ -1,0 +1,36 @@
+// Copyright 2023 Lawrence Livermore National Security, LLC. See the top-level LICENSE file for details.
+//
+// SPDX-License-Identifier: MIT
+
+#ifndef SCALEUPROM_ADVDIFF_SOLVER_HPP
+#define SCALEUPROM_ADVDIFF_SOLVER_HPP
+
+#include "poisson_solver.hpp"
+#include "stokes_solver.hpp"
+
+// By convention we only use mfem namespace as default, not CAROM.
+using namespace mfem;
+
+class AdvDiffSolver : public PoissonSolver
+{
+
+friend class ParameterizedProblem;
+
+protected:
+   double Pe = 0.0;  // Peclet number
+
+public:
+   AdvDiffSolver();
+
+   virtual ~AdvDiffSolver();
+
+   void BuildDomainOperators() override;
+
+   // Component-wise assembly
+   void BuildCompROMElement(Array<FiniteElementSpace *> &fes_comp) override;
+
+protected:
+   void SetMUMPSSolver() override;
+};
+
+#endif

--- a/include/multiblock_solver.hpp
+++ b/include/multiblock_solver.hpp
@@ -137,6 +137,8 @@ public:
    BlockVector* GetSolution() { return U; }
    BlockVector* GetSolutionCopy() { return new BlockVector(*U); }
 
+   void SetSolutionSaveMode(const bool save_sol_);
+
    void GetVariableVector(const int &var_idx, BlockVector &global, BlockVector &var);
    void SetVariableVector(const int &var_idx, BlockVector &var, BlockVector &global);
 

--- a/include/poisson_solver.hpp
+++ b/include/poisson_solver.hpp
@@ -99,6 +99,9 @@ public:
    void SanityCheckOnCoeffs();
 
    virtual void SetParameterizedProblem(ParameterizedProblem *problem);
+
+protected:
+   virtual void SetMUMPSSolver();
 };
 
 #endif

--- a/include/steady_ns_solver.hpp
+++ b/include/steady_ns_solver.hpp
@@ -150,35 +150,34 @@ public:
 
    using StokesSolver::GetVariableNames;
 
-   virtual void InitVariables();
+   void InitVariables() override;
 
-   virtual void BuildOperators() override;
-   virtual void BuildDomainOperators();
+   void BuildDomainOperators() override;
 
-   virtual void SetupRHSBCOperators() override;
-   virtual void SetupDomainBCOperators() override;
+   void SetupRHSBCOperators() override;
+   void SetupDomainBCOperators() override;
 
-   virtual void Assemble();
+   void AssembleOperator() override;
 
-   virtual void SaveROMOperator(const std::string input_prefix="");
-   virtual void LoadROMOperatorFromFile(const std::string input_prefix="");
+   void SaveROMOperator(const std::string input_prefix="") override;
+   void LoadROMOperatorFromFile(const std::string input_prefix="") override;
 
    // Component-wise assembly
-   virtual void BuildCompROMElement(Array<FiniteElementSpace *> &fes_comp);
+   void BuildCompROMElement(Array<FiniteElementSpace *> &fes_comp) override;
    // virtual void BuildBdrROMElement(Array<FiniteElementSpace *> &fes_comp);
    // virtual void BuildInterfaceROMElement(Array<FiniteElementSpace *> &fes_comp);
-   virtual void SaveCompBdrROMElement(hid_t &file_id) override;
-   virtual void LoadCompBdrROMElement(hid_t &file_id) override;
+   void SaveCompBdrROMElement(hid_t &file_id) override;
+   void LoadCompBdrROMElement(hid_t &file_id) override;
 
-   virtual bool Solve();
+   bool Solve() override;
 
-   virtual void ProjectOperatorOnReducedBasis();
+   void ProjectOperatorOnReducedBasis() override;
 
-   virtual void SolveROM() override;
+   void SolveROM() override;
 
-   virtual void TrainEQP(SampleGenerator *sample_generator) override;
-   virtual void SaveEQP() override;
-   virtual void LoadEQP() override;
+   void TrainEQP(SampleGenerator *sample_generator) override;
+   void SaveEQP() override;
+   void LoadEQP() override;
 
 private:
    DenseTensor* GetReducedTensor(DenseMatrix *basis, FiniteElementSpace *fespace);

--- a/include/stokes_solver.hpp
+++ b/include/stokes_solver.hpp
@@ -179,7 +179,7 @@ public:
    // For bilinear case.
    // system-specific.
    virtual void AssembleInterfaceMatrices();
-   virtual void SetupMUMPSSolver();
+   virtual void SetupMUMPSSolver(bool set_oper);
    virtual void SetupPressureMassMatrix();
 
    // Component-wise assembly

--- a/sketches/ns_dg_mms.cpp
+++ b/sketches/ns_dg_mms.cpp
@@ -413,7 +413,7 @@ int main(int argc, char *argv[])
    MUMPSSolver *J_mumps = NULL;
    if (direct_solve)
    {
-      J_mumps = new MUMPSSolver;
+      J_mumps = new MUMPSSolver(MPI_COMM_WORLD);
       J_mumps->SetPrintLevel(-1);
       J_mumps->SetMatrixSymType(MUMPSSolver::MatType::UNSYMMETRIC);
       J_solver = J_mumps;

--- a/sketches/ns_rom.cpp
+++ b/sketches/ns_rom.cpp
@@ -242,7 +242,7 @@ public:
 
       if (direct_solve)
       {
-         J_mumps = new MUMPSSolver();
+         J_mumps = new MUMPSSolver(MPI_COMM_WORLD);
          J_mumps->SetMatrixSymType(MUMPSSolver::MatType::UNSYMMETRIC);
          J_solver = J_mumps;
       }

--- a/sketches/ns_rom.cpp
+++ b/sketches/ns_rom.cpp
@@ -1768,7 +1768,7 @@ int main(int argc, char *argv[])
       J_gmres.SetMaxIter(maxIter);
       J_gmres.SetPrintLevel(-1);
 
-      MUMPSSolver J_mumps;
+      MUMPSSolver J_mumps(MPI_COMM_WORLD);
       J_mumps.SetMatrixSymType(MUMPSSolver::MatType::UNSYMMETRIC);
 
       Solver *J_solver;

--- a/sketches/stokes_mms4.cpp
+++ b/sketches/stokes_mms4.cpp
@@ -322,7 +322,7 @@ int main(int argc, char *argv[])
       HYPRE_BigInt sys_row_starts[2] = {0, sys_mat->NumRows()};
       HypreParMatrix Aop(MPI_COMM_WORLD, sys_glob_size, sys_row_starts, sys_mat);
 
-      MUMPSSolver mumps;
+      MUMPSSolver mumps(MPI_COMM_WORLD);
       mumps.SetPrintLevel(1);
       mumps.SetMatrixSymType(MUMPSSolver::MatType::UNSYMMETRIC);
       // mumps.SetMatrixSymType(MUMPSSolver::MatType::SYMMETRIC_POSITIVE_DEFINITE);

--- a/src/advdiff_solver.cpp
+++ b/src/advdiff_solver.cpp
@@ -1,0 +1,65 @@
+// Copyright 2023 Lawrence Livermore National Security, LLC. See the top-level LICENSE file for details.
+//
+// SPDX-License-Identifier: MIT
+
+#include "advdiff_solver.hpp"
+#include "input_parser.hpp"
+#include "linalg_utils.hpp"
+#include "etc.hpp"
+
+using namespace std;
+using namespace mfem;
+
+AdvDiffSolver::AdvDiffSolver()
+   : PoissonSolver()
+{
+   Pe = config.GetOption<double>("adv-diff/peclet_number", 0.0);
+}
+
+AdvDiffSolver::~AdvDiffSolver()
+{
+}
+
+void AdvDiffSolver::BuildDomainOperators()
+{
+   PoissonSolver::BuildDomainOperators();
+
+   for (int m = 0; m < numSub; m++)
+   {
+      // as[m]->AddDomainIntegrator(new DiffusionIntegrator);
+   }
+}
+
+void AdvDiffSolver::BuildCompROMElement(Array<FiniteElementSpace *> &fes_comp)
+{
+   assert(train_mode == UNIVERSAL);
+   assert(rom_handler->BasisLoaded());
+
+   const int num_comp = fes_comp.Size();
+   assert(comp_mats.Size() == num_comp);
+
+   for (int c = 0; c < num_comp; c++)
+   {
+      Mesh *comp = topol_handler->GetComponentMesh(c);
+      BilinearForm a_comp(fes_comp[c]);
+
+      a_comp.AddDomainIntegrator(new DiffusionIntegrator);
+      if (full_dg)
+         a_comp.AddInteriorFaceIntegrator(new DGDiffusionIntegrator(sigma, kappa));
+
+      a_comp.Assemble();
+      a_comp.Finalize();
+
+      // Poisson equation has only one solution variable.
+      comp_mats[c]->SetSize(1, 1);
+      (*comp_mats[c])(0, 0) = rom_handler->ProjectToRefBasis(c, c, &(a_comp.SpMat()));
+   }
+}
+
+void AdvDiffSolver::SetMUMPSSolver()
+{
+   assert(globalMat_hypre);
+   mumps = new MUMPSSolver();
+   mumps->SetMatrixSymType(MUMPSSolver::MatType::UNSYMMETRIC);
+   mumps->SetOperator(*globalMat_hypre);
+}

--- a/src/advdiff_solver.cpp
+++ b/src/advdiff_solver.cpp
@@ -13,11 +13,17 @@ using namespace mfem;
 AdvDiffSolver::AdvDiffSolver()
    : PoissonSolver()
 {
+   // ConvectionIntegrator does not support L2 space.
+   assert(!full_dg);
+
    Pe = config.GetOption<double>("adv-diff/peclet_number", 0.0);
+
+   flow_coeffs.SetSize(numSub);
 }
 
 AdvDiffSolver::~AdvDiffSolver()
 {
+   DeletePointers(flow_coeffs);
 }
 
 void AdvDiffSolver::BuildDomainOperators()
@@ -26,12 +32,15 @@ void AdvDiffSolver::BuildDomainOperators()
 
    for (int m = 0; m < numSub; m++)
    {
-      // as[m]->AddDomainIntegrator(new DiffusionIntegrator);
+      assert(flow_coeffs[m]);
+      as[m]->AddDomainIntegrator(new ConvectionIntegrator(*flow_coeffs[m], Pe));
    }
 }
 
 void AdvDiffSolver::BuildCompROMElement(Array<FiniteElementSpace *> &fes_comp)
 {
+   mfem_error("AdvDiffSolver::BuildCompROMElement is not implemented yet!\n");
+
    assert(train_mode == UNIVERSAL);
    assert(rom_handler->BasisLoaded());
 
@@ -47,6 +56,8 @@ void AdvDiffSolver::BuildCompROMElement(Array<FiniteElementSpace *> &fes_comp)
       if (full_dg)
          a_comp.AddInteriorFaceIntegrator(new DGDiffusionIntegrator(sigma, kappa));
 
+      // TODO(kevin): ConvectionIntegrator needs to be added
+
       a_comp.Assemble();
       a_comp.Finalize();
 
@@ -54,6 +65,27 @@ void AdvDiffSolver::BuildCompROMElement(Array<FiniteElementSpace *> &fes_comp)
       comp_mats[c]->SetSize(1, 1);
       (*comp_mats[c])(0, 0) = rom_handler->ProjectToRefBasis(c, c, &(a_comp.SpMat()));
    }
+}
+
+void AdvDiffSolver::SetFlowAtSubdomain(std::function<void(const Vector &, Vector &)> F, const int m)
+{
+   assert(flow_coeffs.Size() == numSub);
+   assert((m == -1) || ((m >= 0) && (m < numSub)));
+
+   if (m == -1)
+   {
+      for (int k = 0; k < numSub; k++)
+         flow_coeffs[k] = new VectorFunctionCoefficient(dim, F);
+   }
+   else
+      flow_coeffs[m] = new VectorFunctionCoefficient(dim, F);
+}
+
+void AdvDiffSolver::SetParameterizedProblem(ParameterizedProblem *problem)
+{
+   PoissonSolver::SetParameterizedProblem(problem);
+
+   // TODO(kevin): add flow field setup.
 }
 
 void AdvDiffSolver::SetMUMPSSolver()

--- a/src/advdiff_solver.cpp
+++ b/src/advdiff_solver.cpp
@@ -241,6 +241,7 @@ void AdvDiffSolver::GetFlowField(ParameterizedProblem *flow_problem)
 
    stokes_solver = new StokesSolver;
    stokes_solver->InitVariables();
+   stokes_solver->SetSolutionSaveMode(save_flow);
 
    if (load_flow && FileExists(flow_file))
       stokes_solver->LoadSolution(flow_file);

--- a/src/advdiff_solver.cpp
+++ b/src/advdiff_solver.cpp
@@ -243,8 +243,12 @@ void AdvDiffSolver::GetFlowField(ParameterizedProblem *flow_problem)
    stokes_solver->InitVariables();
    stokes_solver->SetSolutionSaveMode(save_flow);
 
+   bool flow_loaded = false;
    if (load_flow && FileExists(flow_file))
+   {
       stokes_solver->LoadSolution(flow_file);
+      flow_loaded = true;
+   }
    else
    {
       stokes_solver->SetParameterizedProblem(flow_problem);
@@ -255,7 +259,7 @@ void AdvDiffSolver::GetFlowField(ParameterizedProblem *flow_problem)
       stokes_solver->Solve();
    }
 
-   if (save_flow)
+   if (save_flow && (!flow_loaded))
       stokes_solver->SaveSolution(flow_file);
 
    DeletePointers(flow_coeffs);

--- a/src/advdiff_solver.cpp
+++ b/src/advdiff_solver.cpp
@@ -19,6 +19,7 @@ AdvDiffSolver::AdvDiffSolver()
    Pe = config.GetOption<double>("adv-diff/peclet_number", 0.0);
 
    flow_coeffs.SetSize(numSub);
+   flow_coeffs = NULL;
 
    save_flow = config.GetOption<bool>("adv-diff/save_flow", false);
    load_flow = config.GetOption<bool>("adv-diff/load_flow", false);
@@ -175,7 +176,7 @@ void AdvDiffSolver::SetParameterizedProblem(ParameterizedProblem *problem)
 void AdvDiffSolver::SetMUMPSSolver()
 {
    assert(globalMat_hypre);
-   mumps = new MUMPSSolver();
+   mumps = new MUMPSSolver(MPI_COMM_SELF);
    mumps->SetMatrixSymType(MUMPSSolver::MatType::UNSYMMETRIC);
    mumps->SetOperator(*globalMat_hypre);
 }

--- a/src/component_topology_handler.cpp
+++ b/src/component_topology_handler.cpp
@@ -179,9 +179,9 @@ void ComponentTopologyHandler::SetupReferencePorts()
       for (int p = 0; p < port_list.size(); p++)
       {
          // Read hdf5 files.
-         std::string filename = config.GetRequiredOptionFromDict<std::string>("file", port_list[p]);
+         std::string filename = config.GetOptionFromDict<std::string>("file", "", port_list[p]);
 
-         if (FileExists(filename))
+         if ((filename != "") && FileExists(filename))
             ReadPortDatasFromFile(filename);
          else
             BuildPortDataFromInput(port_list[p]);
@@ -320,9 +320,11 @@ void ComponentTopologyHandler::ReadPortsFromFile(const std::string filename)
    int attr_offset = 0;
    for (int c = 0; c < num_comp; c++)
       attr_offset = max(attr_offset, components[c]->bdr_attributes.Max());
-   // Also does not overlap with global boundary attributes.
    assert(bdr_attributes.Size() > 0);
-   attr_offset = max(attr_offset, bdr_attributes.Max());
+   // Also does not overlap with global boundary attributes.
+   // In order to keep consistencity with SubMesh,
+   // We leave bdr_attributes.Max()+1 empty.
+   attr_offset = max(attr_offset, bdr_attributes.Max()+1);
    attr_offset += 1;
 
    for (int p = 0; p < num_ports; p++)

--- a/src/linelast_solver.cpp
+++ b/src/linelast_solver.cpp
@@ -292,7 +292,7 @@ void LinElastSolver::AssembleOperator()
       sys_row_starts[1] = globalMat_mono->NumRows();
       globalMat_hypre = new HypreParMatrix(MPI_COMM_WORLD, sys_glob_size, sys_row_starts, globalMat_mono);
 
-      mumps = new MUMPSSolver();
+      mumps = new MUMPSSolver(MPI_COMM_SELF);
       mumps->SetMatrixSymType(MUMPSSolver::MatType::SYMMETRIC_POSITIVE_DEFINITE);
       mumps->SetOperator(*globalMat_hypre);
    }

--- a/src/main_workflow.cpp
+++ b/src/main_workflow.cpp
@@ -9,6 +9,7 @@
 #include "linelast_solver.hpp"
 #include "stokes_solver.hpp"
 #include "steady_ns_solver.hpp"
+#include "advdiff_solver.hpp"
 #include "etc.hpp"
 #include <fstream>
 #include <iostream>
@@ -55,6 +56,7 @@ MultiBlockSolver* InitSolver()
    else if (solver_type == "stokes")   { solver = new StokesSolver; }
    else if (solver_type == "steady-ns")   { solver = new SteadyNSSolver; }
    else if (solver_type == "linelast")   { solver = new LinElastSolver; }
+   else if (solver_type == "adv-diff")   { solver = new AdvDiffSolver; }
    else
    {
       printf("Unknown MultiBlockSolver %s!\n", solver_type.c_str());

--- a/src/multiblock_solver.cpp
+++ b/src/multiblock_solver.cpp
@@ -125,7 +125,13 @@ void MultiBlockSolver::ParseInputs()
    train_mode = SetTrainMode();
 
    // save solution if single run.
-   save_sol = config.GetOption<bool>("save_solution/enabled", false);
+   SetSolutionSaveMode(config.GetOption<bool>("save_solution/enabled", false));
+}
+
+void MultiBlockSolver::SetSolutionSaveMode(const bool save_sol_)
+{
+   // save solution if single run.
+   save_sol = save_sol_;
    if (save_sol)
    {
       // Default file path if no input file name is provided.

--- a/src/poisson_solver.cpp
+++ b/src/poisson_solver.cpp
@@ -332,9 +332,7 @@ void PoissonSolver::AssembleOperator()
       sys_row_starts[1] = globalMat_mono->NumRows();
       globalMat_hypre = new HypreParMatrix(MPI_COMM_SELF, sys_glob_size, sys_row_starts, globalMat_mono);
 
-      mumps = new MUMPSSolver();
-      mumps->SetMatrixSymType(MUMPSSolver::MatType::SYMMETRIC_POSITIVE_DEFINITE);
-      mumps->SetOperator(*globalMat_hypre);
+      if (direct_solve) SetMUMPSSolver();
    }
 }
 
@@ -586,4 +584,12 @@ void PoissonSolver::SetParameterizedProblem(ParameterizedProblem *problem)
       AddRHSFunction(*(problem->scalar_rhs_ptr));
    else
       AddRHSFunction(0.0);
+}
+
+void PoissonSolver::SetMUMPSSolver()
+{
+   assert(globalMat_hypre);
+   mumps = new MUMPSSolver();
+   mumps->SetMatrixSymType(MUMPSSolver::MatType::SYMMETRIC_POSITIVE_DEFINITE);
+   mumps->SetOperator(*globalMat_hypre);
 }

--- a/src/poisson_solver.cpp
+++ b/src/poisson_solver.cpp
@@ -556,7 +556,7 @@ void PoissonSolver::SetParameterizedProblem(ParameterizedProblem *problem)
 {
    /* set up boundary types */
    MultiBlockSolver::SetParameterizedProblem(problem);
-   
+
    // clean up rhs for parametrized problem.
    if (rhs_coeffs.Size() > 0)
    {
@@ -592,7 +592,7 @@ void PoissonSolver::SetParameterizedProblem(ParameterizedProblem *problem)
 void PoissonSolver::SetMUMPSSolver()
 {
    assert(globalMat_hypre);
-   mumps = new MUMPSSolver();
+   mumps = new MUMPSSolver(MPI_COMM_SELF);
    mumps->SetMatrixSymType(MUMPSSolver::MatType::SYMMETRIC_POSITIVE_DEFINITE);
    mumps->SetOperator(*globalMat_hypre);
 }

--- a/src/poisson_solver.cpp
+++ b/src/poisson_solver.cpp
@@ -554,6 +554,9 @@ void PoissonSolver::SanityCheckOnCoeffs()
 
 void PoissonSolver::SetParameterizedProblem(ParameterizedProblem *problem)
 {
+   /* set up boundary types */
+   MultiBlockSolver::SetParameterizedProblem(problem);
+   
    // clean up rhs for parametrized problem.
    if (rhs_coeffs.Size() > 0)
    {

--- a/src/rom_handler.cpp
+++ b/src/rom_handler.cpp
@@ -674,7 +674,7 @@ void MFEMROMHandler::NonlinearSolve(Operator &oper, BlockVector* U, Solver *prec
    Solver *J_solver = NULL;
    if (linsol_type == SolverType::DIRECT)
    {
-      mumps = new MUMPSSolver();
+      mumps = new MUMPSSolver(MPI_COMM_SELF);
       mumps->SetMatrixSymType(mat_type);
       mumps->SetPrintLevel(jac_print_level);
       J_solver = mumps;
@@ -1086,7 +1086,7 @@ void MFEMROMHandler::SetupDirectSolver()
    sys_row_starts[1] = romMat_mono->NumRows();
    romMat_hypre = new HypreParMatrix(MPI_COMM_SELF, sys_glob_size, sys_row_starts, romMat_mono);
 
-   mumps = new MUMPSSolver();
+   mumps = new MUMPSSolver(MPI_COMM_SELF);
    mumps->SetMatrixSymType(mat_type);
    mumps->SetOperator(*romMat_hypre);
 }

--- a/src/rom_handler.cpp
+++ b/src/rom_handler.cpp
@@ -269,7 +269,7 @@ void ROMHandlerBase::LoadReducedBasis()
       */
       {
          int local_dim = CAROM::split_dimension(dim_ref_basis[k], MPI_COMM_WORLD);
-         basis_reader = new CAROM::BasisReader(basis_name + basis_tags[k], CAROM::Database::HDF5_MPIO, local_dim);
+         basis_reader = new CAROM::BasisReader(basis_name + basis_tags[k], CAROM::Database::formats::HDF5_MPIO, local_dim);
 
          carom_ref_basis[k] = new CAROM::Matrix(*basis_reader->getSpatialBasis(num_ref_basis[k]));
          carom_ref_basis[k]->gather();

--- a/src/sample_generator.cpp
+++ b/src/sample_generator.cpp
@@ -186,7 +186,7 @@ void SampleGenerator::AddSnapshotGenerator(const int &fom_vdofs, const std::stri
 
    snapshot_options.Append(new CAROM::Options(fom_vdofs, max_num_snapshots, 1, update_right_SV));
    snapshot_options.Last()->static_svd_preserve_snapshot = true;
-   snapshot_generators.Append(new CAROM::BasisGenerator(*(snapshot_options.Last()), incremental, filename, CAROM::Database::HDF5_MPIO));
+   snapshot_generators.Append(new CAROM::BasisGenerator(*(snapshot_options.Last()), incremental, filename, CAROM::Database::formats::HDF5_MPIO));
 
    basis_tag2idx[basis_tag] = basis_tags.size();
    basis_tags.push_back(basis_tag);
@@ -264,7 +264,7 @@ void SampleGenerator::FormReducedBasis(const std::string &basis_prefix,
    CAROM::BasisGenerator *basis_generator = snapshot_generators.Last();
 
    for (int s = 0; s < file_list.size(); s++)
-      basis_generator->loadSamples(file_list[s], "snapshot", 1e9, CAROM::Database::HDF5_MPIO);
+      basis_generator->loadSamples(file_list[s], "snapshot", 1e9, CAROM::Database::formats::HDF5_MPIO);
 
    basis_generator->endSamples(); // save the merged basis file
    SaveSV(basis_generator, basis_name, ref_num_basis);
@@ -289,8 +289,7 @@ const int SampleGenerator::GetDimFromSnapshots(const std::string &filename)
       file_id = H5Fopen(filename_ext.c_str(), H5F_ACC_RDONLY, H5P_DEFAULT);
       assert(file_id >= 0);
 
-      // TODO(kevin): will have to reflect dataset name update.
-      hdf5_utils::ReadDataset(file_id, "snapshot_matrix_num_rows_000000", nrows);
+      hdf5_utils::ReadDataset(file_id, "snapshot_matrix_num_rows", nrows);
       assert(nrows[0] > 0);
 
       errf = H5Fclose(file_id);

--- a/src/steady_ns_solver.cpp
+++ b/src/steady_ns_solver.cpp
@@ -645,7 +645,7 @@ bool SteadyNSSolver::Solve()
 
    if (direct_solve)
    {
-      mumps = new MUMPSSolver();
+      mumps = new MUMPSSolver(MPI_COMM_SELF);
       mumps->SetMatrixSymType(MUMPSSolver::MatType::UNSYMMETRIC);
       mumps->SetPrintLevel(jac_print_level);
       J_solver = mumps;

--- a/src/steady_ns_solver.cpp
+++ b/src/steady_ns_solver.cpp
@@ -329,13 +329,6 @@ void SteadyNSSolver::InitVariables()
    }
 }
 
-void SteadyNSSolver::BuildOperators()
-{
-   BuildRHSOperators();
-
-   BuildDomainOperators();
-}
-
 void SteadyNSSolver::BuildDomainOperators()
 {
    StokesSolver::BuildDomainOperators();
@@ -427,13 +420,15 @@ void SteadyNSSolver::SetupDomainBCOperators()
    
 }
 
-void SteadyNSSolver::Assemble()
+void SteadyNSSolver::AssembleOperator()
 {
-   StokesSolver::AssembleRHS();
+   StokesSolver::AssembleOperatorBase();
 
-   StokesSolver::AssembleOperator();
-
-   // nonlinear operator?
+   if (direct_solve)
+      StokesSolver::SetupMUMPSSolver(false);
+   else
+      // pressure mass matrix for preconditioner.
+      StokesSolver::SetupPressureMassMatrix();
 }
 
 void SteadyNSSolver::SaveROMOperator(const std::string input_prefix)

--- a/src/stokes_solver.cpp
+++ b/src/stokes_solver.cpp
@@ -493,7 +493,7 @@ void StokesSolver::SetupMUMPSSolver(bool set_oper)
    systemOp_hypre = new HypreParMatrix(MPI_COMM_SELF, sys_glob_size, sys_row_starts, systemOp_mono);
 
    mumps = new MUMPSSolver(MPI_COMM_SELF);
-   mumps->SetMatrixSymType(MUMPSSolver::MatType::SYMMETRIC_POSITIVE_DEFINITE);
+   mumps->SetMatrixSymType(MUMPSSolver::MatType::SYMMETRIC_INDEFINITE);
    if (set_oper) mumps->SetOperator(*systemOp_hypre);
 }
 

--- a/src/stokes_solver.cpp
+++ b/src/stokes_solver.cpp
@@ -399,7 +399,7 @@ void StokesSolver::AssembleOperator()
    AssembleOperatorBase();
 
    if (direct_solve)
-      SetupMUMPSSolver();
+      SetupMUMPSSolver(true);
    else
       // pressure mass matrix for preconditioner.
       SetupPressureMassMatrix();
@@ -477,7 +477,7 @@ void StokesSolver::AssembleOperatorBase()
    systemOp->SetBlock(1,0, B);
 }
 
-void StokesSolver::SetupMUMPSSolver()
+void StokesSolver::SetupMUMPSSolver(bool set_oper)
 {
    assert(systemOp);
    delete systemOp_mono;
@@ -494,7 +494,7 @@ void StokesSolver::SetupMUMPSSolver()
 
    mumps = new MUMPSSolver(MPI_COMM_SELF);
    mumps->SetMatrixSymType(MUMPSSolver::MatType::SYMMETRIC_POSITIVE_DEFINITE);
-   mumps->SetOperator(*systemOp_hypre);
+   if (set_oper) mumps->SetOperator(*systemOp_hypre);
 }
 
 void StokesSolver::SetupPressureMassMatrix()

--- a/src/stokes_solver.cpp
+++ b/src/stokes_solver.cpp
@@ -1078,6 +1078,9 @@ void StokesSolver::SanityCheckOnCoeffs()
 
 void StokesSolver::SetParameterizedProblem(ParameterizedProblem *problem)
 {
+   /* set up boundary types */
+   MultiBlockSolver::SetParameterizedProblem(problem);
+   
    nu = function_factory::stokes_problem::nu;
    delete nu_coeff;
    nu_coeff = new ConstantCoefficient(nu);

--- a/src/stokes_solver.cpp
+++ b/src/stokes_solver.cpp
@@ -492,7 +492,7 @@ void StokesSolver::SetupMUMPSSolver()
    sys_row_starts[1] = systemOp_mono->NumRows();
    systemOp_hypre = new HypreParMatrix(MPI_COMM_SELF, sys_glob_size, sys_row_starts, systemOp_mono);
 
-   mumps = new MUMPSSolver();
+   mumps = new MUMPSSolver(MPI_COMM_SELF);
    mumps->SetMatrixSymType(MUMPSSolver::MatType::SYMMETRIC_POSITIVE_DEFINITE);
    mumps->SetOperator(*systemOp_hypre);
 }
@@ -1080,7 +1080,7 @@ void StokesSolver::SetParameterizedProblem(ParameterizedProblem *problem)
 {
    /* set up boundary types */
    MultiBlockSolver::SetParameterizedProblem(problem);
-   
+
    nu = function_factory::stokes_problem::nu;
    delete nu_coeff;
    nu_coeff = new ConstantCoefficient(nu);

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -33,6 +33,7 @@ add_executable(test_workflow test_workflow.cpp $<TARGET_OBJECTS:scaleupROMObj>)
 file(COPY inputs/test.base.yml DESTINATION ${CMAKE_BINARY_DIR}/test/inputs)
 file(COPY inputs/stokes.base.yml DESTINATION ${CMAKE_BINARY_DIR}/test/inputs)
 file(COPY inputs/steady_ns.base.yml DESTINATION ${CMAKE_BINARY_DIR}/test/inputs)
+file(COPY inputs/advdiff.base.yml DESTINATION ${CMAKE_BINARY_DIR}/test/inputs)
 file(COPY meshes/test.2x2.mesh DESTINATION ${CMAKE_BINARY_DIR}/test/meshes)
 file(COPY meshes/test.2x1.mesh DESTINATION ${CMAKE_BINARY_DIR}/test/meshes)
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -14,6 +14,7 @@ add_executable(poisson_dd_mms poisson_dd_mms.cpp $<TARGET_OBJECTS:scaleupROMObj>
 add_executable(stokes_dd_mms stokes_dd_mms.cpp $<TARGET_OBJECTS:scaleupROMObj> $<TARGET_OBJECTS:mmsSuiteObj>)
 add_executable(steady_ns_dd_mms steady_ns_dd_mms.cpp $<TARGET_OBJECTS:scaleupROMObj> $<TARGET_OBJECTS:mmsSuiteObj>)
 add_executable(linelast_dd_mms linelast_dd_mms.cpp $<TARGET_OBJECTS:scaleupROMObj> $<TARGET_OBJECTS:mmsSuiteObj>)
+add_executable(advdiff_dd_mms advdiff_dd_mms.cpp $<TARGET_OBJECTS:scaleupROMObj> $<TARGET_OBJECTS:mmsSuiteObj>)
 add_executable(dg_integ_mms dg_integ_mms.cpp $<TARGET_OBJECTS:scaleupROMObj> $<TARGET_OBJECTS:mmsSuiteObj>)
 file(COPY inputs/dd_mms.yml DESTINATION ${CMAKE_BINARY_DIR}/test/inputs)
 file(COPY meshes/dd_mms.mesh DESTINATION ${CMAKE_BINARY_DIR}/test/meshes)

--- a/test/advdiff_dd_mms.cpp
+++ b/test/advdiff_dd_mms.cpp
@@ -16,13 +16,13 @@ TEST(GoogleTestFramework, GoogleTestFrameworkFound) {
    SUCCEED();
 }
 
-// TEST(DDSerialTest, Test_convergence)
-// {
-//    config = InputParser("inputs/dd_mms.yml");
-//    CheckConvergence();
+TEST(DDSerialTest, Test_convergence)
+{
+   config = InputParser("inputs/dd_mms.yml");
+   CheckConvergence();
 
-//    return;
-// }
+   return;
+}
 
 TEST(DDSerialTest, Test_direct_solver)
 {
@@ -33,21 +33,21 @@ TEST(DDSerialTest, Test_direct_solver)
    return;
 }
 
-// TEST(DDSerial_component_wise_test, Test_convergence)
-// {
-//    config = InputParser("inputs/dd_mms.component.yml");
-//    CheckConvergence();
+TEST(DDSerial_component_wise_test, Test_convergence)
+{
+   config = InputParser("inputs/dd_mms.component.yml");
+   CheckConvergence();
 
-//    return;
-// }
+   return;
+}
 
-// TEST(DDSerial_component_3D_hex_test, Test_convergence)
-// {
-//    config = InputParser("inputs/dd_mms.comp.3d.yml");
-//    CheckConvergence();
+TEST(DDSerial_component_3D_hex_test, Test_convergence)
+{
+   config = InputParser("inputs/dd_mms.comp.3d.yml");
+   CheckConvergence();
 
-//    return;
-// }
+   return;
+}
 
 // TEST(DDSerial_component_3D_tet_test, Test_convergence)
 // {

--- a/test/advdiff_dd_mms.cpp
+++ b/test/advdiff_dd_mms.cpp
@@ -1,0 +1,68 @@
+// Copyright 2023 Lawrence Livermore National Security, LLC. See the top-level LICENSE file for details.
+//
+// SPDX-License-Identifier: MIT
+
+#include<gtest/gtest.h>
+#include "mms_suite.hpp"
+
+using namespace std;
+using namespace mfem;
+using namespace mms::advdiff;
+
+/**
+ * Simple smoke test to make sure Google Test is properly linked
+ */
+TEST(GoogleTestFramework, GoogleTestFrameworkFound) {
+   SUCCEED();
+}
+
+// TEST(DDSerialTest, Test_convergence)
+// {
+//    config = InputParser("inputs/dd_mms.yml");
+//    CheckConvergence();
+
+//    return;
+// }
+
+TEST(DDSerialTest, Test_direct_solver)
+{
+   config = InputParser("inputs/dd_mms.yml");
+   config.dict_["solver"]["direct_solve"] = true;
+   CheckConvergence();
+
+   return;
+}
+
+// TEST(DDSerial_component_wise_test, Test_convergence)
+// {
+//    config = InputParser("inputs/dd_mms.component.yml");
+//    CheckConvergence();
+
+//    return;
+// }
+
+// TEST(DDSerial_component_3D_hex_test, Test_convergence)
+// {
+//    config = InputParser("inputs/dd_mms.comp.3d.yml");
+//    CheckConvergence();
+
+//    return;
+// }
+
+// TEST(DDSerial_component_3D_tet_test, Test_convergence)
+// {
+//    config = InputParser("inputs/dd_mms.comp.3d.yml");
+//    config.dict_["mesh"]["component-wise"]["components"][0]["file"] = "meshes/dd_mms.3d.tet.mesh";
+//    CheckConvergence();
+
+//    return;
+// }
+
+int main(int argc, char* argv[])
+{
+   MPI_Init(&argc, &argv);
+   ::testing::InitGoogleTest(&argc, argv);
+   int result = RUN_ALL_TESTS();
+   MPI_Finalize();
+   return result;
+}

--- a/test/gmsh/multi_comp_dd_mms.cpp
+++ b/test/gmsh/multi_comp_dd_mms.cpp
@@ -16,10 +16,19 @@ TEST(GoogleTestFramework, GoogleTestFrameworkFound) {
    SUCCEED();
 }
 
-TEST(DDSerialTest, Test_convergence)
+TEST(Poisson, Test_convergence)
 {
    config = InputParser("test.component.yml");
    CheckConvergence();
+
+   return;
+}
+
+TEST(AdvDiff, Test_convergence)
+{
+   config = InputParser("test.component.yml");
+   config.dict_["adv-diff"]["peclet_number"] = 1.1;
+   mms::advdiff::CheckConvergence();
 
    return;
 }

--- a/test/inputs/advdiff.base.yml
+++ b/test/inputs/advdiff.base.yml
@@ -1,0 +1,81 @@
+main:
+#mode: run_example/sample_generation/build_rom/single_run
+  solver: adv-diff
+  mode: single_run
+  use_rom: true
+
+adv-diff:
+  peclet_number: 1.1
+  save_flow: true
+  flow_file: advdiff.flow_field.h5
+
+mesh:
+  filename: meshes/test.2x2.mesh
+  uniform_refinement: 1
+
+domain-decomposition:
+  type: interior_penalty
+
+discretization:
+  order: 1
+  full-discrete-galerkin: false
+
+visualization:
+  enabled: false
+  unified_paraview: true
+  file_path:
+    prefix: sample_gen_output
+
+parameterized_problem:
+  name: advdiff_flow_past_array
+
+single_run:
+  advdiff_flow_past_array:
+    nu: 2.5
+    u0_x: 1.0
+    u0_y: -1.0
+    du_x: 0.1
+    du_y: 0.1
+    k_u_x: 0.5
+    k_u_y: 0.8
+    k_v_x: 0.7
+    k_v_y: 0.2
+    q0: 1.0
+    dq: 0.8
+    qoffset: 0.0
+    qk_x: 1.5
+    qk_y: 0.9
+
+sample_generation:
+  maximum_number_of_snapshots: 400
+  component_sampling: false
+  file_path:
+    prefix: "advdiff_flow_past_array"
+  parameters:
+    - key: single_run/advdiff_flow_past_array/qk_x
+      type: double
+      sample_size: 3
+      minimum: 1.0
+      maximum: 2.0
+
+basis:
+  prefix: "advdiff0"
+  number_of_basis: 3
+  tags:
+    - name: comp0
+  svd:
+    save_spectrum: true
+    update_right_sv: false
+  visualization:
+    enabled: false
+
+model_reduction:
+  # individual/universal
+  subdomain_training: individual
+  save_operator:
+    level: global
+    prefix: "proj_inv"
+  compare_solution:
+    enabled: true
+  linear_solver_type: direct
+  linear_system_type: us

--- a/test/inputs/dd_mms.comp.3d.yml
+++ b/test/inputs/dd_mms.comp.3d.yml
@@ -39,6 +39,9 @@ discretization:
   order: 2
   full-discrete-galerkin: false
 
+solver:
+  direct_solve: true
+
 visualization:
   enable: false
   output_dir: dd_mms_output
@@ -49,6 +52,9 @@ manufactured_solution:
   amp2: 3.13
   amp3: 2.77
   constant: 1.11
+
+adv-diff:
+  peclet_number: 1.1
 
 stokes:
   nu: 1.2

--- a/test/inputs/dd_mms.component.yml
+++ b/test/inputs/dd_mms.component.yml
@@ -39,5 +39,8 @@ manufactured_solution:
   amp2: 3.13
   constant: 1.11
 
+adv-diff:
+  peclet_number: 1.1
+
 stokes:
   nu: 1.2

--- a/test/inputs/dd_mms.yml
+++ b/test/inputs/dd_mms.yml
@@ -9,14 +9,20 @@ discretization:
   full-discrete-galerkin: false
 
 visualization:
-  enable: false
-  output_dir: dd_mms_output
+  enabled: false
+  file_path:
+    prefix: dd_mms_output
+  visualize_error: true
+  unified_paraview: true
 
 manufactured_solution:
   number_of_refinement: 4
   amp1: 1.23
   amp2: 3.13
   constant: 1.11
+
+adv-diff:
+  peclet_number: 1.1
 
 stokes:
   nu: 1.2

--- a/test/inputs/test_topol.2d.yml
+++ b/test/inputs/test_topol.2d.yml
@@ -9,7 +9,7 @@ mesh:
         file: "meshes/test.2x2.mesh"
     ports:
       - name: "port1"
-        file: "port1.h5"
+        file: "port1.2d.h5"
         comp1:
           name: "unit"
           attr: 3 
@@ -18,7 +18,7 @@ mesh:
           attr: 1
         comp2_configuration: [0.0, 2.0, 0.0, 0.0, 0.0, 0.0]
       - name: "port2"
-        file: "port2.h5"
+        file: "port2.2d.h5"
         comp1:
           name: "unit"
           attr: 2 

--- a/test/inputs/test_topol.3d.yml
+++ b/test/inputs/test_topol.3d.yml
@@ -9,7 +9,6 @@ mesh:
         file: "meshes/test.1x1x1.hex.mesh"
     ports:
       - name: "port1"
-        file: "port1.h5"
         comp1:
           name: "cube"
           attr: 3 
@@ -18,7 +17,6 @@ mesh:
           attr: 5
         comp2_configuration: [0.5, 0.0, 0.0, 0.0, 0.0, 0.0]
       - name: "port2"
-        file: "port2.h5"
         comp1:
           name: "cube"
           attr: 4
@@ -27,7 +25,6 @@ mesh:
           attr: 2
         comp2_configuration: [0.0, 0.5, 0.0, 0.0, 0.0, 0.0]
       - name: "port3"
-        file: "port3.h5"
         comp1:
           name: "cube"
           attr: 6

--- a/test/mms_suite.hpp
+++ b/test/mms_suite.hpp
@@ -10,6 +10,7 @@
 #include "stokes_solver.hpp"
 #include "steady_ns_solver.hpp"
 #include "linelast_solver.hpp"
+#include "advdiff_solver.hpp"
 #include <fstream>
 #include <iostream>
 #include <cmath>
@@ -89,6 +90,30 @@ LinElastSolver *SolveWithRefinement(const int num_refinement);
 void CheckConvergence();
 
 }  // namespace linelast
+
+namespace advdiff
+{
+
+static const double pi = 4.0 * atan(1.0);
+// solution parameters
+static double amp[3];
+static double L[3];
+static double offset[3];
+static double constant;
+// flow parameters
+static double Pe;
+static double du;
+static double wn;
+static double uoffset[3];
+static double u0, v0;
+
+double ExactSolution(const Vector &);
+void ExactFlow(const Vector &, Vector &);
+double ExactRHS(const Vector &);
+AdvDiffSolver *SolveWithRefinement(const int num_refinement);
+void CheckConvergence();
+
+}  // namespace advdiff
 
 namespace fem
 {

--- a/test/test_topol.cpp
+++ b/test/test_topol.cpp
@@ -62,6 +62,9 @@ TEST(PortReadWrite_test, Test_topol)
 {
    config = InputParser("inputs/test_topol.3d.yml");
    config.dict_["mesh"]["component-wise"]["write_ports"] = true;
+   config.dict_["mesh"]["component-wise"]["ports"][0]["file"] = "port1.3d.h5";
+   config.dict_["mesh"]["component-wise"]["ports"][1]["file"] = "port2.3d.h5";
+   config.dict_["mesh"]["component-wise"]["ports"][2]["file"] = "port3.3d.h5";
 
    printf("Generate\n");
    ComponentTopologyHandler *old = new ComponentTopologyHandler();


### PR DESCRIPTION
# libROM [PR #274](https://github.com/LLNL/libROM/pull/274) update

- dataset name change for libROM snapshot matrix files: dataset suffix `_000000` is removed.
- Enforced the use of `CAROM::Dataset::formats`

# MFEM [v 4.6](https://github.com/mfem/mfem/releases/tag/v4.6) update

## `MUMPSSolver` changes

- `MUMPSSolver` initialization requires `MPI_Comm`
- `MUMPSSolver::MatType` is changed.
  - Now `StokesSolver` should use `MUMPSSolver::MatType::SYMMETRIC_INDEFINITE`.
  - `StokesSolver::SetupMUMPSSolver` takes input argument `bool set_oper` and uses `MUMPSSolver::SetOperator` only if `set_oper` is true. For `SteadyNSSolver`, `set_oper` is set `false`.

## `SubMesh` changes

- `SubMesh` does not use `SubMesh::GENERATED_ATTRIBUTE` any more for the generated boundaries of submeshes, instead `parent.bdr_attributes.Max() + 1`.
- Reflecting this, boundary attributes for interfaces are set from `parent.bdr_attributes.Max() + 2`, both for `SubMeshTopologyHandler` and `ComponentTopologyHandler`.
- Minor fix in `ComponentTopologyHandler::SetupReferencePorts`: the input `mesh/component-wise/ports/.../file` for port file name is optional.

# Advection-diffusion equation

- `AdvDiffSolver` solves the advection-diffusion equation given a Peclet number.
- The velocity field must be provided either in analytic form or with a solution from `StokesSolver` or `SteadyNSSolver`.
- Currently `StokesSolver` or `SteadyNSSolver` only provides FOM velocity field.
  - This limits ROM for `AdvDiffSolver` to be always built from a global system. Fully component-wise ROM for `AdvDiffSolver` requires taking velocity POD basis from `StokesSolver` or `SteadyNSSolver`.