### PR TITLE
HyperReductionIntegrators for unsteady Navier-Stokes equation

### DIFF
--- a/include/hyperreduction_integ.hpp
+++ b/include/hyperreduction_integ.hpp
@@ -176,6 +176,9 @@ private:
    DenseMatrix dshape, dshapex, EF, uu, ELV, elmat_comp;
    Vector shape;
 
+   // precomputed basis value at the sample point.
+   Array<DenseMatrix *> shapes;
+   Array<Array<DenseMatrix *> *> dshapes;
 public:
    IncompressibleInviscidFluxNLFIntegrator(Coefficient &q)
       : HyperReductionIntegrator(true), Q(&q) { }
@@ -208,6 +211,17 @@ public:
                               const double &iw,
                               const Vector &elfun,
                               DenseMatrix &elmat);
+
+   void AppendPrecomputeDomainCoeffs(const FiniteElementSpace *fes,
+                                    DenseMatrix &basis,
+                                    const SampleInfo &sample) override;
+
+   void AddAssembleVector_Fast(const int s, const double qw,
+                                 ElementTransformation &T, const IntegrationPoint &ip,
+                                 const Vector &x, Vector &y) override;
+   void AddAssembleGrad_Fast(const int s, const double qw,
+                              ElementTransformation &T, const IntegrationPoint &ip,
+                              const Vector &x, DenseMatrix &jac) override;
 };
 
 /*

--- a/include/hyperreduction_integ.hpp
+++ b/include/hyperreduction_integ.hpp
@@ -243,6 +243,14 @@ public:
                                  const Vector &eltest,
                                  Vector &elquad) override;
 
+   void AssembleQuadratureGrad(const FiniteElement &el1,
+                              const FiniteElement &el2,
+                              FaceElementTransformations &T,
+                              const IntegrationPoint &ip,
+                              const double &iw,
+                              const Vector &eltest,
+                              DenseMatrix &quadmat) override;
+
 };
 
 } // namespace mfem

--- a/include/hyperreduction_integ.hpp
+++ b/include/hyperreduction_integ.hpp
@@ -195,6 +195,13 @@ public:
                                  const double &iw,
                                  const Vector &eltest,
                                  Vector &elquad) override;
+
+   void AssembleQuadratureGrad(const FiniteElement &el,
+                              ElementTransformation &trans,
+                              const IntegrationPoint &ip,
+                              const double &iw,
+                              const Vector &elfun,
+                              DenseMatrix &elmat);
 };
 
 /*

--- a/include/hyperreduction_integ.hpp
+++ b/include/hyperreduction_integ.hpp
@@ -188,6 +188,13 @@ public:
                            ElementTransformation &trans,
                            const Vector &elfun,
                            DenseMatrix &elmat) override;
+
+   void AssembleQuadratureVector(const FiniteElement &el,
+                                 ElementTransformation &T,
+                                 const IntegrationPoint &ip,
+                                 const double &iw,
+                                 const Vector &eltest,
+                                 Vector &elquad) override;
 };
 
 /*

--- a/include/hyperreduction_integ.hpp
+++ b/include/hyperreduction_integ.hpp
@@ -263,6 +263,9 @@ public:
    void AppendPrecomputeInteriorFaceCoeffs(const FiniteElementSpace *fes,
                                        DenseMatrix &basis,
                                        const SampleInfo &sample) override;
+   void AppendPrecomputeBdrFaceCoeffs(const FiniteElementSpace *fes,
+                                    DenseMatrix &basis,
+                                    const SampleInfo &sample) override;
 
    void AddAssembleVector_Fast(const int s, const double qw,
                               FaceElementTransformations &T, const IntegrationPoint &ip,
@@ -270,6 +273,12 @@ public:
    void AddAssembleGrad_Fast(const int s, const double qw,
                            FaceElementTransformations &T, const IntegrationPoint &ip,
                            const Vector &x, DenseMatrix &jac) override;
+
+private:
+   void AppendPrecomputeFaceCoeffs(const FiniteElementSpace *fes, 
+                                    FaceElementTransformations *T,
+                                    DenseMatrix &basis,
+                                    const SampleInfo &sample);
 
 };
 

--- a/include/hyperreduction_integ.hpp
+++ b/include/hyperreduction_integ.hpp
@@ -221,6 +221,14 @@ public:
                            FaceElementTransformations &Tr,
                            const Vector &elfun, DenseMatrix &elmat) override;
 
+   void AssembleQuadratureVector(const FiniteElement &el1,
+                                 const FiniteElement &el2,
+                                 FaceElementTransformations &T,
+                                 const IntegrationPoint &ip,
+                                 const double &iw,
+                                 const Vector &eltest,
+                                 Vector &elquad) override;
+
 };
 
 } // namespace mfem

--- a/include/hyperreduction_integ.hpp
+++ b/include/hyperreduction_integ.hpp
@@ -222,9 +222,9 @@ private:
    double w, un1, un2, un;
    Coefficient *Q{};
 
-   Vector nor, flux, shape1, shape2, u1, u2;
+   Vector nor, flux, shape1, shape2, u1, u2, tmp_vec;
    DenseMatrix udof1, udof2, elv1, elv2;
-   DenseMatrix elmat_comp11, elmat_comp12, elmat_comp21, elmat_comp22;
+   DenseMatrix elmat_comp11, elmat_comp12, elmat_comp21, elmat_comp22, tmp;
 
    // precomputed basis value at the sample point.
    Array<DenseMatrix *> shapes1, shapes2;

--- a/include/hyperreduction_integ.hpp
+++ b/include/hyperreduction_integ.hpp
@@ -64,7 +64,13 @@ public:
                                        const Vector &eltest,
                                        DenseMatrix &quadmat);
 
-   virtual void AppendPrecomputeCoefficients(const FiniteElementSpace *fes,
+   virtual void AppendPrecomputeDomainCoeffs(const FiniteElementSpace *fes,
+                                             DenseMatrix &basis,
+                                             const SampleInfo &sample);
+   virtual void AppendPrecomputeInteriorFaceCoeffs(const FiniteElementSpace *fes,
+                                                   DenseMatrix &basis,
+                                                   const SampleInfo &sample);
+   virtual void AppendPrecomputeBdrFaceCoeffs(const FiniteElementSpace *fes,
                                              DenseMatrix &basis,
                                              const SampleInfo &sample);
 
@@ -146,7 +152,7 @@ public:
                                        const Vector &elfun,
                                        DenseMatrix &elmat) override;
 
-   virtual void AppendPrecomputeCoefficients(const FiniteElementSpace *fes,
+   virtual void AppendPrecomputeDomainCoeffs(const FiniteElementSpace *fes,
                                              DenseMatrix &basis,
                                              const SampleInfo &sample) override;
 
@@ -219,6 +225,9 @@ private:
    Vector nor, flux, shape1, shape2, u1, u2;
    DenseMatrix udof1, udof2, elv1, elv2;
    DenseMatrix elmat_comp11, elmat_comp12, elmat_comp21, elmat_comp22;
+
+   // precomputed basis value at the sample point.
+   Array<DenseMatrix *> shapes1, shapes2;
 public:
    DGLaxFriedrichsFluxIntegrator(Coefficient &q)
       : HyperReductionIntegrator(true), Q(&q) {}
@@ -250,6 +259,17 @@ public:
                               const double &iw,
                               const Vector &eltest,
                               DenseMatrix &quadmat) override;
+
+   void AppendPrecomputeInteriorFaceCoeffs(const FiniteElementSpace *fes,
+                                       DenseMatrix &basis,
+                                       const SampleInfo &sample) override;
+
+   void AddAssembleVector_Fast(const int s, const double qw,
+                              FaceElementTransformations &T, const IntegrationPoint &ip,
+                              const Vector &x, Vector &y) override;
+   void AddAssembleGrad_Fast(const int s, const double qw,
+                           FaceElementTransformations &T, const IntegrationPoint &ip,
+                           const Vector &x, DenseMatrix &jac) override;
 
 };
 

--- a/src/hyperreduction_integ.cpp
+++ b/src/hyperreduction_integ.cpp
@@ -1383,6 +1383,7 @@ void DGLaxFriedrichsFluxIntegrator::AddAssembleGrad_Fast(
    flux.SetSize(dim);
    u1.SetSize(dim);
    elmat_comp11.SetSize(dim);
+   elmat_comp11 = 0.0;
    tmp.SetSize(dim, nbasis);
 
    if (el2)
@@ -1391,6 +1392,10 @@ void DGLaxFriedrichsFluxIntegrator::AddAssembleGrad_Fast(
       elmat_comp12.SetSize(dim);
       elmat_comp21.SetSize(dim);
       elmat_comp22.SetSize(dim);
+
+      elmat_comp12 = 0.0;
+      elmat_comp21 = 0.0;
+      elmat_comp22 = 0.0;
    }
 
    double w = qw * T.Weight();
@@ -1405,6 +1410,11 @@ void DGLaxFriedrichsFluxIntegrator::AddAssembleGrad_Fast(
    {
       CalcOrtho(T.Jacobian(), nor);
    }
+
+   nor *= w;
+
+   shapes1[s]->Mult(x, u1);
+   if (el2) shapes2[s]->Mult(x, u2);
 
    un1 = nor * u1;
    un2 = (el2) ? nor * u2 : 0.0;

--- a/src/hyperreduction_integ.cpp
+++ b/src/hyperreduction_integ.cpp
@@ -1378,10 +1378,20 @@ void DGLaxFriedrichsFluxIntegrator::AddAssembleGrad_Fast(
    // const IntegrationPoint &eip2 = T.GetElement2IntPoint();
 
    dim = shapes1[s]->NumRows();
+   int nbasis = shapes1[s]->NumCols();
    nor.SetSize(dim);
    flux.SetSize(dim);
    u1.SetSize(dim);
-   if (el2) u2.SetSize(dim);
+   elmat_comp11.SetSize(dim);
+   tmp.SetSize(dim, nbasis);
+
+   if (el2)
+   {
+      u2.SetSize(dim);
+      elmat_comp12.SetSize(dim);
+      elmat_comp21.SetSize(dim);
+      elmat_comp22.SetSize(dim);
+   }
 
    double w = qw * T.Weight();
    if (Q) 
@@ -1396,36 +1406,99 @@ void DGLaxFriedrichsFluxIntegrator::AddAssembleGrad_Fast(
       CalcOrtho(T.Jacobian(), nor);
    }
 
-   // {
-   //    dim = shapes[s]->NumRows();
-   //    int nbasis = shapes[s]->NumCols();
-   //    Vector vec1(dim), vec2(dim);
-   //    shapes[s]->Mult(x, vec1);
-   //    Array<DenseMatrix *> *gradEFs = dshapes[s];
+   un1 = nor * u1;
+   un2 = (el2) ? nor * u2 : 0.0;
 
-   //    gradEF.SetSize(dim);
-   //    gradEF = 0.0;
-   //    for (int k = 0; k < gradEFs->Size(); k++)
-   //       gradEF.Add(x(k), *((*gradEFs)[k]));
-   //    gradEF *= w;
+   un = max( abs(un1), abs(un2) );
+   double sgn = 0.0;
+   bool u1_lg_u2 = (abs(un1) >= abs(un2));
+   if (u1_lg_u2)
+   {
+      sgn = (un1 >= 0.0) ? 1.0 : -1.0;
+   }
+   else
+   {
+      sgn = (un2 >= 0.0) ? 1.0 : -1.0;
+   }
 
-   //    ELV.SetSize(dim, nbasis);
-   //    Mult(gradEF, *shapes[s], ELV);
+   double factor = 1.0;
+   if (el2)
+   {
+      un1 *= 0.5;
+      un2 *= 0.5;
+      factor = 0.5;
+   }
 
-   //    for (int k = 0; k < nbasis; k++)
-   //    {
-   //       ELV.GetColumnReference(k, vec2);
-   //       (*gradEFs)[k]->AddMult(vec1, vec2, w);
-   //    }
+   for (int di = 0; di < dim; di++)
+   {
+      elmat_comp11(di, di) += un1 + un;
+      if (el2)
+      {
+         elmat_comp21(di, di) += -un1 - un;
+         elmat_comp12(di, di) += un2 - un;
+         elmat_comp22(di, di) += -un2 + un;
+      }
+   }
 
-   //    Vector jac_col;
-   //    for (int k = 0; k < nbasis; k++)
-   //    {
-   //       jac.GetColumnReference(k, jac_col);
-   //       ELV.GetColumnReference(k, vec2);
-   //       shapes[s]->AddMultTranspose(vec2, jac_col);
-   //    }
-   // }
+   AddMult_a_VWt(factor, u1, nor, elmat_comp11);
+   if (el2)
+   {
+      AddMult_a_VWt(-factor, u1, nor, elmat_comp21);
+      AddMult_a_VWt(factor, u2, nor, elmat_comp12);
+      AddMult_a_VWt(-factor, u2, nor, elmat_comp22);
+   }
+
+   // [ u ] = u1 - u2
+   if (ndofs2)
+      u1.Add(-1.0, u2);
+
+   if (u1_lg_u2)
+   {
+      AddMult_a_VWt(sgn, u1, nor, elmat_comp11);
+      if (el2)
+         AddMult_a_VWt(-sgn, u1, nor, elmat_comp21);
+   }
+   else
+   {
+      AddMult_a_VWt(sgn, u1, nor, elmat_comp12);
+      AddMult_a_VWt(-sgn, u1, nor, elmat_comp22);
+   }
+
+   Mult(elmat_comp11, *shapes1[s], tmp);
+   Vector jac_col;
+   for (int k = 0; k < nbasis; k++)
+   {
+      jac.GetColumnReference(k, jac_col);
+      tmp.GetColumnReference(k, tmp_vec);
+      shapes1[s]->AddMultTranspose(tmp_vec, jac_col);
+   }
+
+   if (el2)
+   {
+      Mult(elmat_comp12, *shapes2[s], tmp);
+      for (int k = 0; k < nbasis; k++)
+      {
+         jac.GetColumnReference(k, jac_col);
+         tmp.GetColumnReference(k, tmp_vec);
+         shapes1[s]->AddMultTranspose(tmp_vec, jac_col);
+      }
+
+      Mult(elmat_comp21, *shapes1[s], tmp);
+      for (int k = 0; k < nbasis; k++)
+      {
+         jac.GetColumnReference(k, jac_col);
+         tmp.GetColumnReference(k, tmp_vec);
+         shapes2[s]->AddMultTranspose(tmp_vec, jac_col);
+      }
+
+      Mult(elmat_comp22, *shapes2[s], tmp);
+      for (int k = 0; k < nbasis; k++)
+      {
+         jac.GetColumnReference(k, jac_col);
+         tmp.GetColumnReference(k, tmp_vec);
+         shapes2[s]->AddMultTranspose(tmp_vec, jac_col);
+      }
+   }
 }
 
 }

--- a/src/hyperreduction_integ.cpp
+++ b/src/hyperreduction_integ.cpp
@@ -1077,4 +1077,163 @@ void DGLaxFriedrichsFluxIntegrator::AssembleQuadratureVector(
       AddMult_a_VWt(-1.0, shape2, flux, elv2);
 }
 
+void DGLaxFriedrichsFluxIntegrator::AssembleQuadratureGrad(
+   const FiniteElement &el1, const FiniteElement &el2, FaceElementTransformations &T,
+   const IntegrationPoint &ip, const double &iw, const Vector &eltest, DenseMatrix &quadmat)
+{
+   dim = el1.GetDim();
+   ndofs1 = el1.GetDof();
+   ndofs2 = (T.Elem2No >= 0) ? el2.GetDof() : 0;
+   nvdofs = dim * (ndofs1 + ndofs2);
+   quadmat.SetSize(nvdofs);
+   elmat_comp11.SetSize(ndofs1);
+
+   nor.SetSize(dim);
+   flux.SetSize(dim);
+
+   udof1.UseExternalData(eltest.GetData(), ndofs1, dim);
+   shape1.SetSize(ndofs1);
+   u1.SetSize(dim);  
+
+   if (ndofs2)
+   {
+      udof2.UseExternalData(eltest.GetData() + ndofs1 * dim, ndofs2, dim);
+      shape2.SetSize(ndofs2);
+      u2.SetSize(dim);
+
+      elmat_comp12.SetSize(ndofs1, ndofs2);
+      elmat_comp21.SetSize(ndofs2, ndofs1);
+      elmat_comp22.SetSize(ndofs2);
+   }
+
+   const IntegrationRule *ir = IntRule;
+   if (ir == NULL)
+   {
+      // a simple choice for the integration order; is this OK?
+      const int order = (int)(ceil(1.5 * (2 * max(el1.GetOrder(), ndofs2 ? el2.GetOrder() : 0) - 1)));
+      ir = &IntRules.Get(T.GetGeometryType(), order);
+   } 
+
+   quadmat = 0.0;
+
+   // Set the integration point in the face and the neighboring elements
+   T.SetAllIntPoints(&ip);
+
+   // Access the neighboring elements' integration points
+   // Note: eip2 will only contain valid data if Elem2 exists
+   const IntegrationPoint &eip1 = T.GetElement1IntPoint();
+   const IntegrationPoint &eip2 = T.GetElement2IntPoint();
+
+   el1.CalcShape(eip1, shape1);
+   udof1.MultTranspose(shape1, u1);
+
+   if (dim == 1)
+   {
+      nor(0) = 2*eip1.x - 1.0;
+   }
+   else
+   {
+      CalcOrtho(T.Jacobian(), nor);
+   }
+
+   if (ndofs2)
+   {
+      el2.CalcShape(eip2, shape2);
+      udof2.MultTranspose(shape2, u2);
+   }
+
+   w = iw * T.Weight();
+   if (Q) { w *= Q->Eval(T, ip); }
+
+   nor *= w;
+   // Just for the average operator gradient.
+   if (ndofs2)
+      nor *= 0.5;
+
+   un1 = nor * u1;
+   un2 = (ndofs2) ? nor * u2 : 0.0;
+
+   MultVVt(shape1, elmat_comp11);
+   if (ndofs2)
+   {
+      MultVWt(shape1, shape2, elmat_comp12);
+      elmat_comp21.Transpose(elmat_comp12);
+      // MultVWt(shape2, shape1, elmat_comp21);
+      MultVVt(shape2, elmat_comp22);
+   }
+
+   for (int di = 0; di < dim; di++)
+   {
+      quadmat.AddMatrix(un1, elmat_comp11, di * ndofs1, di * ndofs1);
+      if (ndofs2)
+      {
+         quadmat.AddMatrix(-un1, elmat_comp21, di * ndofs2 + dim * ndofs1, di * ndofs1);
+         quadmat.AddMatrix(un2, elmat_comp12, di * ndofs1, di * ndofs2 + dim * ndofs1);
+         quadmat.AddMatrix(-un2, elmat_comp22, di * ndofs2 + dim * ndofs1, di * ndofs2 + dim * ndofs1);
+      }
+
+      for (int dj = 0; dj < dim; dj++)
+      {
+         quadmat.AddMatrix(u1(di) * nor(dj), elmat_comp11, di * ndofs1, dj * ndofs1);
+         if (ndofs2)
+         {
+            quadmat.AddMatrix(-u1(di) * nor(dj), elmat_comp21, di * ndofs2 + dim * ndofs1, dj * ndofs1);
+            quadmat.AddMatrix(u2(di) * nor(dj), elmat_comp12, di * ndofs1, dj * ndofs2 + dim * ndofs1);
+            quadmat.AddMatrix(-u2(di) * nor(dj), elmat_comp22, di * ndofs2 + dim * ndofs1, dj * ndofs2 + dim * ndofs1);
+         }
+      }
+   }
+
+   // Recover 1/2 factor on normal vector.
+   if (ndofs2)
+      nor *= 2.0;
+
+   // un1 as maximum absolute eigenvalue, un2 as the sign.
+   un = max( abs(un1), abs(un2) );
+   if (ndofs2) un *= 2.0;
+   
+   double sgn = 0.0;
+   bool u1_lg_u2 = (abs(un1) >= abs(un2));
+   if (u1_lg_u2)
+   {
+      sgn = (un1 >= 0.0) ? 1.0 : -1.0;
+   }
+   else
+   {
+      sgn = (un2 >= 0.0) ? 1.0 : -1.0;
+   }
+
+   // [ u ] = u1 - u2
+   if (ndofs2)
+      u1.Add(-1.0, u2);
+
+   for (int di = 0; di < dim; di++)
+   {
+      quadmat.AddMatrix(un, elmat_comp11, di * ndofs1, di * ndofs1);
+      if (ndofs2)
+      {
+         quadmat.AddMatrix(-un, elmat_comp21, di * ndofs2 + dim * ndofs1, di * ndofs1);
+         quadmat.AddMatrix(-un, elmat_comp12, di * ndofs1, di * ndofs2 + dim * ndofs1);
+         quadmat.AddMatrix(un, elmat_comp22, di * ndofs2 + dim * ndofs1, di * ndofs2 + dim * ndofs1);
+      }
+
+      // remember u1 in this loop is in fact [ u ] = u1 - u2.
+      for (int dj = 0; dj < dim; dj++)
+      {
+         if (u1_lg_u2)
+         {
+            quadmat.AddMatrix(sgn * u1(di) * nor(dj), elmat_comp11, di * ndofs1, dj * ndofs1);
+            if (ndofs2)
+               quadmat.AddMatrix(-sgn * u1(di) * nor(dj), elmat_comp21, di * ndofs2 + dim * ndofs1, dj * ndofs1);
+         }
+         else
+         {
+            assert(ndofs2);
+            quadmat.AddMatrix(sgn * u1(di) * nor(dj), elmat_comp12, di * ndofs1, dj * ndofs2 + dim * ndofs1);
+            quadmat.AddMatrix(-sgn * u1(di) * nor(dj), elmat_comp22, di * ndofs2 + dim * ndofs1, dj * ndofs2 + dim * ndofs1);
+         }
+      }
+   }
+}
+
 }

--- a/src/rom_nonlinearform.cpp
+++ b/src/rom_nonlinearform.cpp
@@ -588,7 +588,7 @@ void ROMNonlinearForm::PrecomputeCoefficients()
 
          SampleInfo *sample = sample_info->GetData();
          for (int i = 0; i < sample_info->Size(); i++, sample++)
-            dnfi[k]->AppendPrecomputeCoefficients(fes, *basis, *sample);
+            dnfi[k]->AppendPrecomputeDomainCoeffs(fes, *basis, *sample);
       }  // for (int k = 0; k < dnfi.Size(); k++)
    }  // if (dnfi.Size())
 
@@ -601,7 +601,7 @@ void ROMNonlinearForm::PrecomputeCoefficients()
 
          SampleInfo *sample = sample_info->GetData();
          for (int i = 0; i < sample_info->Size(); i++, sample++)
-            fnfi[k]->AppendPrecomputeCoefficients(fes, *basis, *sample);
+            fnfi[k]->AppendPrecomputeInteriorFaceCoeffs(fes, *basis, *sample);
       }  // for (int k = 0; k < fnfi.Size(); k++)
    }  // if (fnfi.Size())
 
@@ -649,7 +649,7 @@ void ROMNonlinearForm::PrecomputeCoefficients()
                // continue;
             }
 
-            bfnfi[k]->AppendPrecomputeCoefficients(fes, *basis, *sample);
+            bfnfi[k]->AppendPrecomputeBdrFaceCoeffs(fes, *basis, *sample);
          }  // for (int i = 0; i < sample_info->Size(); i++, sample++)
       }  // for (int k = 0; k < bfnfi.Size(); k++)
    }  // if (bfnfi.Size())

--- a/src/rom_nonlinearform.cpp
+++ b/src/rom_nonlinearform.cpp
@@ -638,7 +638,8 @@ void ROMNonlinearForm::PrecomputeCoefficients()
          for (int i = 0; i < sample_info->Size(); i++, sample++)
          {
             int be = sample->be;
-            const int bdr_attr = mesh->GetBdrAttribute(i);
+
+            const int bdr_attr = mesh->GetBdrAttribute(be);
             if (bfnfi_marker[k] &&
                    (*bfnfi_marker[k])[bdr_attr-1] == 0)
             { 
@@ -717,13 +718,16 @@ void ROMNonlinearForm::TrainEQP(const CAROM::Matrix &snapshots, const double eqp
       bdr_attr_marker = 0;
       if (bfnfi_marker[k] == NULL)
          bdr_attr_marker = 1;
-      Array<int> &bdr_marker = *bfnfi_marker[k];
-      MFEM_ASSERT(bdr_marker.Size() == bdr_attr_marker.Size(),
-                  "invalid boundary marker for boundary face integrator #"
-                  << k << ", counting from zero");
-      for (int i = 0; i < bdr_attr_marker.Size(); i++)
+      else
       {
-         bdr_attr_marker[i] |= bdr_marker[i];
+         Array<int> &bdr_marker = *bfnfi_marker[k];
+         MFEM_ASSERT(bdr_marker.Size() == bdr_attr_marker.Size(),
+                     "invalid boundary marker for boundary face integrator #"
+                     << k << ", counting from zero");
+         for (int i = 0; i < bdr_attr_marker.Size(); i++)
+         {
+            bdr_attr_marker[i] |= bdr_marker[i];
+         }
       }
 
       SetupEQPSystemForBdrFaceIntegrator(snapshots_work, bfnfi[k], bdr_attr_marker, Gt, rhs_Gw, fidxs);
@@ -959,8 +963,6 @@ void ROMNonlinearForm::SetupEQPSystemForInteriorFaceIntegrator(
    const CAROM::Matrix &snapshots, HyperReductionIntegrator *nlfi, 
    CAROM::Matrix &Gt, CAROM::Vector &rhs_Gw, Array<int> &fidxs)
 {
-   mfem_warning("ROMNonlinearForm::SetupEQPSystemForInteriorFaceIntegrator- this routine is not tested. Set up a test routine in test/test_rom_nonlinearform.cpp.\n");
-
    /*
       TODO(kevin): this is a boilerplate for parallel POD/EQP training.
       Full parallelization will have to consider local matrix construction from local snapshot/basis matrix.
@@ -1089,8 +1091,6 @@ void ROMNonlinearForm::SetupEQPSystemForBdrFaceIntegrator(
    const CAROM::Matrix &snapshots, HyperReductionIntegrator *nlfi, const Array<int> &bdr_attr_marker,
    CAROM::Matrix &Gt, CAROM::Vector &rhs_Gw, Array<int> &bidxs)
 {
-   mfem_warning("ROMNonlinearForm::SetupEQPSystemForBdrFaceIntegrator- this routine is not tested. Set up a test routine in test/test_rom_nonlinearform.cpp.\n");
-
    /*
       TODO(kevin): this is a boilerplate for parallel POD/EQP training.
       Full parallelization will have to consider local matrix construction from local snapshot/basis matrix.

--- a/src/rom_nonlinearform.cpp
+++ b/src/rom_nonlinearform.cpp
@@ -237,7 +237,7 @@ void ROMNonlinearForm::Mult(const Vector &x, Vector &y) const
          for (int i = 0; i < sample_info->Size(); i++, sample++)
          {
             int be = sample->be;
-            const int bdr_attr = mesh->GetBdrAttribute(i);
+            const int bdr_attr = mesh->GetBdrAttribute(be);
             if (bfnfi_marker[k] &&
                    (*bfnfi_marker[k])[bdr_attr-1] == 0)
             { 
@@ -494,7 +494,7 @@ Operator& ROMNonlinearForm::GetGradient(const Vector &x) const
          for (int i = 0; i < sample_info->Size(); i++, sample++)
          {
             int be = sample->be;
-            const int bdr_attr = mesh->GetBdrAttribute(i);
+            const int bdr_attr = mesh->GetBdrAttribute(be);
             if (bfnfi_marker[k] &&
                    (*bfnfi_marker[k])[bdr_attr-1] == 0)
             { 

--- a/test/test_rom_nonlinearform.cpp
+++ b/test/test_rom_nonlinearform.cpp
@@ -675,39 +675,39 @@ TEST(ROMNonlinearForm_fast, DGLaxFriedrichsFluxIntegrator)
    for (int k = 0; k < rom_y.Size(); k++)
       EXPECT_NEAR(rom_y(k), rom_yfast(k), threshold);
 
-   // DenseMatrix *jac = dynamic_cast<DenseMatrix *>(&(rform->GetGradient(rom_u)));
+   DenseMatrix *jac = dynamic_cast<DenseMatrix *>(&(rform->GetGradient(rom_u)));
 
-   // double J0 = 0.5 * (rom_y * rom_y);
-   // Vector grad(num_basis);
-   // jac->MultTranspose(rom_y, grad);
-   // double gg = sqrt(grad * grad);
-   // printf("J0: %.15E\n", J0);
-   // printf("grad: %.15E\n", gg);
+   double J0 = 0.5 * (rom_y * rom_y);
+   Vector grad(num_basis);
+   jac->MultTranspose(rom_y, grad);
+   double gg = sqrt(grad * grad);
+   printf("J0: %.15E\n", J0);
+   printf("grad: %.15E\n", gg);
 
-   // Vector du(grad);
-   // du /= gg;
+   Vector du(grad);
+   du /= gg;
 
-   // Vector rom_y1(num_basis);
-   // const int Nk = 40;
-   // double error1 = 1e100, error;
-   // printf("amp\tJ1\tdJdx\terror\n");
-   // for (int k = 0; k < Nk; k++)
-   // {
-   //    double amp = pow(10.0, -0.25 * k);
-   //    Vector rom_u1(rom_u);
-   //    rom_u1.Add(amp, du);
+   Vector rom_y1(num_basis);
+   const int Nk = 40;
+   double error1 = 1e100, error;
+   printf("amp\tJ1\tdJdx\terror\n");
+   for (int k = 0; k < Nk; k++)
+   {
+      double amp = pow(10.0, -0.25 * k);
+      Vector rom_u1(rom_u);
+      rom_u1.Add(amp, du);
 
-   //    rform->Mult(rom_u1, rom_y1);
-   //    double J1 = 0.5 * (rom_y1 * rom_y1);
-   //    double dJdx = (J1 - J0) / amp;
-   //    error = abs(dJdx - gg) / gg;
+      rform->Mult(rom_u1, rom_y1);
+      double J1 = 0.5 * (rom_y1 * rom_y1);
+      double dJdx = (J1 - J0) / amp;
+      error = abs(dJdx - gg) / gg;
 
-   //    printf("%.5E\t%.5E\t%.5E\t%.5E\n", amp, J1, dJdx, error);
-   //    if (error >= error1)
-   //       break;
-   //    error1 = error;
-   // }
-   // EXPECT_TRUE(min(error, error1) < grad_thre);
+      printf("%.5E\t%.5E\t%.5E\t%.5E\n", amp, J1, dJdx, error);
+      if (error >= error1)
+         break;
+      error1 = error;
+   }
+   EXPECT_TRUE(min(error, error1) < grad_thre);
 
    delete mesh;
    delete dg_coll;

--- a/test/test_rom_nonlinearform.cpp
+++ b/test/test_rom_nonlinearform.cpp
@@ -87,6 +87,76 @@ TEST(ROMNonlinearForm, VectorConvectionTrilinearFormIntegrator)
    return;
 }
 
+TEST(ROMNonlinearForm, IncompressibleInviscidFluxNLFIntegrator)
+{
+   Mesh *mesh = new Mesh("meshes/test.4x4.mesh");
+   const int dim = mesh->Dimension();
+   const int order = UniformRandom(1, 3);
+
+   FiniteElementCollection *dg_coll(new DG_FECollection(order, dim));
+   FiniteElementSpace *fes(new FiniteElementSpace(mesh, dg_coll, dim));
+   const int ndofs = fes->GetTrueVSize();
+
+   const int num_basis = 10;
+   // a fictitious basis.
+   DenseMatrix basis(ndofs, num_basis);
+   for (int i = 0; i < ndofs; i++)
+      for (int j = 0; j < num_basis; j++)
+         basis(i, j) = UniformRandom();
+
+   IntegrationRule ir = IntRules.Get(fes->GetFE(0)->GetGeomType(),
+                                    (int)(ceil(1.5 * (2 * fes->GetMaxElementOrder() - 1))));
+   ConstantCoefficient pi(3.141592);
+   auto *integ1 = new IncompressibleInviscidFluxNLFIntegrator(pi);
+   integ1->SetIntRule(&ir);
+   auto *integ2 = new IncompressibleInviscidFluxNLFIntegrator(pi);
+   integ2->SetIntRule(&ir);
+
+   NonlinearForm *nform(new NonlinearForm(fes));
+   nform->AddDomainIntegrator(integ1);
+
+   ROMNonlinearForm *rform(new ROMNonlinearForm(num_basis, fes));
+   rform->AddDomainIntegrator(integ2);
+   rform->SetBasis(basis);
+
+   // we set the full elements/quadrature points,
+   // so that the resulting vector is equilvalent to FOM.
+   const int nqe = ir.GetNPoints();
+   const int ne = fes->GetNE();
+   Array<double> const& w_el = ir.GetWeights();
+   Array<int> sample_el(ne * nqe), sample_qp(ne * nqe);
+   Array<double> sample_qw(ne * nqe);
+   for (int e = 0, idx = 0; e < ne; e++)
+      for (int q = 0; q < nqe; q++, idx++)
+      {
+         sample_el[idx] = e;
+         sample_qp[idx] = q;
+         sample_qw[idx] = w_el[q];
+      }
+   rform->UpdateDomainIntegratorSampling(0, sample_el, sample_qp, sample_qw);
+
+   Vector rom_u(num_basis), u(fes->GetTrueVSize());
+   for (int k = 0; k < rom_u.Size(); k++)
+      rom_u(k) = UniformRandom();
+
+   basis.Mult(rom_u, u);
+
+   Vector rom_y(num_basis), y(fes->GetTrueVSize()), Pty(num_basis);
+   nform->Mult(u, y);
+   basis.MultTranspose(y, Pty);
+   rform->Mult(rom_u, rom_y);
+
+   for (int k = 0; k < rom_y.Size(); k++)
+      EXPECT_NEAR(rom_y(k), Pty(k), 1.0e-12);
+
+   delete mesh;
+   delete dg_coll;
+   delete fes;
+   delete nform;
+   delete rform;
+   return;
+}
+
 TEST(ROMNonlinearForm, DGLaxFriedrichsFluxIntegrator)
 {
    Mesh *mesh = new Mesh("meshes/test.4x4.mesh");
@@ -131,7 +201,7 @@ TEST(ROMNonlinearForm, DGLaxFriedrichsFluxIntegrator)
    {
       tr = mesh->GetInteriorFaceTransformations(f);
       if (tr == NULL) continue;
-      
+
       for (int q = 0; q < nqe; q++)
       {
          sample_el.Append(f);

--- a/test/test_rom_nonlinearform.cpp
+++ b/test/test_rom_nonlinearform.cpp
@@ -666,39 +666,39 @@ TEST(ROMNonlinearForm_fast, IncompressibleInviscidFluxNLFIntegrator)
    for (int k = 0; k < rom_y.Size(); k++)
       EXPECT_NEAR(rom_y(k), rom_yfast(k), threshold);
 
-   // DenseMatrix *jac = dynamic_cast<DenseMatrix *>(&(rform->GetGradient(rom_u)));
+   DenseMatrix *jac = dynamic_cast<DenseMatrix *>(&(rform->GetGradient(rom_u)));
 
-   // double J0 = 0.5 * (rom_y * rom_y);
-   // Vector grad(num_basis);
-   // jac->MultTranspose(rom_y, grad);
-   // double gg = sqrt(grad * grad);
-   // printf("J0: %.15E\n", J0);
-   // printf("grad: %.15E\n", gg);
+   double J0 = 0.5 * (rom_y * rom_y);
+   Vector grad(num_basis);
+   jac->MultTranspose(rom_y, grad);
+   double gg = sqrt(grad * grad);
+   printf("J0: %.15E\n", J0);
+   printf("grad: %.15E\n", gg);
 
-   // Vector du(grad);
-   // du /= gg;
+   Vector du(grad);
+   du /= gg;
 
-   // Vector rom_y1(num_basis);
-   // const int Nk = 40;
-   // double error1 = 1e100, error;
-   // printf("amp\tJ1\tdJdx\terror\n");
-   // for (int k = 0; k < Nk; k++)
-   // {
-   //    double amp = pow(10.0, -0.25 * k);
-   //    Vector rom_u1(rom_u);
-   //    rom_u1.Add(amp, du);
+   Vector rom_y1(num_basis);
+   const int Nk = 40;
+   double error1 = 1e100, error;
+   printf("amp\tJ1\tdJdx\terror\n");
+   for (int k = 0; k < Nk; k++)
+   {
+      double amp = pow(10.0, -0.25 * k);
+      Vector rom_u1(rom_u);
+      rom_u1.Add(amp, du);
 
-   //    rform->Mult(rom_u1, rom_y1);
-   //    double J1 = 0.5 * (rom_y1 * rom_y1);
-   //    double dJdx = (J1 - J0) / amp;
-   //    error = abs(dJdx - gg) / gg;
+      rform->Mult(rom_u1, rom_y1);
+      double J1 = 0.5 * (rom_y1 * rom_y1);
+      double dJdx = (J1 - J0) / amp;
+      error = abs(dJdx - gg) / gg;
 
-   //    printf("%.5E\t%.5E\t%.5E\t%.5E\n", amp, J1, dJdx, error);
-   //    if (error >= error1)
-   //       break;
-   //    error1 = error;
-   // }
-   // EXPECT_TRUE(min(error, error1) < grad_thre);
+      printf("%.5E\t%.5E\t%.5E\t%.5E\n", amp, J1, dJdx, error);
+      if (error >= error1)
+         break;
+      error1 = error;
+   }
+   EXPECT_TRUE(min(error, error1) < grad_thre);
 
    delete mesh;
    delete dg_coll;

--- a/test/test_rom_nonlinearform.cpp
+++ b/test/test_rom_nonlinearform.cpp
@@ -412,6 +412,104 @@ TEST(ROMNonlinearForm_gradient, IncompressibleInviscidFluxNLFIntegrator)
    return;
 }
 
+TEST(ROMNonlinearForm_gradient, DGLaxFriedrichsFluxIntegrator)
+{
+   Mesh *mesh = new Mesh("meshes/test.4x4.mesh");
+   const int dim = mesh->Dimension();
+   const int order = UniformRandom(1, 3);
+
+   FiniteElementCollection *dg_coll(new DG_FECollection(order, dim));
+   FiniteElementSpace *fes(new FiniteElementSpace(mesh, dg_coll, dim));
+   const int ndofs = fes->GetTrueVSize();
+
+   const int num_basis = 10;
+   // a fictitious basis.
+   DenseMatrix basis(ndofs, num_basis);
+   for (int i = 0; i < ndofs; i++)
+      for (int j = 0; j < num_basis; j++)
+         basis(i, j) = UniformRandom();
+
+   IntegrationRule ir = IntRules.Get(fes->GetFE(0)->GetGeomType(),
+                                    (int)(ceil(1.5 * (2 * fes->GetMaxElementOrder() - 1))));
+   ConstantCoefficient pi(3.141592);
+   auto *integ = new DGLaxFriedrichsFluxIntegrator(pi);
+   integ->SetIntRule(&ir);
+
+   ROMNonlinearForm *rform(new ROMNonlinearForm(num_basis, fes));
+   rform->AddInteriorFaceIntegrator(integ);
+   rform->SetBasis(basis);
+
+   // we set some random quadrature points/weights.
+   const int nsample = UniformRandom(15, 20);
+   const int nqe = ir.GetNPoints();
+   const int nf = mesh->GetNumFaces();
+   Array<double> const& w_el = ir.GetWeights();
+   Array<int> sample_el(nsample), sample_qp(nsample);
+   Array<double> sample_qw(nsample);
+
+   int s = 0;
+   FaceElementTransformations *tr;
+   while (s < nsample)
+   {
+      int f = UniformRandom(0, nf-1);
+      tr = mesh->GetInteriorFaceTransformations(f);
+      if (tr == NULL) continue;
+
+      sample_el[s] = f;
+      sample_qp[s] = UniformRandom(0, nqe-1);
+      sample_qw[s] = UniformRandom();
+
+      s++;
+   }
+   rform->UpdateInteriorFaceIntegratorSampling(0, sample_el, sample_qp, sample_qw);
+
+   Vector rom_u(num_basis);
+   for (int k = 0; k < rom_u.Size(); k++)
+      rom_u(k) = UniformRandom();
+
+   Vector rom_y(num_basis);
+   rform->Mult(rom_u, rom_y);
+   DenseMatrix *jac = dynamic_cast<DenseMatrix *>(&(rform->GetGradient(rom_u)));
+
+   double J0 = 0.5 * (rom_y * rom_y);
+   Vector grad(num_basis);
+   jac->MultTranspose(rom_y, grad);
+   double gg = sqrt(grad * grad);
+   printf("J0: %.15E\n", J0);
+   printf("grad: %.15E\n", gg);
+
+   Vector du(grad);
+   du /= gg;
+
+   Vector rom_y1(num_basis);
+   const int Nk = 40;
+   double error1 = 1e100, error;
+   printf("amp\tJ1\tdJdx\terror\n");
+   for (int k = 0; k < Nk; k++)
+   {
+      double amp = pow(10.0, -0.25 * k);
+      Vector rom_u1(rom_u);
+      rom_u1.Add(amp, du);
+
+      rform->Mult(rom_u1, rom_y1);
+      double J1 = 0.5 * (rom_y1 * rom_y1);
+      double dJdx = (J1 - J0) / amp;
+      error = abs(dJdx - gg) / gg;
+
+      printf("%.5E\t%.5E\t%.5E\t%.5E\n", amp, J1, dJdx, error);
+      if (error >= error1)
+         break;
+      error1 = error;
+   }
+   EXPECT_TRUE(min(error, error1) < 1.0e-7);
+
+   delete mesh;
+   delete dg_coll;
+   delete fes;
+   delete rform;
+   return;
+}
+
 TEST(ROMNonlinearForm_fast, VectorConvectionTrilinearFormIntegrator)
 {
    Mesh *mesh = new Mesh("meshes/test.4x4.mesh");

--- a/test/test_rom_nonlinearform.cpp
+++ b/test/test_rom_nonlinearform.cpp
@@ -10,6 +10,9 @@
 using namespace std;
 using namespace mfem;
 
+static const double threshold = 1.0e-12;
+static const double grad_thre = 1.0e-7;
+
 /**
  * Simple smoke test to make sure Google Test is properly linked
  */
