### PR TITLE
EQPElement and EQPSample

### DIFF
--- a/include/hdf5_utils.hpp
+++ b/include/hdf5_utils.hpp
@@ -9,7 +9,6 @@
 #include "hdf5.h"
 #include "linalg_utils.hpp"
 #include "rom_handler.hpp"
-#include "hyperreduction_integ.hpp"
 
 namespace mfem
 {
@@ -21,6 +20,20 @@ enum IntegratorType
    BDRFACE,
    INTERFACE,
    NUM_INTEG_TYPE
+};
+
+struct SampleInfo
+{
+   /*
+      - For DomainIntegrator: element index
+      - For BdrFaceIntegrator: boundary element index
+      - For InteriorFaceIntegrator: face index
+      - For InterfaceIntegrator: interface info index
+   */
+   int el;
+
+   int qp;         // quadrature point
+   double qw;      // quadrature weight
 };
 
 }

--- a/include/hdf5_utils.hpp
+++ b/include/hdf5_utils.hpp
@@ -8,7 +8,6 @@
 #include "mfem.hpp"
 #include "hdf5.h"
 #include "linalg_utils.hpp"
-#include "rom_handler.hpp"
 
 namespace mfem
 {
@@ -34,6 +33,47 @@ struct SampleInfo
 
    int qp;         // quadrature point
    double qw;      // quadrature weight
+};
+
+struct BasisTag
+{
+   /* component mesh name */
+   std::string comp = "";
+   /* variable name, if separate basis is used */
+   std::string var = "";
+
+   BasisTag() {}
+
+   BasisTag(const std::string &comp_, const std::string &var_="")
+      : comp(comp_), var(var_) {}
+
+   const std::string print() const
+   {
+      std::string tag = comp;
+      if (var != "")
+         tag += "_" + var;
+      return tag;
+   }
+
+   bool operator==(const BasisTag &tag) const
+   {
+      return ((comp == tag.comp) && (var == tag.var));
+   }
+
+   bool operator<(const BasisTag &tag) const
+   {
+      if (comp == tag.comp)
+         return (var < tag.var);
+
+      return (comp < tag.comp);
+   }
+
+   BasisTag& operator=(const BasisTag &tag)
+   {
+      comp = tag.comp;
+      var = tag.var;
+      return *this;
+   }
 };
 
 }

