### PR TITLE
Remove `TrainMode`

### DIFF
--- a/include/main_workflow.hpp
+++ b/include/main_workflow.hpp
@@ -15,7 +15,7 @@ void RunExample();
 
 MultiBlockSolver* InitSolver();
 SampleGenerator* InitSampleGenerator(MPI_Comm comm);
-std::vector<std::string> GetGlobalBasisTagList(const TopologyHandlerMode &topol_mode, const TrainMode &train_mode, bool separate_variable_basis);
+std::vector<std::string> GetGlobalBasisTagList(const TopologyHandlerMode &topol_mode, bool separate_variable_basis);
 
 void GenerateSamples(MPI_Comm comm);
 void CollectSamples(SampleGenerator *sample_generator);

--- a/include/multiblock_solver.hpp
+++ b/include/multiblock_solver.hpp
@@ -108,7 +108,6 @@ protected:
 
    // rom variables.
    ROMHandlerBase *rom_handler = NULL;
-   TrainMode train_mode = NUM_TRAINMODE;
    bool use_rom = false;
    bool separate_variable_basis = false;
 
@@ -136,7 +135,6 @@ public:
    const bool UseRom() const { return use_rom; }
    ROMHandlerBase* GetROMHandler() const { return rom_handler; }
    TopologyHandler* GetTopologyHandler() const { return topol_handler; }
-   const TrainMode GetTrainMode() { return train_mode; }
    const bool IsVisualizationSaved() const { return visual.save; }
    const std::string GetSolutionFilePrefix() const { return sol_prefix; }
    const std::string GetVisualizationPrefix() const { return visual.prefix; }