@@ -77,7 +80,7 @@ TEST(ROMNonlinearForm, VectorConvectionTrilinearFormIntegrator)
    rform->Mult(rom_u, rom_y);
 
    for (int k = 0; k < rom_y.Size(); k++)
-      EXPECT_NEAR(rom_y(k), Pty(k), 1.0e-12);
+      EXPECT_NEAR(rom_y(k), Pty(k), threshold);
 
    delete mesh;
    delete h1_coll;
@@ -147,7 +150,7 @@ TEST(ROMNonlinearForm, IncompressibleInviscidFluxNLFIntegrator)
    rform->Mult(rom_u, rom_y);
 
    for (int k = 0; k < rom_y.Size(); k++)
-      EXPECT_NEAR(rom_y(k), Pty(k), 1.0e-12);
+      EXPECT_NEAR(rom_y(k), Pty(k), threshold);
 
    delete mesh;
    delete dg_coll;
@@ -223,7 +226,7 @@ TEST(ROMNonlinearForm, DGLaxFriedrichsFluxIntegrator)
    rform->Mult(rom_u, rom_y);
 
    for (int k = 0; k < rom_y.Size(); k++)
-      EXPECT_NEAR(rom_y(k), Pty(k), 1.0e-12);
+      EXPECT_NEAR(rom_y(k), Pty(k), threshold);
 
    delete mesh;
    delete dg_coll;