--- a/include/hyperreduction_integ.hpp
+++ b/include/hyperreduction_integ.hpp
@@ -67,12 +67,9 @@ public:
 
 class HyperReductionIntegrator : virtual public NonlinearFormIntegrator
 {
-public:
-   const bool precomputable;
-
 protected:
-   HyperReductionIntegrator(const bool precomputable_ = false, const IntegrationRule *ir = NULL)
-      : precomputable(precomputable_), NonlinearFormIntegrator(ir) {}
+   HyperReductionIntegrator(const IntegrationRule *ir = NULL)
+      : NonlinearFormIntegrator(ir) {}
 
    // removed const qualifier for basis in order to use its column view vector.
    void GetBasisElement(DenseMatrix &basis, const int col,
@@ -142,7 +139,7 @@ private:
 public:
    VectorConvectionTrilinearFormIntegrator(Coefficient &q, VectorCoefficient *vq = NULL)
       // : HyperReductionIntegrator(true), Q(&q), vQ(vq), coeffs(0) { }
-      : HyperReductionIntegrator(true), Q(&q), vQ(vq) { }
+      : HyperReductionIntegrator(), Q(&q), vQ(vq) { }
 
    VectorConvectionTrilinearFormIntegrator() = default;
 
@@ -195,7 +192,7 @@ private:
 
 public:
    IncompressibleInviscidFluxNLFIntegrator(Coefficient &q)
-      : HyperReductionIntegrator(true), Q(&q) { }
+      : HyperReductionIntegrator(), Q(&q) { }
 
    IncompressibleInviscidFluxNLFIntegrator() = default;
 

--- a/include/hyperreduction_integ.hpp
+++ b/include/hyperreduction_integ.hpp
@@ -117,13 +117,13 @@ public:
                                              DenseMatrix &basis,
                                              const SampleInfo &sample);
 
-   virtual void AddAssembleVector_Fast(const int s, const EQPSample &eqp_sample,
+   virtual void AddAssembleVector_Fast(const EQPSample &eqp_sample,
                                        ElementTransformation &T, const Vector &x, Vector &y);
-   virtual void AddAssembleVector_Fast(const int s, const EQPSample &eqp_sample,
+   virtual void AddAssembleVector_Fast(const EQPSample &eqp_sample,
                                        FaceElementTransformations &T, const Vector &x, Vector &y);
-   virtual void AddAssembleGrad_Fast(const int s, const EQPSample &eqp_sample,
+   virtual void AddAssembleGrad_Fast(const EQPSample &eqp_sample,
                                      ElementTransformation &T, const Vector &x, DenseMatrix &jac);
-   virtual void AddAssembleGrad_Fast(const int s, const EQPSample &eqp_sample,
+   virtual void AddAssembleGrad_Fast(const EQPSample &eqp_sample,
                                      FaceElementTransformations &T, const Vector &x, DenseMatrix &jac);
 };
 
@@ -172,9 +172,9 @@ public:
                                        const Vector &elfun,
                                        DenseMatrix &elmat) override;
 
-   void AddAssembleVector_Fast(const int s, const EQPSample &eqp_sample, 
+   void AddAssembleVector_Fast(const EQPSample &eqp_sample, 
                               ElementTransformation &T, const Vector &x, Vector &y) override;
-   void AddAssembleGrad_Fast(const int s, const EQPSample &eqp_sample, 
+   void AddAssembleGrad_Fast(const EQPSample &eqp_sample, 
                               ElementTransformation &T, const Vector &x, DenseMatrix &jac) override;
 };
 
@@ -223,9 +223,9 @@ public:
                               const Vector &elfun,
                               DenseMatrix &elmat);
 
-   void AddAssembleVector_Fast(const int s, const EQPSample &eqp_sample, 
+   void AddAssembleVector_Fast(const EQPSample &eqp_sample, 
                                  ElementTransformation &T, const Vector &x, Vector &y);
-   void AddAssembleGrad_Fast(const int s, const EQPSample &eqp_sample, 
+   void AddAssembleGrad_Fast(const EQPSample &eqp_sample, 
                               ElementTransformation &T, const Vector &x, DenseMatrix &jac);
 };
 

--- a/include/interfaceinteg.hpp
+++ b/include/interfaceinteg.hpp
@@ -71,17 +71,15 @@ public:
                                           const Vector &eltest1, const Vector &eltest2,
                                           Array2D<DenseMatrix*> &quadmats);
 
-   virtual void AddAssembleVector_Fast(const int s, const double qw,
+   virtual void AddAssembleVector_Fast(const EQPSample &eqp_sample,
                                        FaceElementTransformations &Tr1,
                                        FaceElementTransformations &Tr2,
-                                       const IntegrationPoint &ip,
                                        const Vector &x1, const Vector &x2,
                                        Vector &y1, Vector &y2);
 
-   virtual void AddAssembleGrad_Fast(const int s, const double qw,
+   virtual void AddAssembleGrad_Fast(const EQPSample &eqp_sample,
                                      FaceElementTransformations &Tr1,
                                      FaceElementTransformations &Tr2,
-                                     const IntegrationPoint &ip,
                                      const Vector &x1, const Vector &x2,
                                      Array2D<SparseMatrix *> &jac);
 };
@@ -300,8 +298,6 @@ private:
    DenseMatrix udof1, udof2, elv1, elv2;
    DenseMatrix elmat_comp11, elmat_comp12, elmat_comp21, elmat_comp22;
 
-   // precomputed basis value at the sample point.
-   Array<DenseMatrix *> shapes1, shapes2;
 public:
    DGLaxFriedrichsFluxIntegrator(Coefficient &q, VectorCoefficient *ud = NULL, const IntegrationRule *ir = NULL)
       : InterfaceNonlinearFormIntegrator(ir), Q(&q), UD(ud) {}
@@ -373,17 +369,15 @@ public:
                                  const Vector &eltest1, const Vector &eltest2,
                                  Array2D<DenseMatrix*> &quadmats) override;
 
-   void AddAssembleVector_Fast(const int s, const double qw,
+   void AddAssembleVector_Fast(const EQPSample &eqp_sample,
                               FaceElementTransformations &Tr1,
                               FaceElementTransformations &Tr2,
-                              const IntegrationPoint &ip,
                               const Vector &x1, const Vector &x2,
                               Vector &y1, Vector &y2) override;
 
-   void AddAssembleGrad_Fast(const int s, const double qw,
+   void AddAssembleGrad_Fast(const EQPSample &eqp_sample,
                            FaceElementTransformations &Tr1,
                            FaceElementTransformations &Tr2,
-                           const IntegrationPoint &ip,
                            const Vector &x1, const Vector &x2,
                            Array2D<SparseMatrix *> &jac) override;
 

--- a/include/interfaceinteg.hpp
+++ b/include/interfaceinteg.hpp
@@ -14,8 +14,8 @@ namespace mfem
 class InterfaceNonlinearFormIntegrator : virtual public HyperReductionIntegrator
 {
 protected:
-  InterfaceNonlinearFormIntegrator(const bool precomputable_ = false, const IntegrationRule *ir = NULL)
-      : HyperReductionIntegrator(precomputable_, ir) {}
+   InterfaceNonlinearFormIntegrator(const IntegrationRule *ir = NULL)
+      : HyperReductionIntegrator(ir) {}
 public:
    // FaceElementTransformations belongs to one mesh (having mesh pointer).
    // In order to extract element/transformation from each mesh,
@@ -304,7 +304,7 @@ private:
    Array<DenseMatrix *> shapes1, shapes2;
 public:
    DGLaxFriedrichsFluxIntegrator(Coefficient &q, VectorCoefficient *ud = NULL, const IntegrationRule *ir = NULL)
-      : InterfaceNonlinearFormIntegrator(true, ir), Q(&q), UD(ud) {}
+      : InterfaceNonlinearFormIntegrator(ir), Q(&q), UD(ud) {}
 
    void AssembleFaceVector(const FiniteElement &el1,
                            const FiniteElement &el2,
@@ -333,13 +333,6 @@ public:
                               const double &iw,
                               const Vector &eltest,
                               DenseMatrix &quadmat) override;
-
-   void AppendPrecomputeInteriorFaceCoeffs(const FiniteElementSpace *fes,
-                                       DenseMatrix &basis,
-                                       const SampleInfo &sample) override;
-   void AppendPrecomputeBdrFaceCoeffs(const FiniteElementSpace *fes,
-                                    DenseMatrix &basis,
-                                    const SampleInfo &sample) override;
 
    void AddAssembleVector_Fast(const int s, const EQPSample &eqp_sample,
                               FaceElementTransformations &T,
@@ -416,11 +409,6 @@ private:
                              const DenseMatrix &elfun1, const DenseMatrix &elfun2,
                              double &w, DenseMatrix &gradu1, DenseMatrix &gradu2,
                              DenseMatrix &elmat11, DenseMatrix &elmat12, DenseMatrix &elmat21, DenseMatrix &elmat22);
-
-   void AppendPrecomputeFaceCoeffs(const FiniteElementSpace *fes, 
-                                    FaceElementTransformations *T,
-                                    DenseMatrix &basis,
-                                    const SampleInfo &sample);
 
 };
 

--- a/include/interfaceinteg.hpp
+++ b/include/interfaceinteg.hpp
@@ -330,10 +330,10 @@ public:
                               const Vector &eltest,
                               DenseMatrix &quadmat) override;
 
-   void AddAssembleVector_Fast(const int s, const EQPSample &eqp_sample,
+   void AddAssembleVector_Fast(const EQPSample &eqp_sample,
                               FaceElementTransformations &T,
                               const Vector &x, Vector &y) override;
-   void AddAssembleGrad_Fast(const int s, const EQPSample &eqp_sample,
+   void AddAssembleGrad_Fast(const EQPSample &eqp_sample,
                            FaceElementTransformations &T,
                            const Vector &x, DenseMatrix &jac) override;
 

--- a/include/interfaceinteg.hpp
+++ b/include/interfaceinteg.hpp
@@ -341,11 +341,11 @@ public:
                                     DenseMatrix &basis,
                                     const SampleInfo &sample) override;
 
-   void AddAssembleVector_Fast(const int s, const double qw,
-                              FaceElementTransformations &T, const IntegrationPoint &ip,
+   void AddAssembleVector_Fast(const int s, const EQPSample &eqp_sample,
+                              FaceElementTransformations &T,
                               const Vector &x, Vector &y) override;
-   void AddAssembleGrad_Fast(const int s, const double qw,
-                           FaceElementTransformations &T, const IntegrationPoint &ip,
+   void AddAssembleGrad_Fast(const int s, const EQPSample &eqp_sample,
+                           FaceElementTransformations &T,
                            const Vector &x, DenseMatrix &jac) override;
 
    void AssembleInterfaceVector(const FiniteElement &el1,

--- a/include/linalg_utils.hpp
+++ b/include/linalg_utils.hpp
@@ -182,6 +182,12 @@ void AddSubMatrixRtAP(const DenseMatrix& R, const Array<int> &Rrows,
 void TensorContract(const DenseTensor &tensor, const Vector &xi, const Vector &xj, Vector &yk);
 // y_k += w * T_{ijk} * x_i * x_j
 void TensorAddScaledContract(const DenseTensor &tensor, const double w, const Vector &xi, const Vector &xj, Vector &yk);
+// Contracts along the last axis.
+// M_{ij} = T_{ijk} * x_k
+void TensorMult(const DenseTensor &tensor, const Vector &x, DenseMatrix &M);
+// Contracts along the last axis.
+// M_{ik} += T_{ijk} * x_j
+void TensorAddMultOnJ(const DenseTensor &tensor, const Vector &x, DenseMatrix &M);
 // Contracts along the axis (0 or 1) and add the multipled transpose.
 // axis 0: M_{kj} += T_{ijk} * x_i
 // axis 1: M_{ki} += T_{ijk} * x_j
@@ -226,6 +232,9 @@ private:
 
    double Brent(const Vector &rhs, const Vector &xi, Vector &sol, double b0 = 1e-1, double lin_tol = 1e-2) const;
 };
+
+void GetBasisElement(const DenseMatrix &basis, const int col, const Array<int> vdofs,
+                     Vector &basis_el, DofTransformation *dof_trans=NULL);
 
 }
 

--- a/include/rom_element_collection.hpp
+++ b/include/rom_element_collection.hpp
@@ -6,8 +6,6 @@
 #define SCALEUPROM_ROM_ELEMENT_COLLECTION_HPP
 
 #include "topology_handler.hpp"
-#include "rom_nonlinearform.hpp"
-#include "rom_interfaceform.hpp"
 #include "mfem.hpp"
 #include "hdf5_utils.hpp"
 
@@ -94,25 +92,25 @@ public:
 
 };
 
-class ROMEQPElement : public ROMElementCollection
-{
-public:
-   Array<ROMNonlinearForm *> comp;     // Size(num_components);
-   // boundary condition is enforced via forcing term.
-   Array<Array<ROMNonlinearForm *> *> bdr;
-   ROMInterfaceForm *port = NULL;   // reference ports.
+// class ROMEQPElement : public ROMElementCollection
+// {
+// public:
+//    Array<ROMNonlinearForm *> comp;     // Size(num_components);
+//    // boundary condition is enforced via forcing term.
+//    Array<Array<ROMNonlinearForm *> *> bdr;
+//    ROMInterfaceForm *port = NULL;   // reference ports.
 
-public:
-   ROMEQPElement(TopologyHandler *topol_handler_,
-                 const Array<FiniteElementSpace *> &fes_,
-                 const bool separate_variable_)
-      : ROMElementCollection(topol_handler_, fes_, separate_variable_) {}
+// public:
+//    ROMEQPElement(TopologyHandler *topol_handler_,
+//                  const Array<FiniteElementSpace *> &fes_,
+//                  const bool separate_variable_)
+//       : ROMElementCollection(topol_handler_, fes_, separate_variable_) {}
 
-   virtual ~ROMEQPElement() {}
+//    virtual ~ROMEQPElement() {}
 
-   void Save(const std::string &filename) override {}
-   void Load(const std::string &filename) override {}
+//    void Save(const std::string &filename) override {}
+//    void Load(const std::string &filename) override {}
 
-};
+// };
 
 #endif

--- a/include/rom_handler.hpp
+++ b/include/rom_handler.hpp
@@ -11,6 +11,7 @@
 #include "mfem/Utilities.hpp"
 #include "topology_handler.hpp"
 #include "linalg_utils.hpp"
+#include "hdf5_utils.hpp"
 
 namespace mfem
 {
@@ -29,48 +30,6 @@ enum NonlinearHandling
    EQP,
    NUM_NLNHNDL
 };
-
-struct BasisTag
-{
-   /* component mesh name */
-   std::string comp = "";
-   /* variable name, if separate basis is used */
-   std::string var = "";
-
-   BasisTag() {}
-
-   BasisTag(const std::string &comp_, const std::string &var_="")
-      : comp(comp_), var(var_) {}
-
-   const std::string print() const
-   {
-      std::string tag = comp;
-      if (var != "")
-         tag += "_" + var;
-      return tag;
-   }
-
-   bool operator==(const BasisTag &tag) const
-   {
-      return ((comp == tag.comp) && (var == tag.var));
-   }
-
-   bool operator<(const BasisTag &tag) const
-   {
-      if (comp == tag.comp)
-         return (var < tag.var);
-
-      return (comp < tag.comp);
-   }
-
-   BasisTag& operator=(const BasisTag &tag)
-   {
-      comp = tag.comp;
-      var = tag.var;
-      return *this;
-   }
-};
-
 
 const BasisTag GetBasisTagForComponent(const int &comp_idx, const TopologyHandler *topol_handler, const std::string var_name="");
 const BasisTag GetBasisTag(const int &subdomain_index, const TopologyHandler *topol_handler, const std::string var_name="");

--- a/include/rom_interfaceform.hpp
+++ b/include/rom_interfaceform.hpp
@@ -64,6 +64,8 @@ public:
    const bool PrecomputeMode() { return precompute; }
    void SetPrecomputeMode(const bool precompute_) { precompute = precompute_; }
 
+   void PrecomputeCoefficients();
+
    void SetBasisAtComponent(const int c, DenseMatrix &basis_, const int offset=0);
    void UpdateBlockOffsets();
 
@@ -131,6 +133,9 @@ private:
    using InterfaceForm::AssembleInterfaceVector;
    using InterfaceForm::AssembleInterfaceGrad;
 
+   void PrecomputeEQPSample(const IntegrationRule &ir, const InterfaceInfo &it_info,
+                            FiniteElementSpace *fes1, FiniteElementSpace *fes2,
+                            const DenseMatrix &basis1, const DenseMatrix &basis2, EQPSample &eqp_sample);
 };
 
 } // namespace mfem

--- a/include/rom_interfaceform.hpp
+++ b/include/rom_interfaceform.hpp
@@ -8,6 +8,7 @@
 #include "interface_form.hpp"
 #include "rom_handler.hpp"
 #include "hdf5_utils.hpp"
+#include "hyperreduction_integ.hpp"
 
 namespace mfem
 {
@@ -35,21 +36,21 @@ protected:
    /*
       View Array of fnfi_ref_sample.
       Array of size (fnfi.Size() * topol_handler->GetNumPorts()),
-      where each element is another Array of EQP samples
+      where each element is an EQPElement
       at the given port p and the given integrator i.
       For the port p and the integrator i,
          fnfi_sample[p + i * numPorts]
    */
-   Array<Array<SampleInfo> *> fnfi_sample;
+   Array<EQPElement *> fnfi_sample;
 
    /*
       Array of size (fnfi.Size() * topol_handler->GetNumRefPorts()),
-      where each element is another Array of EQP samples
+      where each element is an EQPElement
       at the given reference port p and the given integrator i.
       For the reference port p and the integrator i,
          fnfi_sample[p + i * numRefPorts]
    */
-   Array<Array<SampleInfo> *> fnfi_ref_sample;
+   Array<EQPElement *> fnfi_ref_sample;
 
    /// @brief Flag for precomputing necessary coefficients for fast computation.
    bool precompute = false;
@@ -59,6 +60,9 @@ public:
                     Array<FiniteElementSpace *> &comp_fes_, TopologyHandler *topol_);
 
    virtual ~ROMInterfaceForm();
+
+   const bool PrecomputeMode() { return precompute; }
+   void SetPrecomputeMode(const bool precompute_) { precompute = precompute_; }
 
    void SetBasisAtComponent(const int c, DenseMatrix &basis_, const int offset=0);
    void UpdateBlockOffsets();
@@ -85,7 +89,7 @@ public:
       if (fnfi_ref_sample[idx])
          delete fnfi_ref_sample[idx];
 
-      fnfi_ref_sample[idx] = new Array<SampleInfo>(samples);
+      fnfi_ref_sample[idx] = new EQPElement(samples);
 
       for (int p = 0; p < numPorts; p++)
       {

--- a/include/rom_interfaceform.hpp
+++ b/include/rom_interfaceform.hpp
@@ -133,7 +133,8 @@ private:
    using InterfaceForm::AssembleInterfaceVector;
    using InterfaceForm::AssembleInterfaceGrad;
 
-   void PrecomputeEQPSample(const IntegrationRule &ir, const InterfaceInfo &it_info,
+   void PrecomputeEQPSample(const IntegrationRule &ir,
+                            FaceElementTransformations *tr1, FaceElementTransformations *tr2,
                             FiniteElementSpace *fes1, FiniteElementSpace *fes2,
                             const DenseMatrix &basis1, const DenseMatrix &basis2, EQPSample &eqp_sample);
 };

--- a/include/rom_nonlinearform.hpp
+++ b/include/rom_nonlinearform.hpp
@@ -228,6 +228,13 @@ public:
        The state @a x must be a true-dof vector. */
    virtual Operator &GetGradient(const Vector &x) const;
 
+private:
+   void GetBasisElement(const DenseMatrix &basis, const int col,
+                        const Array<int> vdofs, Vector &basis_el,
+                        DofTransformation *dof_trans = NULL);
+
+   void PrecomputeDomainEQPSample(const IntegrationRule &ir, const DenseMatrix &basis, EQPSample &eqp_sample);
+
 };
 
 } // namespace mfem

--- a/include/rom_nonlinearform.hpp
+++ b/include/rom_nonlinearform.hpp
@@ -229,10 +229,6 @@ public:
    virtual Operator &GetGradient(const Vector &x) const;
 
 private:
-   void GetBasisElement(const DenseMatrix &basis, const int col,
-                        const Array<int> vdofs, Vector &basis_el,
-                        DofTransformation *dof_trans = NULL);
-
    void PrecomputeDomainEQPSample(const IntegrationRule &ir, const DenseMatrix &basis, EQPSample &eqp_sample);
    void PrecomputeFaceEQPSample(const IntegrationRule &ir, const DenseMatrix &basis,
                                 FaceElementTransformations *T, EQPSample &eqp_sample);

--- a/include/rom_nonlinearform.hpp
+++ b/include/rom_nonlinearform.hpp
@@ -234,6 +234,10 @@ private:
                         DofTransformation *dof_trans = NULL);
 
    void PrecomputeDomainEQPSample(const IntegrationRule &ir, const DenseMatrix &basis, EQPSample &eqp_sample);
+   void PrecomputeFaceEQPSample(const IntegrationRule &ir, const DenseMatrix &basis,
+                                FaceElementTransformations *T, EQPSample &eqp_sample);
+   void PrecomputeInteriorFaceEQPSample(const IntegrationRule &ir, const DenseMatrix &basis, EQPSample &eqp_sample);
+   void PrecomputeBdrFaceEQPSample(const IntegrationRule &ir, const DenseMatrix &basis, EQPSample &eqp_sample);
 
 };
 

--- a/include/rom_nonlinearform.hpp
+++ b/include/rom_nonlinearform.hpp
@@ -9,6 +9,7 @@
 #include "hyperreduction_integ.hpp"
 #include "linalg/NNLS.h"
 #include "hdf5_utils.hpp"
+#include "rom_element_collection.hpp"
 
 namespace mfem
 {
@@ -30,24 +31,31 @@ protected:
    /// Set of Domain Integrators to be assembled (added).
    Array<HyperReductionIntegrator*> dnfi; // owned
    // hyper reduction sampling indexes.
-   Array<Array<SampleInfo> *> dnfi_sample;
+   Array<EQPElement *> dnfi_sample;
 
    /// Set of interior face Integrators to be assembled (added).
    Array<HyperReductionIntegrator*> fnfi; // owned
-   Array<Array<SampleInfo> *> fnfi_sample;
+   Array<EQPElement *> fnfi_sample;
 
    /// Set of boundary face Integrators to be assembled (added).
    Array<HyperReductionIntegrator*> bfnfi; // owned
-   Array<Array<SampleInfo> *> bfnfi_sample;
+   Array<EQPElement *> bfnfi_sample;
 
    /// @brief Flag for precomputing necessary coefficients for fast computation.
    bool precompute = false;
+
+   /*
+      Flag for being reference ROMNonlinearForm.
+      If not reference, all EQPElement arrays are view arrays, not owning them.
+      reference should be turned on only for component RONNonlinearForm.
+    */
+   const bool reference;
 
 public:
    /// Construct a NonlinearForm on the given FiniteElementSpace, @a f.
    /** As an Operator, the NonlinearForm has input and output size equal to the
       number of true degrees of freedom, i.e. f->GetTrueVSize(). */
-   ROMNonlinearForm(const int num_basis, FiniteElementSpace *f);
+   ROMNonlinearForm(const int num_basis, FiniteElementSpace *f, const bool reference_=true);
 
    /** @brief Destroy the NonlinearForm including the owned
        NonlinearFormIntegrator%s and gradient Operator. */
@@ -71,7 +79,7 @@ public:
    void SetupEQPSystemForBdrFaceIntegrator(const CAROM::Matrix &snapshots, HyperReductionIntegrator *nlfi, 
                                            const Array<int> &bdr_attr_marker, CAROM::Matrix &Gt, CAROM::Vector &rhs_Gw, Array<int> &bidxs);
 
-   Array<SampleInfo>* GetEQPForIntegrator(const IntegratorType type, const int k);
+   EQPElement* GetEQPForIntegrator(const IntegratorType type, const int k);
    void SaveEQPForIntegrator(const IntegratorType type, const int k, hid_t file_id, const std::string &dsetname);
    void LoadEQPForIntegrator(const IntegratorType type, const int k, hid_t file_id, const std::string &dsetname);
 
@@ -84,10 +92,23 @@ public:
 
    void UpdateDomainIntegratorSampling(const int i, const Array<SampleInfo> &samples)
    {
+      if (!reference)
+         mfem_error("ROMNonlinearForm::UpdateDomainIntegratorSampling is allowed only for reference!\n");
       assert((i >= 0) && (i < dnfi.Size()));
       assert(dnfi.Size() == dnfi_sample.Size());
 
-      dnfi_sample[i] = new Array<SampleInfo>(samples);
+      if (dnfi_sample[i]) delete dnfi_sample[i];
+      dnfi_sample[i] = new EQPElement(samples);
+   }
+
+   void SetDomainEQPElems(const int i, EQPElement* const eqp_elem)
+   {
+      if (reference)
+         mfem_error("ROMNonlinearForm::SetDomainEQPElems is allowed only for non-reference!\n");
+      assert((i >= 0) && (i < dnfi.Size()));
+      assert(dnfi.Size() == dnfi_sample.Size());
+
+      dnfi_sample[i] = eqp_elem;
    }
 
    /// Access all integrators added with AddDomainIntegrator().
@@ -103,10 +124,23 @@ public:
 
    void UpdateInteriorFaceIntegratorSampling(const int i, const Array<SampleInfo> &samples)
    {
+      if (!reference)
+         mfem_error("ROMNonlinearForm::UpdateInteriorFaceIntegratorSampling is allowed only for reference!\n");
       assert((i >= 0) && (i < fnfi.Size()));
       assert(fnfi.Size() == fnfi_sample.Size());
 
-      fnfi_sample[i] = new Array<SampleInfo>(samples);
+      if (fnfi_sample[i]) delete fnfi_sample[i];
+      fnfi_sample[i] = new EQPElement(samples);
+   }
+
+   void SetInteriorEQPElems(const int i, EQPElement* const eqp_elem)
+   {
+      if (reference)
+         mfem_error("ROMNonlinearForm::SetInteriorEQPElems is allowed only for non-reference!\n");
+      assert((i >= 0) && (i < fnfi.Size()));
+      assert(fnfi.Size() == fnfi_sample.Size());
+
+      fnfi_sample[i] = eqp_elem;
    }
 
    /** @brief Access all interior face integrators added with
@@ -135,10 +169,23 @@ public:
 
    void UpdateBdrFaceIntegratorSampling(const int i, const Array<SampleInfo> &samples)
    {
+      if (!reference)
+         mfem_error("ROMNonlinearForm::UpdateBdrFaceIntegratorSampling is allowed only for reference!\n");
       assert((i >= 0) && (i < bfnfi.Size()));
       assert(bfnfi.Size() == bfnfi_sample.Size());
 
-      bfnfi_sample[i] = new Array<SampleInfo>(samples);
+      if (bfnfi_sample[i]) delete bfnfi_sample[i];
+      bfnfi_sample[i] = new EQPElement(samples);
+   }
+
+   void SetBdrEQPElems(const int i, EQPElement* const eqp_elem)
+   {
+      if (reference)
+         mfem_error("ROMNonlinearForm::SetBdrEQPElems is allowed only for non-reference!\n");
+      assert((i >= 0) && (i < bfnfi.Size()));
+      assert(bfnfi.Size() == bfnfi_sample.Size());
+
+      bfnfi_sample[i] = eqp_elem;
    }
 
    /** @brief Access all boundary face integrators added with

--- a/include/steady_ns_solver.hpp
+++ b/include/steady_ns_solver.hpp
@@ -7,6 +7,7 @@
 
 #include "stokes_solver.hpp"
 #include "rom_nonlinearform.hpp"
+#include "rom_interfaceform.hpp"
 
 // By convention we only use mfem namespace as default, not CAROM.
 using namespace mfem;

--- a/sketches/ns_rom.cpp
+++ b/sketches/ns_rom.cpp
@@ -1435,7 +1435,7 @@ int main(int argc, char *argv[])
          rom_nlinf->SetBasis(u_basis);
 
          rom_nlinf->TrainEQP(*snapshots, eqp_tol);
-         Array<SampleInfo> *samples = rom_nlinf->GetEQPForIntegrator(IntegratorType::DOMAIN, 0);
+         Array<SampleInfo> *samples = &(rom_nlinf->GetEQPForIntegrator(IntegratorType::DOMAIN, 0)->samples);
 
          {  // save empirical quadrature point locations.
             ElementTransformation *T;

--- a/sketches/ns_rom.cpp
+++ b/sketches/ns_rom.cpp
@@ -1435,16 +1435,17 @@ int main(int argc, char *argv[])
          rom_nlinf->SetBasis(u_basis);
 
          rom_nlinf->TrainEQP(*snapshots, eqp_tol);
-         Array<SampleInfo> *samples = &(rom_nlinf->GetEQPForIntegrator(IntegratorType::DOMAIN, 0)->samples);
+         EQPElement *eqp_elem = rom_nlinf->GetEQPForIntegrator(IntegratorType::DOMAIN, 0);
 
          {  // save empirical quadrature point locations.
             ElementTransformation *T;
             Vector loc(dim);
-            DenseMatrix qp_loc(samples->Size(), dim);
-            for (int p = 0; p < samples->Size(); p++)
+            DenseMatrix qp_loc(eqp_elem->Size(), dim);
+            for (int p = 0; p < eqp_elem->Size(); p++)
             {
-               T = ufes->GetElementTransformation((*samples)[p].el);
-               const IntegrationPoint &ip = ir->IntPoint((*samples)[p].qp);
+               EQPSample *sample = eqp_elem->GetSample(p);
+               T = ufes->GetElementTransformation(sample->info.el);
+               const IntegrationPoint &ip = ir->IntPoint(sample->info.qp);
                T->Transform(ip, loc);
 
                for (int d = 0; d < dim; d++)

--- a/src/hyperreduction_integ.cpp
+++ b/src/hyperreduction_integ.cpp
@@ -144,7 +144,7 @@ void HyperReductionIntegrator::AppendPrecomputeBdrFaceCoeffs(
 }
 
 void HyperReductionIntegrator::AddAssembleVector_Fast(
-   const int s, const EQPSample &eqp_sample, ElementTransformation &T, const Vector &x, Vector &y)
+   const EQPSample &eqp_sample, ElementTransformation &T, const Vector &x, Vector &y)
 {
    mfem_error ("HyperReductionIntegrator::AddAssembleVector_Fast(...)\n"
                "is not implemented for this class,\n"
@@ -152,7 +152,7 @@ void HyperReductionIntegrator::AddAssembleVector_Fast(
 }
 
 void HyperReductionIntegrator::AddAssembleVector_Fast(
-   const int s, const EQPSample &eqp_sample, FaceElementTransformations &T, const Vector &x, Vector &y)
+   const EQPSample &eqp_sample, FaceElementTransformations &T, const Vector &x, Vector &y)
 {
    mfem_error ("HyperReductionIntegrator::AddAssembleVector_Fast(...)\n"
                "is not implemented for this class,\n"
@@ -160,7 +160,7 @@ void HyperReductionIntegrator::AddAssembleVector_Fast(
 }
 
 void HyperReductionIntegrator::AddAssembleGrad_Fast(
-   const int s, const EQPSample &eqp_sample, ElementTransformation &T, const Vector &x, DenseMatrix &jac)
+   const EQPSample &eqp_sample, ElementTransformation &T, const Vector &x, DenseMatrix &jac)
 {
    mfem_error ("HyperReductionIntegrator::AddAssembleGrad_Fast(...)\n"
                "is not implemented for this class,\n"
@@ -168,7 +168,7 @@ void HyperReductionIntegrator::AddAssembleGrad_Fast(
 }
 
 void HyperReductionIntegrator::AddAssembleGrad_Fast(
-   const int s, const EQPSample &eqp_sample, FaceElementTransformations &T, const Vector &x, DenseMatrix &jac)
+   const EQPSample &eqp_sample, FaceElementTransformations &T, const Vector &x, DenseMatrix &jac)
 {
    mfem_error ("HyperReductionIntegrator::AddAssembleGrad_Fast(...)\n"
                "is not implemented for this class,\n"
@@ -464,7 +464,7 @@ void VectorConvectionTrilinearFormIntegrator::AssembleQuadratureGrad(
 }
 
 void VectorConvectionTrilinearFormIntegrator::AddAssembleVector_Fast(
-   const int s, const EQPSample &eqp_sample, ElementTransformation &T, const Vector &x, Vector &y)
+   const EQPSample &eqp_sample, ElementTransformation &T, const Vector &x, Vector &y)
 {
    const IntegrationPoint &ip = GetIntegrationRule()->IntPoint(eqp_sample.info.qp);
    const double qw = eqp_sample.info.qw;
@@ -491,7 +491,7 @@ void VectorConvectionTrilinearFormIntegrator::AddAssembleVector_Fast(
 }
 
 void VectorConvectionTrilinearFormIntegrator::AddAssembleGrad_Fast(
-   const int s, const EQPSample &eqp_sample, ElementTransformation &T, const Vector &x, DenseMatrix &jac)
+   const EQPSample &eqp_sample, ElementTransformation &T, const Vector &x, DenseMatrix &jac)
 {
    const IntegrationPoint &ip = GetIntegrationRule()->IntPoint(eqp_sample.info.qp);
    const double qw = eqp_sample.info.qw;
@@ -727,7 +727,7 @@ void IncompressibleInviscidFluxNLFIntegrator::AssembleQuadratureGrad(
 }
 
 void IncompressibleInviscidFluxNLFIntegrator::AddAssembleVector_Fast(
-   const int s, const EQPSample &eqp_sample, ElementTransformation &T, const Vector &x, Vector &y)
+   const EQPSample &eqp_sample, ElementTransformation &T, const Vector &x, Vector &y)
 {
    const IntegrationPoint &ip = GetIntegrationRule()->IntPoint(eqp_sample.info.qp);
    const double qw = eqp_sample.info.qw;
@@ -753,7 +753,7 @@ void IncompressibleInviscidFluxNLFIntegrator::AddAssembleVector_Fast(
 }
 
 void IncompressibleInviscidFluxNLFIntegrator::AddAssembleGrad_Fast(
-   const int s, const EQPSample &eqp_sample, ElementTransformation &T, const Vector &x, DenseMatrix &jac)
+   const EQPSample &eqp_sample, ElementTransformation &T, const Vector &x, DenseMatrix &jac)
 {
    const IntegrationPoint &ip = GetIntegrationRule()->IntPoint(eqp_sample.info.qp);
    const double qw = eqp_sample.info.qw;

--- a/src/interface_form.cpp
+++ b/src/interface_form.cpp
@@ -190,13 +190,15 @@ void InterfaceForm::AssembleInterfaceMatrixAtPort(
 
    int c1, c2;
    topol_handler->GetComponentPair(p, c1, c2);
-   Mesh *comp1 = topol_handler->GetComponentMesh(c1);
-   Mesh *comp2 = topol_handler->GetComponentMesh(c2);
 
    // NOTE: If comp1 == comp2, using comp1 and comp2 directly leads to an incorrect penalty matrix.
    // Need to use two copied instances.
-   Mesh mesh1(*comp1);
-   Mesh mesh2(*comp2);
+   Mesh *comp1 = topol_handler->GetComponentMesh(c1);
+   Mesh *comp2;
+   if (c1 == c2)
+      comp2 = new Mesh(*comp1);
+   else
+      comp2 = topol_handler->GetComponentMesh(c2);
 
    Array<int> c_idx(2);
    c_idx[0] = c1;
@@ -210,10 +212,13 @@ void InterfaceForm::AssembleInterfaceMatrixAtPort(
 
    // NOTE: If comp1 == comp2, using comp1 and comp2 directly leads to an incorrect penalty matrix.
    // Need to use two copied instances.
-   AssembleInterfaceMatrix(&mesh1, &mesh2, fes_comp[c1], fes_comp[c2], if_infos, mats_p);
+   AssembleInterfaceMatrix(comp1, comp2, fes_comp[c1], fes_comp[c2], if_infos, mats_p);
 
    for (int i = 0; i < 2; i++)
       for (int j = 0; j < 2; j++) mats_p(i, j)->Finalize();
+
+   if (c1 == c2)
+      delete comp2;
 }
 
 void InterfaceForm::AssembleInterfaceVector(Mesh *mesh1, Mesh *mesh2,

--- a/src/interfaceinteg.cpp
+++ b/src/interfaceinteg.cpp
@@ -1802,8 +1802,11 @@ void DGLaxFriedrichsFluxIntegrator::AppendPrecomputeFaceCoeffs(
 }
 
 void DGLaxFriedrichsFluxIntegrator::AddAssembleVector_Fast(
-   const int s, const double qw, FaceElementTransformations &T, const IntegrationPoint &ip, const Vector &x, Vector &y)
+   const int s, const EQPSample &eqp_sample, FaceElementTransformations &T, const Vector &x, Vector &y)
 {
+   const IntegrationPoint &ip = GetIntegrationRule()->IntPoint(eqp_sample.info.qp);
+   const double qw = eqp_sample.info.qw;
+
    const bool el2 = (T.Elem2No >= 0);
 
    dim = shapes1[s]->NumRows();
@@ -1846,8 +1849,11 @@ void DGLaxFriedrichsFluxIntegrator::AddAssembleVector_Fast(
 }
 
 void DGLaxFriedrichsFluxIntegrator::AddAssembleGrad_Fast(
-   const int s, const double qw, FaceElementTransformations &T, const IntegrationPoint &ip, const Vector &x, DenseMatrix &jac)
+   const int s, const EQPSample &eqp_sample, FaceElementTransformations &T, const Vector &x, DenseMatrix &jac)
 {
+   const IntegrationPoint &ip = GetIntegrationRule()->IntPoint(eqp_sample.info.qp);
+   const double qw = eqp_sample.info.qw;
+
    const bool el2 = (T.Elem2No >= 0);
 
    dim = shapes1[s]->NumRows();

--- a/src/interfaceinteg.cpp
+++ b/src/interfaceinteg.cpp
@@ -1754,8 +1754,8 @@ void DGLaxFriedrichsFluxIntegrator::AddAssembleVector_Fast(
    if (Q) { w *= Q->Eval(T, ip); }
 
    assert(y.Size() == x.Size());
-   shapes1->AddMultTranspose(flux, y, 1.0);
-   if (el2) shapes2->AddMultTranspose(flux, y, -1.0);
+   shapes1->AddMultTranspose(flux, y, -w);
+   if (el2) shapes2->AddMultTranspose(flux, y, w);
 }
 
 void DGLaxFriedrichsFluxIntegrator::AddAssembleGrad_Fast(

--- a/src/interfaceinteg.cpp
+++ b/src/interfaceinteg.cpp
@@ -1710,7 +1710,7 @@ void DGLaxFriedrichsFluxIntegrator::AssembleQuadratureGrad(
 }
 
 void DGLaxFriedrichsFluxIntegrator::AddAssembleVector_Fast(
-   const int s, const EQPSample &eqp_sample, FaceElementTransformations &T, const Vector &x, Vector &y)
+   const EQPSample &eqp_sample, FaceElementTransformations &T, const Vector &x, Vector &y)
 {
    const IntegrationPoint &ip = GetIntegrationRule()->IntPoint(eqp_sample.info.qp);
    const double qw = eqp_sample.info.qw;
@@ -1759,7 +1759,7 @@ void DGLaxFriedrichsFluxIntegrator::AddAssembleVector_Fast(
 }
 
 void DGLaxFriedrichsFluxIntegrator::AddAssembleGrad_Fast(
-   const int s, const EQPSample &eqp_sample, FaceElementTransformations &T, const Vector &x, DenseMatrix &jac)
+   const EQPSample &eqp_sample, FaceElementTransformations &T, const Vector &x, DenseMatrix &jac)
 {
    const IntegrationPoint &ip = GetIntegrationRule()->IntPoint(eqp_sample.info.qp);
    const double qw = eqp_sample.info.qw;

--- a/src/rom_interfaceform.cpp
+++ b/src/rom_interfaceform.cpp
@@ -137,7 +137,7 @@ void ROMInterfaceForm::InterfaceAddMult(const Vector &x, Vector &y) const
             topol_handler->GetInterfaceTransformations(mesh1, mesh2, if_info, tr1, tr2);
             const IntegrationPoint &ip = ir->IntPoint(sample->qp);
 
-            if (precompute && (fnfi[k]->precomputable))
+            if (precompute)
                mfem_error("ROMInterfaceForm- precompute mode is not implemented!\n");
             else
             {
@@ -172,7 +172,7 @@ void ROMInterfaceForm::InterfaceAddMult(const Vector &x, Vector &y) const
 
                AddMultTransposeSubMatrix(*basis1, vdofs1, el_y1, y1);
                AddMultTransposeSubMatrix(*basis2, vdofs2, el_y2, y2);
-            }  // if not (precompute && (fnfi[k]->precomputable))
+            }  // if not (precompute)
          }  // for (int i = 0; i < sample_info->Size(); i++, sample++)
       }  // for (int p = 0; p < numPorts; p++)
    }  // for (int k = 0; k < fnfi.Size(); k++)
@@ -260,7 +260,7 @@ void ROMInterfaceForm::InterfaceGetGradient(const Vector &x, Array2D<SparseMatri
             topol_handler->GetInterfaceTransformations(mesh1, mesh2, if_info, tr1, tr2);
             const IntegrationPoint &ip = ir->IntPoint(sample->qp);
 
-            if (precompute && (fnfi[k]->precomputable))
+            if (precompute)
                mfem_error("ROMInterfaceForm- precompute mode is not implemented!\n");
             else
             {
@@ -297,7 +297,7 @@ void ROMInterfaceForm::InterfaceGetGradient(const Vector &x, Array2D<SparseMatri
                AddSubMatrixRtAP(*basis1, vdofs1, *quadmats(0, 1), *basis2, vdofs2, *mats_p(0, 1));
                AddSubMatrixRtAP(*basis2, vdofs2, *quadmats(1, 0), *basis1, vdofs1, *mats_p(1, 0));
                AddSubMatrixRtAP(*basis2, vdofs2, *quadmats(1, 1), *basis2, vdofs2, *mats_p(1, 1));
-            }  // if not (precompute && (fnfi[k]->precomputable))
+            }  // if not (precompute)
          }  // for (int i = 0; i < sample_info->Size(); i++, sample++)
       }  // for (int p = 0; p < numPorts; p++)
    }  // for (int k = 0; k < fnfi.Size(); k++)

--- a/src/rom_interfaceform.cpp
+++ b/src/rom_interfaceform.cpp
@@ -719,7 +719,7 @@ void ROMInterfaceForm::PrecomputeCoefficients()
          interface_infos = topol_handler->GetRefInterfaceInfos(p);
          assert(interface_infos);
 
-         eqp_elem = fnfi_sample[p + k * numRefPorts];
+         eqp_elem = fnfi_ref_sample[p + k * numRefPorts];
          assert(eqp_elem);
 
          topol_handler->GetComponentPair(p, c1, c2);

--- a/src/rom_nonlinearform.cpp
+++ b/src/rom_nonlinearform.cpp
@@ -1459,6 +1459,8 @@ void ROMNonlinearForm::PrecomputeFaceEQPSample(
 
    eqp_sample.shape1 = vec1s;
    if (el2) eqp_sample.shape2 = vec2s;
+
+   // TODO(kevin): compute dshape1 and dshape2 as well.
 }
 
 void ROMNonlinearForm::PrecomputeInteriorFaceEQPSample(

--- a/src/rom_nonlinearform.cpp
+++ b/src/rom_nonlinearform.cpp
@@ -1343,15 +1343,6 @@ void ROMNonlinearForm::LoadEQPForIntegrator(
    return;
 }
 
-void ROMNonlinearForm::GetBasisElement(
-   const DenseMatrix &basis, const int col, const Array<int> vdofs, Vector &basis_el, DofTransformation *dof_trans)
-{
-   Vector tmp;
-   const_cast<DenseMatrix &>(basis).GetColumnReference(col, tmp);
-   tmp.GetSubVector(vdofs, basis_el);   // this involves a copy.
-   if (dof_trans) {dof_trans->InvTransformPrimal(basis_el); }
-}
-
 void ROMNonlinearForm::PrecomputeDomainEQPSample(
    const IntegrationRule &ir, const DenseMatrix &basis, EQPSample &eqp_sample)
 {

--- a/src/rom_nonlinearform.cpp
+++ b/src/rom_nonlinearform.cpp
@@ -116,7 +116,7 @@ void ROMNonlinearForm::Mult(const Vector &x, Vector &y) const
 
             if (precompute)
             {
-               dnfi[k]->AddAssembleVector_Fast(i, *sample, *T, x, y);
+               dnfi[k]->AddAssembleVector_Fast(*sample, *T, x, y);
                continue;
             }
 
@@ -163,7 +163,7 @@ void ROMNonlinearForm::Mult(const Vector &x, Vector &y) const
 
             if (precompute)
             {
-               fnfi[k]->AddAssembleVector_Fast(i, *sample, *tr, x, y);
+               fnfi[k]->AddAssembleVector_Fast(*sample, *tr, x, y);
                continue;
             }
 
@@ -252,7 +252,7 @@ void ROMNonlinearForm::Mult(const Vector &x, Vector &y) const
 
             if (precompute)
             {
-               bfnfi[k]->AddAssembleVector_Fast(i, *sample, *tr, x, y);
+               bfnfi[k]->AddAssembleVector_Fast(*sample, *tr, x, y);
                continue;
             }
 
@@ -376,7 +376,7 @@ Operator& ROMNonlinearForm::GetGradient(const Vector &x) const
             jac_timers[3]->Start();
             if (precompute)
             {
-               dnfi[k]->AddAssembleGrad_Fast(i, *sample, *T, x, *Grad);
+               dnfi[k]->AddAssembleGrad_Fast(*sample, *T, x, *Grad);
                continue;
             }
 
@@ -426,7 +426,7 @@ Operator& ROMNonlinearForm::GetGradient(const Vector &x) const
 
             if (precompute)
             {
-               fnfi[k]->AddAssembleGrad_Fast(i, *sample, *tr, x, *Grad);
+               fnfi[k]->AddAssembleGrad_Fast(*sample, *tr, x, *Grad);
                continue;
             }
 
@@ -516,7 +516,7 @@ Operator& ROMNonlinearForm::GetGradient(const Vector &x) const
 
             if (precompute)
             {
-               bfnfi[k]->AddAssembleGrad_Fast(i, *sample, *tr, x, *Grad);
+               bfnfi[k]->AddAssembleGrad_Fast(*sample, *tr, x, *Grad);
                continue;
             }
 

--- a/src/steady_ns_solver.cpp
+++ b/src/steady_ns_solver.cpp
@@ -1031,6 +1031,8 @@ void SteadyNSSolver::AllocateROMEQPElems()
       itf_eqp->SetBasisAtComponent(c, *basis);
    }
    itf_eqp->UpdateBlockOffsets();
+
+   itf_eqp->SetPrecomputeMode(precompute);
 }
 
 void SteadyNSSolver::TrainROMEQPElems(SampleGenerator *sample_generator)
@@ -1215,7 +1217,12 @@ void SteadyNSSolver::LoadEQPElems(const std::string &filename)
    assert(errf >= 0);
 
    if (oper_type == OperType::LF)
+   {
       itf_eqp->LoadEQPForIntegrator(0, file_id, "interface_integ0");
+
+      if (itf_eqp->PrecomputeMode())
+         itf_eqp->PrecomputeCoefficients();
+   }
 
    errf = H5Fclose(file_id);
    assert(errf >= 0);
@@ -1304,8 +1311,6 @@ void SteadyNSSolver::AssembleROMEQPOper()
       subdomain_eqps[m]->SetBasis(*basis);
       // TODO(kevin): load these coefficients, not re-computing.
       subdomain_eqps[m]->SetPrecomputeMode(comp_eqps[c_type]->PrecomputeMode());
-      if (subdomain_eqps[m]->PrecomputeMode())
-         subdomain_eqps[m]->PrecomputeCoefficients();
    }  // for (int m = 0; m < numSub; m++)
 
    /* ROMInterfaceForm is already loaded */

--- a/src/steady_ns_solver.cpp
+++ b/src/steady_ns_solver.cpp
@@ -1240,7 +1240,7 @@ void SteadyNSSolver::AssembleROMEQPOper()
       int idx = (separate_variable_basis) ? m * num_var : m;
       rom_handler->GetDomainBasis(idx, basis);
 
-      subdomain_eqps[m] = new ROMNonlinearForm(basis->NumCols(), ufes[m]);
+      subdomain_eqps[m] = new ROMNonlinearForm(basis->NumCols(), ufes[m], false);
 
       switch (oper_type)
       {
@@ -1249,8 +1249,8 @@ void SteadyNSSolver::AssembleROMEQPOper()
          nl_integ_tmp->SetIntRule(ir_nl);
          subdomain_eqps[m]->AddDomainIntegrator(nl_integ_tmp);
 
-         subdomain_eqps[m]->UpdateDomainIntegratorSampling(0,
-            *(comp_eqps[c_type]->GetEQPForIntegrator(IntegratorType::DOMAIN, 0)));
+         subdomain_eqps[m]->SetDomainEQPElems(0,
+            comp_eqps[c_type]->GetEQPForIntegrator(IntegratorType::DOMAIN, 0));
          break;
       
       case (OperType::LF):
@@ -1264,11 +1264,11 @@ void SteadyNSSolver::AssembleROMEQPOper()
          if (full_dg)
             subdomain_eqps[m]->AddInteriorFaceIntegrator(lf_integ2);
 
-         subdomain_eqps[m]->UpdateDomainIntegratorSampling(0,
-            *(comp_eqps[c_type]->GetEQPForIntegrator(IntegratorType::DOMAIN, 0)));
+         subdomain_eqps[m]->SetDomainEQPElems(0,
+            comp_eqps[c_type]->GetEQPForIntegrator(IntegratorType::DOMAIN, 0));
          if (full_dg)
-            subdomain_eqps[m]->UpdateInteriorFaceIntegratorSampling(0,
-               *(comp_eqps[c_type]->GetEQPForIntegrator(IntegratorType::INTERIORFACE, 0)));
+            subdomain_eqps[m]->SetInteriorEQPElems(0,
+               comp_eqps[c_type]->GetEQPForIntegrator(IntegratorType::INTERIORFACE, 0));
 
          Array<int> *bdr_c2g = topol_handler->GetBdrAttrComponentToGlobalMap(m);
          int idx = 0;
@@ -1290,8 +1290,8 @@ void SteadyNSSolver::AssembleROMEQPOper()
             subdomain_eqps[m]->AddBdrFaceIntegrator(lf_integ2, *bdr_markers[global_idx]);
 
             int kind = (bdr_type[global_idx] == BoundaryType::ZERO) ? 1 : 0;
-            subdomain_eqps[m]->UpdateBdrFaceIntegratorSampling(idx,
-               *(comp_eqps[c_type]->GetEQPForIntegrator(IntegratorType::BDRFACE, 2 * b + kind)));
+            subdomain_eqps[m]->SetBdrEQPElems(idx,
+               comp_eqps[c_type]->GetEQPForIntegrator(IntegratorType::BDRFACE, 2 * b + kind));
 
             idx++;
          }  // for (int b = 0; b < bdr_c2g->Size(); b++)

--- a/src/topology_handler.cpp
+++ b/src/topology_handler.cpp
@@ -54,6 +54,9 @@ void TopologyHandler::GetInterfaceTransformations(Mesh *m1, Mesh *m2, const Inte
                                                    FaceElementTransformations* &tr1,
                                                    FaceElementTransformations* &tr2)
 {
+   if (m1 == m2)
+      mfem_error("TopologyHandler::GetInterfaceTransformations- two meshes should not be identical!\n");
+
    // We cannot write a function that replaces this, since only Mesh can access to FaceElemTr.SetConfigurationMask.
    tr1 = m1->GetBdrFaceTransformations(if_info->BE1);
    tr2 = m2->GetBdrFaceTransformations(if_info->BE2);

--- a/test/nonlinear_integ_grad.cpp
+++ b/test/nonlinear_integ_grad.cpp
@@ -12,11 +12,11 @@
 using namespace std;
 using namespace mfem;
 
-enum IntegratorType {
+enum TestIntegratorType {
    DOMAIN, INTERIOR, BDR
 };
 
-void CheckGradient(NonlinearFormIntegrator *integ, const IntegratorType type, bool use_dg=false)
+void CheckGradient(NonlinearFormIntegrator *integ, const TestIntegratorType type, bool use_dg=false)
 {   
    // 1. Parse command-line options.
    std::string mesh_file = config.GetRequiredOption<std::string>("mesh/filename");
@@ -67,13 +67,13 @@ void CheckGradient(NonlinearFormIntegrator *integ, const IntegratorType type, bo
    integ->SetIntRule(&gll_ir_nl);
    switch (type)
    {
-      case DOMAIN:
+      case TestIntegratorType::DOMAIN:
          nform->AddDomainIntegrator(integ);
          break;
-      case INTERIOR:
+      case TestIntegratorType::INTERIOR:
          nform->AddInteriorFaceIntegrator(integ);
          break;
-      case BDR:
+      case TestIntegratorType::BDR:
          nform->AddBdrFaceIntegrator(integ, ess_attr);
          break;
       default:
@@ -176,7 +176,7 @@ TEST(IncompressibleInviscidFlux, Test_grad)
    auto *nlc_nlfi = new IncompressibleInviscidFluxNLFIntegrator(pi);
    // auto *nlc_nlfi = new VectorConvectionNLFIntegrator(pi);
     
-   CheckGradient(nlc_nlfi, IntegratorType::DOMAIN, use_dg);
+   CheckGradient(nlc_nlfi, TestIntegratorType::DOMAIN, use_dg);
 
    return;
 }
@@ -189,7 +189,7 @@ TEST(DGLaxFriedrichsFlux, Test_grad_interior)
    ConstantCoefficient pi(3.141592);
    auto *nlc_nlfi = new DGLaxFriedrichsFluxIntegrator(pi);
     
-   CheckGradient(nlc_nlfi, IntegratorType::INTERIOR, true);
+   CheckGradient(nlc_nlfi, TestIntegratorType::INTERIOR, true);
 
    return;
 }
@@ -202,7 +202,7 @@ TEST(DGLaxFriedrichsFlux, Test_grad_bdr)
    ConstantCoefficient pi(3.141592);
    auto *nlc_nlfi = new DGLaxFriedrichsFluxIntegrator(pi);
     
-   CheckGradient(nlc_nlfi, IntegratorType::BDR, true);
+   CheckGradient(nlc_nlfi, TestIntegratorType::BDR, true);
 
    return;
 }
@@ -215,7 +215,7 @@ TEST(DGTemamFlux, Test_grad_interior)
    ConstantCoefficient pi(3.141592);
    auto *nlc_nlfi = new DGTemamFluxIntegrator(pi);
     
-   CheckGradient(nlc_nlfi, IntegratorType::INTERIOR, true);
+   CheckGradient(nlc_nlfi, TestIntegratorType::INTERIOR, true);
 
    return;
 }
@@ -228,7 +228,7 @@ TEST(DGTemamFlux, Test_grad_bdr)
    ConstantCoefficient pi(3.141592);
    auto *nlc_nlfi = new DGTemamFluxIntegrator(pi);
     
-   CheckGradient(nlc_nlfi, IntegratorType::BDR, true);
+   CheckGradient(nlc_nlfi, TestIntegratorType::BDR, true);
 
    return;
 }
@@ -241,7 +241,7 @@ TEST(VectorConvectionTrilinearFormIntegrator, Test_grad)
    ConstantCoefficient pi(3.141592);
    auto *nlc_nlfi = new VectorConvectionTrilinearFormIntegrator(pi);
     
-   CheckGradient(nlc_nlfi, IntegratorType::DOMAIN, false);
+   CheckGradient(nlc_nlfi, TestIntegratorType::DOMAIN, false);
 
    return;
 }
@@ -254,7 +254,7 @@ TEST(TemamTrilinearFormIntegrator, Test_grad)
    ConstantCoefficient pi(3.141592);
    auto *nlc_nlfi = new TemamTrilinearFormIntegrator(pi);
     
-   CheckGradient(nlc_nlfi, IntegratorType::DOMAIN, false);
+   CheckGradient(nlc_nlfi, TestIntegratorType::DOMAIN, false);
 
    return;
 }


