### PR TITLE
hot fix for LC quartz installation with parallel hdf module

### DIFF
--- a/script/install_quartz.bash
+++ b/script/install_quartz.bash
@@ -14,6 +14,7 @@ module load gcc/11.2.1
 module load git/2.36.1
 module load mvapich2
 module load cmake/3.26.3
+module load hdf5-parallel/1.14.0
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 INSTALL_HELPER=$SCRIPT_DIR/../install-helper


### PR DESCRIPTION
For parallel I/O, parallel hdf must be used for libROM compilation.