@@ -564,7 +567,7 @@ TEST(ROMNonlinearForm_fast, VectorConvectionTrilinearFormIntegrator)
    rform->SetPrecomputeMode(true);
    rform->Mult(rom_u, rom_yfast);
    for (int k = 0; k < rom_y.Size(); k++)
-      EXPECT_NEAR(rom_y(k), rom_yfast(k), 1.0e-12);
+      EXPECT_NEAR(rom_y(k), rom_yfast(k), threshold);
 
    DenseMatrix *jac = dynamic_cast<DenseMatrix *>(&(rform->GetGradient(rom_u)));
 
@@ -685,7 +688,7 @@ TEST(ROMNonlinearForm, SetupEQPSystemForDomainIntegrator)
    rform->SetupEQPSystemForDomainIntegrator(carom_snapshots_work, integ2, Gt, rhs2);
 
    for (int k = 0; k < rhs1.dim(); k++)
-      EXPECT_NEAR(rhs1(k), rhs2(k), 1.0e-14);
+      EXPECT_NEAR(rhs1(k), rhs2(k), threshold);
 
    double eqp_tol = 1.0e-10;
    rform->TrainEQP(*carom_snapshots, eqp_tol);
@@ -708,10 +711,121 @@ TEST(ROMNonlinearForm, SetupEQPSystemForDomainIntegrator)
 
    for (int i = 0; i < num_basis; i++)
       for (int j = 0; j < num_snap; j++)