### PR DESCRIPTION
# Important bug fix on `TopologyHandler::GetInterfaceTransformations`

`TopologyHandler::GetInterfaceTransformations` does not return proper `FaceElementTransformations`s, if two input meshes are an identical object. Previously it was not explicitly known where this is happening, and only `InterfaceForm::AssembleInterfaceMatrixAtPort` implicitly handled it.

`TopologyHandler::GetInterfaceTransformations` now enforces the input meshes to be not identical, and all routines using this function ensure to pass a copied object if two meshes are identical.

**NOTE**: currently copying a mesh only happens at matrix assembly/EQP training and does not impact the performance of the ROM solve.

# EQPSample

This class is essentially a quadrature point for EQP scheme. It contains:
- `SampleInfo`
- Shape functions and gradient of shape functions

# EQPElement

This class is essentially a finite element for EQP scheme. Actually, it serves as a container for array of `EQPSample`, supporting file I/O for them.

# Changes in HyperreductionIntegrator

## Fast integration routines taking `EQPSample`

Instead of passing sample point and weight individually, now an `EQPSample` is passed as an input. This `EQPSample` contains precomputed shape functions and their gradients.

## Removed precomputation

- Previously we let `HyperreductionIntegrator` to decide what type of coefficients it would use, but now all `HyperreductionIntegrator`s are regulated to use the shape functions and their gradients.
- `HyperreductionIntegrator` used to have a member variable `bool precomputable`, in order to specify the integrators that support precomputed EQP scheme. Now that all EQP shape functions are moved out of the integrator, this member variable `precomputable` is removed and all integrators should be able to support precomputed EQP scheme.