--- a/include/rom_handler.hpp
+++ b/include/rom_handler.hpp
@@ -15,13 +15,6 @@
 namespace mfem
 {
 
-enum TrainMode
-{
-   INDIVIDUAL,
-   UNIVERSAL,
-   NUM_TRAINMODE
-};
-
 enum ROMBuildingLevel
 {
    NONE,
@@ -37,10 +30,8 @@ enum NonlinearHandling
    NUM_NLNHNDL
 };
 
-const TrainMode SetTrainMode();
-
-const std::string GetBasisTagForComponent(const int &comp_idx, const TrainMode &train_mode, const TopologyHandler *topol_handler, const std::string var_name="");
-const std::string GetBasisTag(const int &subdomain_index, const TrainMode &train_mode, const TopologyHandler *topol_handler, const std::string var_name="");
+const std::string GetBasisTagForComponent(const int &comp_idx, const TopologyHandler *topol_handler, const std::string var_name="");
+const std::string GetBasisTag(const int &subdomain_index, const TopologyHandler *topol_handler, const std::string var_name="");
 
 class ROMHandlerBase
 {
@@ -61,7 +52,6 @@ protected:
    bool component_sampling = false;
    bool save_lspg_basis = false;
    ROMBuildingLevel save_operator = NUM_BLD_LVL;
-   TrainMode train_mode = NUM_TRAINMODE;
    bool nonlinear_mode = false;
    bool separate_variable = false;
    NonlinearHandling nlin_handle = NUM_NLNHNDL;
@@ -120,14 +110,13 @@ protected:
 
    void ParseInputs();
 public:
-   ROMHandlerBase(const TrainMode &train_mode_, TopologyHandler *input_topol,
-              const Array<int> &input_var_offsets, const std::vector<std::string> &var_names, const bool separate_variable_basis);
+   ROMHandlerBase(TopologyHandler *input_topol, const Array<int> &input_var_offsets,
+      const std::vector<std::string> &var_names, const bool separate_variable_basis);
 
    virtual ~ROMHandlerBase();
 
    // access
    const int GetNumSubdomains() { return numSub; }
-   const TrainMode GetTrainMode() { return train_mode; }
    const int GetNumROMRefComps() { return num_rom_comp; }
    const int GetNumROMRefBlocks() { return num_rom_ref_blocks; }
    const int GetRefNumBasis(const int &basis_idx) { return num_ref_basis[basis_idx]; }
@@ -232,8 +221,8 @@ protected:
    mfem::BlockVector *reduced_sol = NULL;
 
 public:
-   MFEMROMHandler(const TrainMode &train_mode_, TopologyHandler *input_topol,
-                  const Array<int> &input_var_offsets, const std::vector<std::string> &var_names, const bool separate_variable_basis);
+   MFEMROMHandler(TopologyHandler *input_topol, const Array<int> &input_var_offsets,
+      const std::vector<std::string> &var_names, const bool separate_variable_basis);
 
    virtual ~MFEMROMHandler();
 

--- a/include/sample_generator.hpp
+++ b/include/sample_generator.hpp
@@ -111,7 +111,7 @@ public:
       The appended column indices of each basis tag are stored in col_idxs.
    */
    void SaveSnapshot(BlockVector *U_snapshots, std::vector<std::string> &snapshot_basis_tags, Array<int> &col_idxs);
-   void SaveSnapshotPorts(TopologyHandler *topol_handler, const TrainMode &train_mode, const Array<int> &col_idxs);
+   void SaveSnapshotPorts(TopologyHandler *topol_handler, const Array<int> &col_idxs);
    void AddSnapshotGenerator(const int &fom_vdofs, const std::string &prefix, const std::string &basis_tag);
    void WriteSnapshots();
    void WriteSnapshotPorts();

--- a/src/advdiff_solver.cpp
+++ b/src/advdiff_solver.cpp
@@ -51,7 +51,6 @@ void AdvDiffSolver::BuildCompROMLinElems()
 {
    mfem_error("AdvDiffSolver::BuildCompROMLinElems is not implemented yet!\n");
 
-   assert(train_mode == UNIVERSAL);
    assert(rom_handler->BasisLoaded());
    assert(rom_elems);
 

--- a/src/linelast_solver.cpp
+++ b/src/linelast_solver.cpp
@@ -500,7 +500,6 @@ void LinElastSolver::ProjectOperatorOnReducedBasis()
 // Component-wise assembly
 void LinElastSolver::BuildCompROMLinElems()
 {
-   assert(train_mode == UNIVERSAL);
    assert(rom_handler->BasisLoaded());
    assert(rom_elems);
 
@@ -524,7 +523,6 @@ void LinElastSolver::BuildCompROMLinElems()
 
 void LinElastSolver::BuildBdrROMLinElems()
 {
-   assert(train_mode == UNIVERSAL);
    assert(rom_handler->BasisLoaded());
    assert(rom_elems);
 
@@ -555,7 +553,6 @@ void LinElastSolver::BuildBdrROMLinElems()
 void LinElastSolver::BuildItfaceROMLinElems()
 {
    assert(topol_mode == TopologyHandlerMode::COMPONENT);
-   assert(train_mode == UNIVERSAL);
    assert(rom_handler->BasisLoaded());
    assert(rom_elems);
 

--- a/src/poisson_solver.cpp
+++ b/src/poisson_solver.cpp
@@ -344,7 +344,6 @@ void PoissonSolver::AssembleInterfaceMatrices()
 
 void PoissonSolver::BuildCompROMLinElems()
 {
-   assert(train_mode == UNIVERSAL);
    assert(rom_handler->BasisLoaded());
    assert(rom_elems);
 
@@ -368,7 +367,6 @@ void PoissonSolver::BuildCompROMLinElems()
 
 void PoissonSolver::BuildBdrROMLinElems()
 {
-   assert(train_mode == UNIVERSAL);
    assert(rom_handler->BasisLoaded());
    assert(rom_elems);
 
@@ -399,7 +397,6 @@ void PoissonSolver::BuildBdrROMLinElems()
 void PoissonSolver::BuildItfaceROMLinElems()
 {
    assert(topol_mode == TopologyHandlerMode::COMPONENT);
-   assert(train_mode == UNIVERSAL);
    assert(rom_handler->BasisLoaded());
    assert(rom_elems);
 

--- a/src/sample_generator.cpp
+++ b/src/sample_generator.cpp
@@ -202,7 +202,7 @@ void SampleGenerator::SaveSnapshot(BlockVector *U_snapshots, std::vector<std::st
    }
 }
 
-void SampleGenerator::SaveSnapshotPorts(TopologyHandler *topol_handler, const TrainMode &train_mode, const Array<int> &col_idxs)
+void SampleGenerator::SaveSnapshotPorts(TopologyHandler *topol_handler, const Array<int> &col_idxs)
 {
    assert(topol_handler);
    const int numSub = topol_handler->GetNumSubdomains();
@@ -217,14 +217,14 @@ void SampleGenerator::SaveSnapshotPorts(TopologyHandler *topol_handler, const Tr
       const PortInfo *port = topol_handler->GetPortInfo(p);
 
       /*
-         We save the snapshot ports by dom%d (INDIVIDUAL) or component names (UNIVERSAL).
+         We save the snapshot ports by component names.
          Variable separation does not matter at this point.
          Though we use basis tags here, it is only for the sake of
          getting consistent domain/component mesh names.
       */
       std::string mesh1, mesh2;
-      mesh1 = GetBasisTag(port->Mesh1, train_mode, topol_handler);
-      mesh2 = GetBasisTag(port->Mesh2, train_mode, topol_handler); 
+      mesh1 = GetBasisTag(port->Mesh1, topol_handler);
+      mesh2 = GetBasisTag(port->Mesh2, topol_handler); 
 
       /*
          note the mesh names are not necessarily the same as the subdomain names

--- a/src/steady_ns_solver.cpp
+++ b/src/steady_ns_solver.cpp
@@ -632,7 +632,6 @@ void SteadyNSSolver::SolveROM()
 void SteadyNSSolver::AllocateROMTensorElems()
 {
    assert(topol_mode == TopologyHandlerMode::COMPONENT);
-   assert(train_mode == UNIVERSAL);
 
    const int num_comp = topol_handler->GetNumComponents();
    comp_tensors.SetSize(num_comp);
@@ -642,7 +641,6 @@ void SteadyNSSolver::AllocateROMTensorElems()
 void SteadyNSSolver::BuildROMTensorElems()
 {
    assert(topol_mode == TopologyHandlerMode::COMPONENT);
-   assert(train_mode == UNIVERSAL);
    assert(rom_handler->BasisLoaded());
 
    // Component domain system
@@ -667,7 +665,6 @@ void SteadyNSSolver::BuildROMTensorElems()
 void SteadyNSSolver::SaveROMTensorElems(const std::string &filename)
 {
    assert(topol_mode == TopologyHandlerMode::COMPONENT);
-   assert(train_mode == UNIVERSAL);
    assert(FileExists(filename));
 
    hid_t file_id;
@@ -709,7 +706,6 @@ void SteadyNSSolver::SaveROMTensorElems(const std::string &filename)
 void SteadyNSSolver::LoadROMTensorElems(const std::string &filename)
 {
    assert(topol_mode == TopologyHandlerMode::COMPONENT);
-   assert(train_mode == UNIVERSAL);
 
    hid_t file_id;
    herr_t errf = 0;
@@ -749,7 +745,6 @@ void SteadyNSSolver::LoadROMTensorElems(const std::string &filename)
 void SteadyNSSolver::AssembleROMTensorOper()
 {
    assert(topol_mode == TopologyHandlerMode::COMPONENT);
-   assert(train_mode == UNIVERSAL);
 
    const int num_comp = topol_handler->GetNumComponents();
    assert(comp_tensors.Size() == num_comp);
@@ -764,7 +759,6 @@ void SteadyNSSolver::AssembleROMTensorOper()
 void SteadyNSSolver::AllocateROMEQPElems()
 {
    assert(topol_mode == TopologyHandlerMode::COMPONENT);
-   assert(train_mode == UNIVERSAL);
 
    assert(rom_handler);
    assert(rom_handler->BasisLoaded());
@@ -794,7 +788,6 @@ void SteadyNSSolver::AllocateROMEQPElems()
 void SteadyNSSolver::TrainEQPElems(SampleGenerator *sample_generator)
 {
    assert(topol_mode == TopologyHandlerMode::COMPONENT);
-   assert(train_mode == UNIVERSAL);
 
    assert(sample_generator);
    assert(rom_handler);
@@ -820,7 +813,6 @@ void SteadyNSSolver::TrainEQPElems(SampleGenerator *sample_generator)
 void SteadyNSSolver::SaveEQPElems(const std::string &filename)
 {
    assert(topol_mode == TopologyHandlerMode::COMPONENT);
-   assert(train_mode == UNIVERSAL);
 
    /*
       TODO(kevin): this is a boilerplate for parallel POD/EQP training.
@@ -866,7 +858,6 @@ void SteadyNSSolver::SaveEQPElems(const std::string &filename)
 void SteadyNSSolver::LoadEQPElems(const std::string &filename)
 {
    assert(topol_mode == TopologyHandlerMode::COMPONENT);
-   assert(train_mode == UNIVERSAL);
    assert(rom_handler->BasisLoaded());
 
    hid_t file_id;
@@ -906,7 +897,6 @@ void SteadyNSSolver::LoadEQPElems(const std::string &filename)
 void SteadyNSSolver::AssembleROMEQPOper()
 {
    assert(topol_mode == TopologyHandlerMode::COMPONENT);
-   assert(train_mode == UNIVERSAL);
 
    const int num_comp = rom_handler->GetNumROMRefComps();
    assert(comp_eqps.Size() == num_comp);

--- a/src/topology_handler.cpp
+++ b/src/topology_handler.cpp
@@ -207,14 +207,23 @@ SubMeshTopologyHandler::SubMeshTopologyHandler(Mesh* pmesh_)
       }
    }
 
-   // for SubMeshTopologyHandler, only single-component is allowed.
-   num_comp = 1;
+   /* for SubMeshTopologyHandler, each subdomain corresponds to a unique component. */
+   num_comp = numSub;
+
+   /* inidividual subdomains are unique */
    mesh_types.SetSize(numSub);
-   mesh_types = 0;
+   for (int m = 0; m < numSub; m++)
+      mesh_types[m] = m;
+
+   /* there is only 1 subdomain per component */
    sub_composition.SetSize(num_comp);
-   sub_composition = numSub;
+   sub_composition = 1;
+
+   /* every subdomain is the first mesh of its own type */
    mesh_comp_idx.SetSize(numSub);
-   for (int m = 0; m < numSub; m++) mesh_comp_idx[m] = m;
+   mesh_comp_idx = 0;
+
+   /* component names by index */
    comp_names.resize(num_comp);
    for (int c = 0; c < num_comp; c++) comp_names[c] = "comp" + std::to_string(c);
 

--- a/test/inputs/linelast.base.yml
+++ b/test/inputs/linelast.base.yml
@@ -38,7 +38,7 @@ sample_generation:
   parameters:
     - key: single_run/linelast_disp/rdisp_f
       type: double
-      sample_size: 2
+      sample_size: 3
       minimum: 0.9
       maximum: 1.1
 

--- a/test/test_workflow.cpp
+++ b/test/test_workflow.cpp
@@ -21,36 +21,7 @@ TEST(GoogleTestFramework, GoogleTestFrameworkFound)
    SUCCEED();
 }
 
-TEST(Poisson_Workflow, MFEMIndividualTest)
-{
-   config = InputParser("inputs/test.base.yml");
-
-   config.dict_["model_reduction"]["rom_handler_type"] = "mfem";
-   config.dict_["model_reduction"]["visualization"]["enabled"] = true;
-   config.dict_["model_reduction"]["visualization"]["prefix"] = "basis_paraview";
-   for (int k = 0; k < 4; k++)
-      config.dict_["basis"]["tags"][k]["name"] = "dom" + std::to_string(k);
-
-   config.dict_["main"]["mode"] = "sample_generation";
-   GenerateSamples(MPI_COMM_WORLD);
-
-   config.dict_["main"]["mode"] = "train_rom";
-   TrainROM(MPI_COMM_WORLD);
-
-   config.dict_["main"]["mode"] = "build_rom";
-   BuildROM(MPI_COMM_WORLD);
-
-   config.dict_["main"]["mode"] = "single_run";
-   double error = SingleRun(MPI_COMM_WORLD);
-
-   // This reproductive case must have a very small error at the level of finite-precision.
-   printf("Error: %.15E\n", error);
-   EXPECT_TRUE(error < threshold);
-
-   return;
-}
-
-TEST(Poisson_Workflow, MFEMUniversalTest)
+TEST(Poisson_Workflow, SubmeshTest)
 {
    config = InputParser("inputs/test.base.yml");
 
@@ -144,38 +115,7 @@ TEST(Poisson_Workflow, ComponentWiseWithDirectSolve)
    return;
 }
 
-TEST(Stokes_Workflow, MFEMIndividualTest)
-{
-   config = InputParser("inputs/stokes.base.yml");
-   for (int k = 0; k < 4; k++)
-      config.dict_["basis"]["tags"][k]["name"] = "dom" + std::to_string(k);
-
-   config.dict_["model_reduction"]["rom_handler_type"] = "mfem";
-   config.dict_["model_reduction"]["visualization"]["enabled"] = true;
-   config.dict_["model_reduction"]["visualization"]["prefix"] = "basis_paraview";
-
-   config.dict_["main"]["mode"] = "sample_generation";
-   config.dict_["main"]["use_rom"] = false;
-   GenerateSamples(MPI_COMM_WORLD);
-   config.dict_["main"]["use_rom"] = true;
-
-   config.dict_["main"]["mode"] = "train_rom";
-   TrainROM(MPI_COMM_WORLD);
-
-   config.dict_["main"]["mode"] = "build_rom";
-   BuildROM(MPI_COMM_WORLD);
-
-   config.dict_["main"]["mode"] = "single_run";
-   double error = SingleRun(MPI_COMM_WORLD);
-
-   // This reproductive case must have a very small error at the level of finite-precision.
-   printf("Error: %.15E\n", error);
-   EXPECT_TRUE(error < stokes_threshold);
-
-   return;
-}
-
-TEST(Stokes_Workflow, MFEMUniversalTest)
+TEST(Stokes_Workflow, SubmeshTest)
 {
    config = InputParser("inputs/stokes.base.yml");
 
@@ -340,36 +280,7 @@ TEST(Stokes_Workflow, ComponentSeparateVariable)
    return;
 }
 
-TEST(SteadyNS_Workflow, MFEMIndividualTest)
-{
-   config = InputParser("inputs/steady_ns.base.yml");
-   for (int k = 0; k < 4; k++)
-      config.dict_["basis"]["tags"][k]["name"] = "dom" + std::to_string(k);
-
-   config.dict_["model_reduction"]["rom_handler_type"] = "mfem";
-   config.dict_["model_reduction"]["visualization"]["enabled"] = true;
-   config.dict_["model_reduction"]["visualization"]["prefix"] = "basis_paraview";
-
-   config.dict_["main"]["mode"] = "sample_generation";
-   GenerateSamples(MPI_COMM_WORLD);
-
-   config.dict_["main"]["mode"] = "train_rom";
-   TrainROM(MPI_COMM_WORLD);
-
-   config.dict_["main"]["mode"] = "build_rom";
-   BuildROM(MPI_COMM_WORLD);
-
-   config.dict_["main"]["mode"] = "single_run";
-   double error = SingleRun(MPI_COMM_WORLD);
-
-   // This reproductive case must have a very small error at the level of finite-precision.
-   printf("Error: %.15E\n", error);
-   EXPECT_TRUE(error < stokes_threshold);
-
-   return;
-}
-
-TEST(SteadyNS_Workflow, MFEMUniversalTest)
+TEST(SteadyNS_Workflow, SubmeshTest)
 {
    config = InputParser("inputs/steady_ns.base.yml");
 
@@ -566,32 +477,7 @@ TEST(SteadyNS_Workflow, ComponentSeparateVariable_EQP)
    return;
 }
 
-TEST(LinElast_Workflow, MFEMIndividualTest)
-{
-   config = InputParser("inputs/linelast.base.yml");
-
-   config.dict_["model_reduction"]["rom_handler_type"] = "mfem";
-   for (int k = 0; k < 3; k++)
-      config.dict_["basis"]["tags"][k]["name"] = "dom" + std::to_string(k);
-
-   config.dict_["main"]["mode"] = "sample_generation";
-   GenerateSamples(MPI_COMM_WORLD);
-
-   config.dict_["main"]["mode"] = "train_rom";
-   TrainROM(MPI_COMM_WORLD);
-   config.dict_["main"]["mode"] = "build_rom";
-   BuildROM(MPI_COMM_WORLD);
-   config.dict_["main"]["mode"] = "single_run";
-   double error = SingleRun(MPI_COMM_WORLD);
-
-   // This reproductive case must have a very small error at the level of finite-precision.
-   printf("Error: %.15E\n", error);
-   EXPECT_TRUE(error < threshold);
-
-   return;
-}
-
-TEST(LinElast_Workflow, MFEMUniversalTest)
+TEST(LinElast_Workflow, SubmeshTest)
 {
    config = InputParser("inputs/linelast.base.yml");
 
@@ -680,11 +566,9 @@ TEST(LinElast_Workflow, ComponentWiseTest)
    return;
 }
 
-TEST(AdvDiff_Workflow, MFEMIndividualTest)
+TEST(AdvDiff_Workflow, SubmeshTest)
 {
    config = InputParser("inputs/advdiff.base.yml");
-   for (int k = 0; k < 4; k++)
-      config.dict_["basis"]["tags"][k]["name"] = "dom" + std::to_string(k);
 
    config.dict_["model_reduction"]["visualization"]["enabled"] = true;
    config.dict_["model_reduction"]["visualization"]["prefix"] = "basis_paraview";

--- a/test/test_workflow.cpp
+++ b/test/test_workflow.cpp
@@ -10,7 +10,7 @@ using namespace std;
 using namespace mfem;
 
 static const double threshold = 1.0e-14;
-static const double stokes_threshold = 1.0e-12;
+static const double stokes_threshold = 1.0e-11;
 static const double linelast_threshold = 1.0e-13;
 
 /**
@@ -60,15 +60,10 @@ TEST(Poisson_Workflow, MFEMUniversalTest)
    config.dict_["model_reduction"]["visualization"]["enabled"] = true;
    config.dict_["model_reduction"]["visualization"]["prefix"] = "basis_paraview";
 
-   config.dict_["single_run"]["poisson0"]["k"] = 2.0;
-   config.dict_["sample_generation"]["parameters"][0]["sample_size"] = 1;
-   config.dict_["model_reduction"]["subdomain_training"] = "universal";
-   config.dict_["basis"]["number_of_basis"] = 4;
-
    // Test save/loadSolution as well.
    config.dict_["save_solution"]["enabled"] = true;
    config.dict_["model_reduction"]["compare_solution"]["load_solution"] = true;
-   config.dict_["model_reduction"]["compare_solution"]["fom_solution_file"] = "./sample0_solution.h5";
+   config.dict_["model_reduction"]["compare_solution"]["fom_solution_file"] = "./sample1_solution.h5";
 
    config.dict_["main"]["mode"] = "sample_generation";
    GenerateSamples(MPI_COMM_WORLD);
@@ -190,15 +185,10 @@ TEST(Stokes_Workflow, MFEMUniversalTest)
    config.dict_["model_reduction"]["visualization"]["enabled"] = true;
    config.dict_["model_reduction"]["visualization"]["prefix"] = "basis_paraview";
 
-   config.dict_["single_run"]["channel_flow"]["nu"] = 2.0;
-   config.dict_["sample_generation"]["parameters"][0]["sample_size"] = 1;
-   config.dict_["model_reduction"]["subdomain_training"] = "universal";
-   config.dict_["basis"]["number_of_basis"] = 4;
-
    // Test save/loadSolution as well.
    config.dict_["save_solution"]["enabled"] = true;
    config.dict_["model_reduction"]["compare_solution"]["load_solution"] = true;
-   config.dict_["model_reduction"]["compare_solution"]["fom_solution_file"] = "./sample0_solution.h5";
+   config.dict_["model_reduction"]["compare_solution"]["fom_solution_file"] = "./sample1_solution.h5";
 
    config.dict_["main"]["mode"] = "sample_generation";
    config.dict_["main"]["use_rom"] = false;
@@ -233,15 +223,10 @@ TEST(Stokes_Workflow, MFEMGlobalSeparateTest)
    config.dict_["model_reduction"]["visualization"]["prefix"] = "basis_paraview";
    config.dict_["model_reduction"]["linear_solver_type"] = "minres";
 
-   config.dict_["single_run"]["channel_flow"]["nu"] = 2.0;
-   config.dict_["sample_generation"]["parameters"][0]["sample_size"] = 1;
-   config.dict_["model_reduction"]["subdomain_training"] = "universal";
-   config.dict_["basis"]["number_of_basis"] = 4;
-
    // Test save/loadSolution as well.
    config.dict_["save_solution"]["enabled"] = true;
    config.dict_["model_reduction"]["compare_solution"]["load_solution"] = true;
-   config.dict_["model_reduction"]["compare_solution"]["fom_solution_file"] = "./sample0_solution.h5";
+   config.dict_["model_reduction"]["compare_solution"]["fom_solution_file"] = "./sample1_solution.h5";
 
    config.dict_["main"]["mode"] = "sample_generation";
    config.dict_["main"]["use_rom"] = false;
@@ -396,15 +381,10 @@ TEST(SteadyNS_Workflow, MFEMUniversalTest)
    config.dict_["model_reduction"]["visualization"]["enabled"] = true;
    config.dict_["model_reduction"]["visualization"]["prefix"] = "basis_paraview";
 
-   config.dict_["single_run"]["channel_flow"]["nu"] = 2.0;
-   config.dict_["sample_generation"]["parameters"][0]["sample_size"] = 1;
-   config.dict_["model_reduction"]["subdomain_training"] = "universal";
-   config.dict_["basis"]["number_of_basis"] = 4;
-
    // Test save/loadSolution as well.
    config.dict_["save_solution"]["enabled"] = true;
    config.dict_["model_reduction"]["compare_solution"]["load_solution"] = true;
-   config.dict_["model_reduction"]["compare_solution"]["fom_solution_file"] = "./sample0_solution.h5";
+   config.dict_["model_reduction"]["compare_solution"]["fom_solution_file"] = "./sample1_solution.h5";
 
    config.dict_["main"]["mode"] = "sample_generation";
    GenerateSamples(MPI_COMM_WORLD);
@@ -439,15 +419,10 @@ TEST(SteadyNS_Workflow, MFEMGlobalUniversalTest)
    config.dict_["model_reduction"]["visualization"]["enabled"] = true;
    config.dict_["model_reduction"]["visualization"]["prefix"] = "basis_paraview";
 
-   config.dict_["single_run"]["channel_flow"]["nu"] = 2.0;
-   config.dict_["sample_generation"]["parameters"][0]["sample_size"] = 1;
-   config.dict_["model_reduction"]["subdomain_training"] = "universal";
-   config.dict_["basis"]["number_of_basis"] = 4;
-
    // Test save/loadSolution as well.
    config.dict_["save_solution"]["enabled"] = true;
    config.dict_["model_reduction"]["compare_solution"]["load_solution"] = true;
-   config.dict_["model_reduction"]["compare_solution"]["fom_solution_file"] = "./sample0_solution.h5";
+   config.dict_["model_reduction"]["compare_solution"]["fom_solution_file"] = "./sample1_solution.h5";
 
    config.dict_["main"]["mode"] = "sample_generation";
    GenerateSamples(MPI_COMM_WORLD);
@@ -596,9 +571,7 @@ TEST(LinElast_Workflow, MFEMIndividualTest)
    config = InputParser("inputs/linelast.base.yml");
 
    config.dict_["model_reduction"]["rom_handler_type"] = "mfem";
-   config.dict_["sample_generation"]["parameters"][0]["sample_size"] = 4;
-   config.dict_["basis"]["number_of_basis"] = 2;
-   for (int k = 0; k < 2; k++)
+   for (int k = 0; k < 3; k++)
       config.dict_["basis"]["tags"][k]["name"] = "dom" + std::to_string(k);
 
    config.dict_["main"]["mode"] = "sample_generation";
@@ -624,15 +597,10 @@ TEST(LinElast_Workflow, MFEMUniversalTest)
 
    config.dict_["model_reduction"]["rom_handler_type"] = "mfem";
 
-   config.dict_["single_run"]["linelast_disp"]["rdisp_f"] = 0.9;
-   config.dict_["sample_generation"]["parameters"][0]["sample_size"] = 2;
-   config.dict_["model_reduction"]["subdomain_training"] = "universal";
-   config.dict_["basis"]["number_of_basis"] = 4;
-
    // Test save/loadSolution as well.
    config.dict_["save_solution"]["enabled"] = true;
    config.dict_["model_reduction"]["compare_solution"]["load_solution"] = true;
-   config.dict_["model_reduction"]["compare_solution"]["fom_solution_file"] = "./sample0_solution.h5";
+   config.dict_["model_reduction"]["compare_solution"]["fom_solution_file"] = "./sample1_solution.h5";
 
    config.dict_["main"]["mode"] = "sample_generation";
    GenerateSamples(MPI_COMM_WORLD);


### PR DESCRIPTION
This PR partially addresses the issue #40 .

There were two `TrainMode`: `UNIVERSAL` that trains POD per each component; and `INDIVIDUAL` that trains POD per each subdomain.

While `TrainMode::INDIVIDUAL` may provide a little convenience in limited cases, it rather complicates the code implementation significantly, which is becoming a road block for adding more essential features. More fundamentally, `TrainMode::INDIVIDUAL` can be supported 100% from `TrainMode::UNIVERSAL`, thus being redundant.

Now `TrainMode` is removed from the entire code, simplifying some workflow.