-         EXPECT_NEAR(rom_rhs1(i, j), rom_rhs2(i, j), 1.0e-14);
+         EXPECT_NEAR(rom_rhs1(i, j), rom_rhs2(i, j), threshold);
 
    delete mesh;
    delete h1_coll;
+   delete fes;
+   delete nform;
+   delete rform;
+}
+
+TEST(ROMNonlinearForm, SetupEQPSystemForInteriorFaceIntegrator)
+{
+   Mesh *mesh = new Mesh("meshes/test.4x4.mesh");
+   const int dim = mesh->Dimension();
+   const int order = UniformRandom(1, 3);
+
+   FiniteElementCollection *dg_coll(new DG_FECollection(order, dim));
+   FiniteElementSpace *fes(new FiniteElementSpace(mesh, dg_coll, dim));
+   const int ndofs = fes->GetTrueVSize();
+   const int num_snap = UniformRandom(3, 5);
+   const int num_basis = num_snap;
+
+   // a fictitious snapshots.
+   DenseMatrix snapshots(ndofs, num_snap);
+   for (int i = 0; i < ndofs; i++)
+      for (int j = 0; j < num_snap; j++)
+         snapshots(i, j) = 2.0 * UniformRandom() - 1.0;
+
+   CAROM::Options options(ndofs, num_snap, 1, true);
+   options.static_svd_preserve_snapshot = true;
+   CAROM::BasisGenerator basis_generator(options, false, "test_basis");
+   Vector snapshot(ndofs);
+   for (int s = 0; s < num_snap; s++)
+   {
+      snapshots.GetColumnReference(s, snapshot);
+      basis_generator.takeSample(snapshot.GetData());
+   }
+   basis_generator.endSamples();
+   const CAROM::Matrix *carom_snapshots = basis_generator.getSnapshotMatrix();
+   const CAROM::Matrix *carom_basis = basis_generator.getSpatialBasis();
+   DenseMatrix basis(ndofs, num_basis);
+   CAROM::CopyMatrix(*carom_basis, basis);
+
+   IntegrationRule ir = IntRules.Get(fes->GetFE(0)->GetGeomType(),
+                                    (int)(ceil(1.5 * (2 * fes->GetMaxElementOrder() - 1))));
+   ConstantCoefficient pi(3.141592);
+   auto *integ1 = new DGLaxFriedrichsFluxIntegrator(pi);
+   integ1->SetIntRule(&ir);
+   auto *integ2 = new DGLaxFriedrichsFluxIntegrator(pi);
+   integ2->SetIntRule(&ir);
+
+   NonlinearForm *nform(new NonlinearForm(fes));
+   nform->AddInteriorFaceIntegrator(integ1);
+
+   ROMNonlinearForm *rform(new ROMNonlinearForm(num_basis, fes));
+   rform->AddInteriorFaceIntegrator(integ2);
+   rform->SetBasis(basis);
+   rform->SetPrecomputeMode(false);
+
+   CAROM::Vector rhs1(num_snap * num_basis, false);
+   CAROM::Vector rhs2(num_snap * num_basis, false);
+   CAROM::Matrix Gt(1, 1, true);
+
+   /* exact right-hand side by inner product of basis and fom vectors */
+   Vector rhs_vec(ndofs), basis_col(ndofs);
+   for (int s = 0; s < num_snap; s++)
+   {
+      snapshots.GetColumnReference(s, snapshot);
+
+      nform->Mult(snapshot, rhs_vec);
+      for (int b = 0; b < num_basis; b++)
+      {
+         basis.GetColumnReference(b, basis_col);
+         rhs1(b + s * num_basis) = basis_col * rhs_vec;
+      }
+   }
+
+   /*
+      TODO(kevin): this is a boilerplate for parallel POD/EQP training.
+      Will have to consider parallel-compatible test.
+   */
+   CAROM::Matrix carom_snapshots_work(*carom_snapshots);
+   carom_snapshots_work.gather();
+
+   /* equivalent operation must happen within this routine */
+   Array<int> fidxs;
+   rform->SetupEQPSystemForInteriorFaceIntegrator(carom_snapshots_work, integ2, Gt, rhs2, fidxs);
+
+   for (int k = 0; k < rhs1.dim(); k++)
+      EXPECT_NEAR(rhs1(k), rhs2(k), threshold);
+
+   double eqp_tol = 1.0e-10;
+   rform->TrainEQP(*carom_snapshots, eqp_tol);
+   if (rform->PrecomputeMode()) rform->PrecomputeCoefficients();
+
+   DenseMatrix rom_rhs1(num_basis, num_snap), rom_rhs2(num_basis, num_snap);
+   Vector rom_sol(num_basis), rom_rhs1_vec, rom_rhs2_vec;
+   for (int s = 0; s < num_snap; s++)
+   {
+      snapshots.GetColumnReference(s, snapshot);
+
+      nform->Mult(snapshot, rhs_vec);
+      rom_rhs1.GetColumnReference(s, rom_rhs1_vec);
+      basis.MultTranspose(rhs_vec, rom_rhs1_vec);
+
+      basis.MultTranspose(snapshot, rom_sol);
+      rom_rhs2.GetColumnReference(s, rom_rhs2_vec);
+      rform->Mult(rom_sol, rom_rhs2_vec);
+   }
+
+   for (int i = 0; i < num_basis; i++)
+      for (int j = 0; j < num_snap; j++)
+         EXPECT_NEAR(rom_rhs1(i, j), rom_rhs2(i, j), threshold);
+
+   delete mesh;
+   delete dg_coll;
    delete fes;
    delete nform;
    delete rform;

--- a/test/test_rom_nonlinearform.cpp
+++ b/test/test_rom_nonlinearform.cpp
@@ -323,6 +323,95 @@ TEST(ROMNonlinearForm_gradient, VectorConvectionTrilinearFormIntegrator)
    return;
 }
 