# Changes in ROMNonlinearForm and ROMInterfaceForm

- Instead of storing arrays of `SampleInfo`, now arrays of `EQPElement`s are stored.
- `PrecomputeCoefficients` routines compute the shape functions and their gradients. 
- `Mult` (`InterfaceAddMult`) and `GetGradient` (`InterfaceGradient`) now iterate over `EQPSample`s.

## Changes in ROMNonlinearForm

There are now two ways of changing the `EQPElement` arrays, depending on the use of `ROMNonlinearForm`:

- `Update...IntegratorSampling` assumes the ownership of `EQPElement` arrays. It deletes the existing array and creates a new one to contain the input samples.
- `Set...EQPElems` assumes the non-ownership of `EQPElement` arrays. It only changes the pointer to the `EQPElement` array.

It is determined by a member variable `const bool reference`, which denotes whether the object is a reference to create/train EQP samples:

- `reference=true` is set for component `ROMNonlinearForm`.
  - EQP samples can be created and trained via `TrainEQP`, and updated via `Update...IntegratorSampling`.
  - `Set...EQPElems` routines are forbidden, which store pointers to `EQPElement` of other (reference) `ROMNonlinearForm`.
- `reference=false` is set for subdomain `ROMNonlinearForm`.
  - Subdomain `ROMNonlinearForm` is supposed to only use the pre-trained `EQPSample`s. The use of `TrainEQP` and `Update...IntegratorSampling` is forbidden.
  - It is only supposed to use `Set...EQPElems` routines, in order to use `EQPElement` from other (reference) `ROMNonlinearForm`.

# Some datatypes moved to `include/hdf5_utils.hpp`
- `BasisTag`
- `SampleInfo`

We may want a separate header file for datatypes.