+TEST(ROMNonlinearForm_gradient, IncompressibleInviscidFluxNLFIntegrator)
+{
+   Mesh *mesh = new Mesh("meshes/test.4x4.mesh");
+   const int dim = mesh->Dimension();
+   const int order = UniformRandom(1, 3);
+
+   FiniteElementCollection *dg_coll(new DG_FECollection(order, dim));
+   FiniteElementSpace *fes(new FiniteElementSpace(mesh, dg_coll, dim));
+   const int ndofs = fes->GetTrueVSize();
+
+   const int num_basis = 10;
+   // a fictitious basis.
+   DenseMatrix basis(ndofs, num_basis);
+   for (int i = 0; i < ndofs; i++)
+      for (int j = 0; j < num_basis; j++)
+         basis(i, j) = UniformRandom();
+
+   IntegrationRule ir = IntRules.Get(fes->GetFE(0)->GetGeomType(),
+                                    (int)(ceil(1.5 * (2 * fes->GetMaxElementOrder() - 1))));
+   ConstantCoefficient pi(3.141592);
+   auto *integ = new IncompressibleInviscidFluxNLFIntegrator(pi);
+   integ->SetIntRule(&ir);
+
+   ROMNonlinearForm *rform(new ROMNonlinearForm(num_basis, fes));
+   rform->AddDomainIntegrator(integ);
+   rform->SetBasis(basis);
+
+   // we set some random quadrature points/weights.
+   const int nsample = UniformRandom(15, 20);
+   const int nqe = ir.GetNPoints();
+   const int ne = fes->GetNE();
+   Array<double> const& w_el = ir.GetWeights();
+   Array<int> sample_el(nsample), sample_qp(nsample);
+   Array<double> sample_qw(nsample);
+   for (int s = 0; s < nsample; s++)
+   {
+      sample_el[s] = UniformRandom(0, ne-1);
+      sample_qp[s] = UniformRandom(0, nqe-1);
+      sample_qw[s] = UniformRandom();
+   }
+   rform->UpdateDomainIntegratorSampling(0, sample_el, sample_qp, sample_qw);
+
+   Vector rom_u(num_basis);
+   for (int k = 0; k < rom_u.Size(); k++)
+      rom_u(k) = UniformRandom();
+
+   Vector rom_y(num_basis);
+   rform->Mult(rom_u, rom_y);
+   DenseMatrix *jac = dynamic_cast<DenseMatrix *>(&(rform->GetGradient(rom_u)));
+
+   double J0 = 0.5 * (rom_y * rom_y);
+   Vector grad(num_basis);
+   jac->MultTranspose(rom_y, grad);
+   double gg = sqrt(grad * grad);
+   printf("J0: %.15E\n", J0);
+   printf("grad: %.15E\n", gg);
+
+   Vector du(grad);
+   du /= gg;
+
+   Vector rom_y1(num_basis);
+   const int Nk = 40;
+   double error1 = 1e100, error;
+   printf("amp\tJ1\tdJdx\terror\n");
+   for (int k = 0; k < Nk; k++)
+   {
+      double amp = pow(10.0, -0.25 * k);
+      Vector rom_u1(rom_u);
+      rom_u1.Add(amp, du);
+
+      rform->Mult(rom_u1, rom_y1);
+      double J1 = 0.5 * (rom_y1 * rom_y1);
+      double dJdx = (J1 - J0) / amp;
+      error = abs(dJdx - gg) / gg;
+
+      printf("%.5E\t%.5E\t%.5E\t%.5E\n", amp, J1, dJdx, error);
+      if (error >= error1)
+         break;
+      error1 = error;
+   }
+   EXPECT_TRUE(min(error, error1) < 1.0e-7);
+
+   delete mesh;
+   delete dg_coll;
+   delete fes;
+   delete rform;
+   return;
+}
+
 TEST(ROMNonlinearForm_fast, VectorConvectionTrilinearFormIntegrator)
 {
    Mesh *mesh = new Mesh("meshes/test.4x4.mesh");

--- a/test/test_rom_nonlinearform.cpp
+++ b/test/test_rom_nonlinearform.cpp
@@ -317,7 +317,7 @@ TEST(ROMNonlinearForm_gradient, VectorConvectionTrilinearFormIntegrator)
          break;
       error1 = error;
    }
-   EXPECT_TRUE(min(error, error1) < 1.0e-7);
+   EXPECT_TRUE(min(error, error1) < grad_thre);
 
    delete mesh;
    delete h1_coll;
@@ -406,7 +406,7 @@ TEST(ROMNonlinearForm_gradient, IncompressibleInviscidFluxNLFIntegrator)
          break;
       error1 = error;
    }
-   EXPECT_TRUE(min(error, error1) < 1.0e-7);
+   EXPECT_TRUE(min(error, error1) < grad_thre);
 
    delete mesh;
    delete dg_coll;
@@ -504,7 +504,7 @@ TEST(ROMNonlinearForm_gradient, DGLaxFriedrichsFluxIntegrator)
          break;
       error1 = error;
    }
-   EXPECT_TRUE(min(error, error1) < 1.0e-7);
+   EXPECT_TRUE(min(error, error1) < grad_thre);
 
    delete mesh;
    delete dg_coll;
@@ -601,10 +601,116 @@ TEST(ROMNonlinearForm_fast, VectorConvectionTrilinearFormIntegrator)
          break;
       error1 = error;
    }
-   EXPECT_TRUE(min(error, error1) < 1.0e-7);
+   EXPECT_TRUE(min(error, error1) < grad_thre);
 
    delete mesh;
    delete h1_coll;
+   delete fes;
+   delete rform;
+   return;
+}
+
+TEST(ROMNonlinearForm_fast, DGLaxFriedrichsFluxIntegrator)
+{
+   Mesh *mesh = new Mesh("meshes/test.4x4.mesh");
+   const int dim = mesh->Dimension();
+   const int order = UniformRandom(1, 3);
+
+   FiniteElementCollection *dg_coll(new DG_FECollection(order, dim));
+   FiniteElementSpace *fes(new FiniteElementSpace(mesh, dg_coll, dim));
+   const int ndofs = fes->GetTrueVSize();
+
+   const int num_basis = 10;
+   // a fictitious basis.
+   DenseMatrix basis(ndofs, num_basis);
+   for (int i = 0; i < ndofs; i++)
+      for (int j = 0; j < num_basis; j++)
+         basis(i, j) = UniformRandom();
+
+   IntegrationRule ir = IntRules.Get(fes->GetFE(0)->GetGeomType(),
+                                    (int)(ceil(1.5 * (2 * fes->GetMaxElementOrder() - 1))));
+   ConstantCoefficient pi(3.141592);
+   auto *integ = new DGLaxFriedrichsFluxIntegrator(pi);
+   integ->SetIntRule(&ir);
+
+   ROMNonlinearForm *rform(new ROMNonlinearForm(num_basis, fes));
+   rform->AddInteriorFaceIntegrator(integ);
+   rform->SetBasis(basis);
+
+   // we set the full elements/quadrature points,
+   // so that the resulting vector is equilvalent to FOM.
+   const int nsample = UniformRandom(15, 20);
+   const int nqe = ir.GetNPoints();
+   const int nf = mesh->GetNumFaces();
+   Array<double> const& w_el = ir.GetWeights();
+   Array<int> sample_el(nsample), sample_qp(nsample);
+   Array<double> sample_qw(nsample);
+
+   int s = 0;
+   FaceElementTransformations *tr;
+   while (s < nsample)
+   {
+      int f = UniformRandom(0, nf-1);
+      tr = mesh->GetInteriorFaceTransformations(f);
+      if (tr == NULL) continue;
+
+      sample_el[s] = f;
+      sample_qp[s] = UniformRandom(0, nqe-1);
+      sample_qw[s] = UniformRandom();
+
+      s++;
+   }
+   rform->UpdateInteriorFaceIntegratorSampling(0, sample_el, sample_qp, sample_qw);
+   rform->PrecomputeCoefficients();
+
+   Vector rom_u(num_basis);
+   for (int k = 0; k < rom_u.Size(); k++)
+      rom_u(k) = UniformRandom();
+
+   Vector rom_y(num_basis), rom_yfast(num_basis);
+   rform->Mult(rom_u, rom_y);
+
+   rform->SetPrecomputeMode(true);
+   rform->Mult(rom_u, rom_yfast);
+   for (int k = 0; k < rom_y.Size(); k++)
+      EXPECT_NEAR(rom_y(k), rom_yfast(k), threshold);
+
+   // DenseMatrix *jac = dynamic_cast<DenseMatrix *>(&(rform->GetGradient(rom_u)));
+
+   // double J0 = 0.5 * (rom_y * rom_y);
+   // Vector grad(num_basis);
+   // jac->MultTranspose(rom_y, grad);
+   // double gg = sqrt(grad * grad);
+   // printf("J0: %.15E\n", J0);
+   // printf("grad: %.15E\n", gg);
+
+   // Vector du(grad);
+   // du /= gg;
+
+   // Vector rom_y1(num_basis);
+   // const int Nk = 40;
+   // double error1 = 1e100, error;
+   // printf("amp\tJ1\tdJdx\terror\n");
+   // for (int k = 0; k < Nk; k++)
+   // {
+   //    double amp = pow(10.0, -0.25 * k);
+   //    Vector rom_u1(rom_u);
+   //    rom_u1.Add(amp, du);
+
+   //    rform->Mult(rom_u1, rom_y1);
+   //    double J1 = 0.5 * (rom_y1 * rom_y1);
+   //    double dJdx = (J1 - J0) / amp;
+   //    error = abs(dJdx - gg) / gg;
+
+   //    printf("%.5E\t%.5E\t%.5E\t%.5E\n", amp, J1, dJdx, error);
+   //    if (error >= error1)
+   //       break;
+   //    error1 = error;
+   // }
+   // EXPECT_TRUE(min(error, error1) < grad_thre);
+
+   delete mesh;
+   delete dg_coll;
    delete fes;
    delete rform;
    return;

--- a/test/test_rom_nonlinearform.cpp
+++ b/test/test_rom_nonlinearform.cpp
@@ -886,7 +886,7 @@ TEST(ROMNonlinearForm, SetupEQPSystemForInteriorFaceIntegrator)
    ROMNonlinearForm *rform(new ROMNonlinearForm(num_basis, fes));
    rform->AddInteriorFaceIntegrator(integ2);
    rform->SetBasis(basis);
-   rform->SetPrecomputeMode(false);
+   rform->SetPrecomputeMode(true);
 
    CAROM::Vector rhs1(num_snap * num_basis, false);
    CAROM::Vector rhs2(num_snap * num_basis, false);
@@ -916,6 +916,120 @@ TEST(ROMNonlinearForm, SetupEQPSystemForInteriorFaceIntegrator)
    /* equivalent operation must happen within this routine */
    Array<int> fidxs;
    rform->SetupEQPSystemForInteriorFaceIntegrator(carom_snapshots_work, integ2, Gt, rhs2, fidxs);
+
+   for (int k = 0; k < rhs1.dim(); k++)
+      EXPECT_NEAR(rhs1(k), rhs2(k), threshold);
+
+   double eqp_tol = 1.0e-10;
+   rform->TrainEQP(*carom_snapshots, eqp_tol);
+   if (rform->PrecomputeMode()) rform->PrecomputeCoefficients();
+
+   DenseMatrix rom_rhs1(num_basis, num_snap), rom_rhs2(num_basis, num_snap);
+   Vector rom_sol(num_basis), rom_rhs1_vec, rom_rhs2_vec;
+   for (int s = 0; s < num_snap; s++)
+   {
+      snapshots.GetColumnReference(s, snapshot);
+
+      nform->Mult(snapshot, rhs_vec);
+      rom_rhs1.GetColumnReference(s, rom_rhs1_vec);
+      basis.MultTranspose(rhs_vec, rom_rhs1_vec);
+
+      basis.MultTranspose(snapshot, rom_sol);
+      rom_rhs2.GetColumnReference(s, rom_rhs2_vec);
+      rform->Mult(rom_sol, rom_rhs2_vec);
+   }
+
+   for (int i = 0; i < num_basis; i++)
+      for (int j = 0; j < num_snap; j++)
+         EXPECT_NEAR(rom_rhs1(i, j), rom_rhs2(i, j), threshold);
+
+   delete mesh;
+   delete dg_coll;
+   delete fes;
+   delete nform;
+   delete rform;
+}
+
+TEST(ROMNonlinearForm, SetupEQPSystemForBdrFaceIntegrator)
+{
+   Mesh *mesh = new Mesh("meshes/test.4x4.mesh");
+   const int dim = mesh->Dimension();
+   const int order = UniformRandom(1, 3);
+
+   FiniteElementCollection *dg_coll(new DG_FECollection(order, dim));
+   FiniteElementSpace *fes(new FiniteElementSpace(mesh, dg_coll, dim));
+   const int ndofs = fes->GetTrueVSize();
+   const int num_snap = UniformRandom(3, 5);
+   const int num_basis = num_snap;
+
+   // a fictitious snapshots.
+   DenseMatrix snapshots(ndofs, num_snap);
+   for (int i = 0; i < ndofs; i++)
+      for (int j = 0; j < num_snap; j++)
+         snapshots(i, j) = 2.0 * UniformRandom() - 1.0;
+
+   CAROM::Options options(ndofs, num_snap, 1, true);
+   options.static_svd_preserve_snapshot = true;
+   CAROM::BasisGenerator basis_generator(options, false, "test_basis");
+   Vector snapshot(ndofs);
+   for (int s = 0; s < num_snap; s++)
+   {
+      snapshots.GetColumnReference(s, snapshot);
+      basis_generator.takeSample(snapshot.GetData());
+   }
+   basis_generator.endSamples();
+   const CAROM::Matrix *carom_snapshots = basis_generator.getSnapshotMatrix();
+   const CAROM::Matrix *carom_basis = basis_generator.getSpatialBasis();
+   DenseMatrix basis(ndofs, num_basis);
+   CAROM::CopyMatrix(*carom_basis, basis);
+
+   IntegrationRule ir = IntRules.Get(fes->GetFE(0)->GetGeomType(),
+                                    (int)(ceil(1.5 * (2 * fes->GetMaxElementOrder() - 1))));
+   ConstantCoefficient pi(3.141592);
+   auto *integ1 = new DGLaxFriedrichsFluxIntegrator(pi);
+   integ1->SetIntRule(&ir);
+   auto *integ2 = new DGLaxFriedrichsFluxIntegrator(pi);
+   integ2->SetIntRule(&ir);
+
+   NonlinearForm *nform(new NonlinearForm(fes));
+   nform->AddBdrFaceIntegrator(integ1);
+
+   ROMNonlinearForm *rform(new ROMNonlinearForm(num_basis, fes));
+   rform->AddBdrFaceIntegrator(integ2);
+   rform->SetBasis(basis);
+   rform->SetPrecomputeMode(true);
+
+   CAROM::Vector rhs1(num_snap * num_basis, false);
+   CAROM::Vector rhs2(num_snap * num_basis, false);
+   CAROM::Matrix Gt(1, 1, true);
+
+   /* exact right-hand side by inner product of basis and fom vectors */
+   Vector rhs_vec(ndofs), basis_col(ndofs);
+   for (int s = 0; s < num_snap; s++)
+   {
+      snapshots.GetColumnReference(s, snapshot);
+
+      nform->Mult(snapshot, rhs_vec);
+      for (int b = 0; b < num_basis; b++)
+      {
+         basis.GetColumnReference(b, basis_col);
+         rhs1(b + s * num_basis) = basis_col * rhs_vec;
+      }
+   }
+
+   /*
+      TODO(kevin): this is a boilerplate for parallel POD/EQP training.
+      Will have to consider parallel-compatible test.
+   */
+   CAROM::Matrix carom_snapshots_work(*carom_snapshots);
+   carom_snapshots_work.gather();
+
+   /* equivalent operation must happen within this routine */
+   Array<int> bdr_attr_marker(mesh->bdr_attributes.Size() ?
+                              mesh->bdr_attributes.Max() : 0);
+   bdr_attr_marker = 1;
+   Array<int> bidxs;
+   rform->SetupEQPSystemForBdrFaceIntegrator(carom_snapshots_work, integ2, bdr_attr_marker, Gt, rhs2, bidxs);
 
    for (int k = 0; k < rhs1.dim(); k++)
       EXPECT_NEAR(rhs1(k), rhs2(k), threshold);


### PR DESCRIPTION
- Two `HyperReductionIntegrator` classes are added and verified:
  - `IncompressibleInviscidFluxNLFIntegrator`
  - `DGLaxFriedrichsFluxIntegrator`
- `ROMNonlinearForm`: Single-component EQP training procedure is verified for boundary and interior face integrators.