### PR TITLE
EQP ROM workflow for unsteady NS

### DIFF
--- a/include/multiblock_solver.hpp
+++ b/include/multiblock_solver.hpp
@@ -259,6 +259,9 @@ public:
    void ComputeSubdomainErrorAndNorm(GridFunction *fom_sol, GridFunction *rom_sol, double &error, double &norm);
    void ComputeRelativeError(Array<GridFunction *> fom_sols, Array<GridFunction *> rom_sols, Vector &error);
    void CompareSolution(BlockVector &test_U, Vector &error);
+
+protected:
+   virtual void AssembleROMMat(BlockMatrix &romMat);
 };
 
 #endif

--- a/include/rom_element_collection.hpp
+++ b/include/rom_element_collection.hpp
@@ -50,6 +50,8 @@ public:
    Array<Array<MatrixBlocks *> *> bdr;
    Array<MatrixBlocks *> port;   // reference ports.
 
+   Array<MatrixBlocks *> mass;     // Size(num_components);
+
 public:
    ROMLinearElement(TopologyHandler *topol_handler_,
                     const Array<FiniteElementSpace *> &fes_,

--- a/include/steady_ns_solver.hpp
+++ b/include/steady_ns_solver.hpp
@@ -60,7 +60,10 @@ protected:
    const int num_var = 2;
    int numSub = -1;
 
+   /* block offsets of velocity */
    Array<int> block_offsets;
+   /* block index of velocity on FOM variable */
+   Array<int> midxs;
    Array<Array<int> *> block_idxs;
    SparseMatrix *linearOp = NULL;
 
@@ -71,7 +74,7 @@ protected:
    HYPRE_BigInt sys_glob_size;
    mutable HYPRE_BigInt sys_row_starts[2];
 public:
-   SteadyNSROM(SparseMatrix *linearOp_, const int numSub_, const Array<int> &block_offsets_, const bool direct_solve_=true);
+   SteadyNSROM(const int numSub_, ROMHandlerBase *rom_handler, const bool direct_solve_=true);
 
    virtual ~SteadyNSROM();
 
@@ -85,8 +88,8 @@ protected:
    Array<DenseTensor *> hs; // not owned by SteadyNSTensorROM.
 
 public:
-   SteadyNSTensorROM(SparseMatrix *linearOp_, Array<DenseTensor *> &hs_, const Array<int> &block_offsets_, const bool direct_solve_=true)
-      : SteadyNSROM(linearOp_, hs_.Size(), block_offsets_, direct_solve_), hs(hs_) {}
+   SteadyNSTensorROM(ROMHandlerBase *rom_handler, Array<DenseTensor *> &hs_, const bool direct_solve_=true)
+      : SteadyNSROM(hs_.Size(), rom_handler, direct_solve_), hs(hs_) {}
 
    virtual ~SteadyNSTensorROM() {}
 
@@ -101,13 +104,12 @@ protected:
    ROMInterfaceForm *itf = NULL; // not owned by SteadyNSEQPROM.
 
    Array<int> u_offsets;
-   Array<int> u_idxs;
 
    mutable Vector x_u, y_u;
 
 public:
-   SteadyNSEQPROM(SparseMatrix *linearOp_, Array<ROMNonlinearForm *> &hs_, ROMInterfaceForm *itf_,
-                  const Array<int> &block_offsets_, const bool direct_solve_=true);
+   SteadyNSEQPROM(ROMHandlerBase *rom_handler, Array<ROMNonlinearForm *> &hs_,
+                  ROMInterfaceForm *itf_, const bool direct_solve_=true);
 
    virtual ~SteadyNSEQPROM() {}
 

--- a/include/unsteady_ns_solver.hpp
+++ b/include/unsteady_ns_solver.hpp
@@ -59,6 +59,10 @@ protected:
 
    BlockOperator *Hop = NULL;
 
+   /* mass matrix operator for ROM */
+   Array<int> rom_u_offsets;
+   BlockMatrix *rom_mass = NULL;
+
 public:
    UnsteadyNSSolver();
 
@@ -81,22 +85,20 @@ public:
 
    void SetParameterizedProblem(ParameterizedProblem *problem) override;
 
+   BlockVector* PrepareSnapshots(std::vector<BasisTag> &basis_tags) override;
+
    void ProjectOperatorOnReducedBasis() override
    { mfem_error("UnsteadyNSSolver::ProjectOperatorOnReducedBasis is not implemented yet!\n"); }
+
+   void BuildCompROMLinElems() override;
 
    void SolveROM() override
    { mfem_error("UnsteadyNSSolver::SolveROM is not implemented yet!\n"); }
 
+   void InitROMHandler() override;
+
    void BuildROMTensorElems() override
    { mfem_error("UnsteadyNSSolver::BuildROMTensorElems is not implemented yet!\n"); }
-   void TrainROMEQPElems(SampleGenerator *sample_generator) override
-   { mfem_error("UnsteadyNSSolver::TrainROMEQPElems is not implemented yet!\n"); }
-   void SaveROMNlinElems(const std::string &input_prefix) override
-   { mfem_error("UnsteadyNSSolver::SaveROMNlinElems is not implemented yet!\n"); }
-   void LoadROMNlinElems(const std::string &input_prefix) override
-   { mfem_error("UnsteadyNSSolver::LoadROMNlinElems is not implemented yet!\n"); }
-   void AssembleROMNlinOper() override
-   { mfem_error("UnsteadyNSSolver::AssembleROMNlinOper is not implemented yet!\n"); }
 
 private:
    void InitializeTimeIntegration();
@@ -112,6 +114,8 @@ private:
    }
    double ComputeCFL(const double dt);
    void SetTime(const double time);
+
+   void AssembleROMMat(BlockMatrix &romMat) override;
 
 };
 

--- a/include/unsteady_ns_solver.hpp
+++ b/include/unsteady_ns_solver.hpp
@@ -92,8 +92,7 @@ public:
 
    void BuildCompROMLinElems() override;
 
-   void SolveROM() override
-   { mfem_error("UnsteadyNSSolver::SolveROM is not implemented yet!\n"); }
+   void SolveROM() override;
 
    void InitROMHandler() override;
 

--- a/include/unsteady_ns_solver.hpp
+++ b/include/unsteady_ns_solver.hpp
@@ -59,6 +59,10 @@ protected:
 
    BlockOperator *Hop = NULL;
 
+   /* function coefficients for initial condition */
+   VectorCoefficient *u_ic = NULL;
+   VectorCoefficient *p_ic = NULL;
+
    /* mass matrix operator for ROM */
    Array<int> rom_u_offsets;
    BlockMatrix *rom_mass = NULL;
@@ -101,6 +105,7 @@ public:
 
 private:
    void InitializeTimeIntegration();
+   void SetupInitialCondition(int &initial_step, double &time);
    void Step(double &time, int step);
 
    void SanityCheck(const int step)

--- a/src/main_workflow.cpp
+++ b/src/main_workflow.cpp
@@ -288,12 +288,14 @@ void AuxiliaryTrainROM(MPI_Comm comm, SampleGenerator *sample_generator)
    bool separate_variable_basis = config.GetOption<bool>("model_reduction/separate_variable_basis", false);
 
    /* Supremizer enrichment */
-   if ((separate_variable_basis) && ((solver_type == "stokes") || (solver_type == "steady-ns")))
+   if ((separate_variable_basis) &&
+       ((solver_type == "stokes") || (solver_type == "steady-ns") || (solver_type == "unsteady-ns")))
    {
       ParameterizedProblem *problem = InitParameterizedProblem();
       StokesSolver *solver = NULL;
       if (solver_type == "stokes")           { solver = new StokesSolver; }
       else if (solver_type == "steady-ns")   { solver = new SteadyNSSolver; }
+      else if (solver_type == "unsteady-ns")   { solver = new UnsteadyNSSolver; }
 
       if (!solver->UseRom()) mfem_error("ROM must be enabled for supremizer enrichment!\n");
 

--- a/src/multiblock_solver.cpp
+++ b/src/multiblock_solver.cpp
@@ -283,17 +283,11 @@ void MultiBlockSolver::AssembleROMMat()
    for (int m = 0; m < numSub; m++)
    {
       int c_type = topol_handler->GetMeshType(m);
-      int num_block = 1;
-      int midx0 = m;
-      if (separate_variable_basis)
-      {
-         num_block *= num_var;
-         midx0 *= num_var;
-      }
+      int num_block = (separate_variable_basis) ? num_var : 1;
 
       Array<int> midx(num_block);
-      for (int k = 0; k < num_block; k++)
-         midx[k] = midx0 + k;
+      for (int v = 0; v < num_block; v++)
+         midx[v] = rom_handler->GetBlockIndex(m, v);
 
       MatrixBlocks *comp_mat = rom_elems->comp[c_type];
       AddToBlockMatrix(midx, midx, *comp_mat, *romMat);
@@ -325,32 +319,16 @@ void MultiBlockSolver::AssembleROMMat()
 
       const int m1 = pInfo->Mesh1;
       const int m2 = pInfo->Mesh2;
-      const int c1 = topol_handler->GetMeshType(m1);
-      const int c2 = topol_handler->GetMeshType(m2);
 
-      int num_block = 2;
-      int c1idx0 = c1, c2idx0 = c2;
-      int m1idx0 = m1, m2idx0 = m2;
-      if (separate_variable_basis)
-      {
-         num_block *= num_var;
-         c1idx0 *= num_var;
-         c2idx0 *= num_var;
-         m1idx0 *= num_var;
-         m2idx0 *= num_var;
-      }
+      int num_block = (separate_variable_basis) ? num_var : 1;
 
-      Array<int> midx(num_block), num_basis(num_block);
-      for (int k = 0, cidx = c1idx0, m = m1idx0; k < num_block/2; k++, cidx++, m++)
-      {
-         num_basis[k] = rom_handler->GetRefNumBasis(cidx);
-         midx[k] = m;
-      }
-      for (int k = num_block/2, cidx = c2idx0, m = m2idx0; k < num_block; k++, cidx++, m++)
-      {
-         num_basis[k] = rom_handler->GetRefNumBasis(cidx);
-         midx[k] = m;
-      }
+      Array<int> midx(0);
+
+      for (int v = 0; v < num_block; v++)
+         midx.Append(rom_handler->GetBlockIndex(m1, v));
+
+      for (int v = 0; v < num_block; v++)
+         midx.Append(rom_handler->GetBlockIndex(m2, v));
 
       AddToBlockMatrix(midx, midx, *port_mat, *romMat);
    }

--- a/src/rom_element_collection.cpp
+++ b/src/rom_element_collection.cpp
@@ -12,9 +12,13 @@ ROMLinearElement::ROMLinearElement(
    : ROMElementCollection(topol_handler_, fes_, separate_variable_)
 {
    comp.SetSize(num_comp);
+   mass.SetSize(num_comp);
    const int block_size = (separate_variable) ? num_var : 1;
    for (int c = 0; c < num_comp; c++)
+   {
       comp[c] = new MatrixBlocks(block_size, block_size);
+      mass[c] = new MatrixBlocks(block_size, block_size);
+   }
 
    bdr.SetSize(num_comp);
    for (int c = 0; c < num_comp; c++)
@@ -79,6 +83,8 @@ void ROMLinearElement::SaveCompBdrElems(hid_t &file_id)
       assert(comp_grp_id >= 0);
 
       hdf5_utils::WriteDataset(comp_grp_id, "domain", *comp[c]);
+
+      hdf5_utils::WriteDataset(comp_grp_id, "mass", *mass[c]);
 
       // boundaries are saved for each component group.
       SaveBdrElems(comp_grp_id, c);
@@ -181,6 +187,8 @@ void ROMLinearElement::LoadCompBdrElems(hid_t &file_id)
       assert(comp_grp_id >= 0);
 
       hdf5_utils::ReadDataset(comp_grp_id, "domain", *comp[c]);
+
+      hdf5_utils::ReadDataset(comp_grp_id, "mass", *mass[c]);
 
       // boundary
       LoadBdrElems(comp_grp_id, c);

--- a/src/sample_generator.cpp
+++ b/src/sample_generator.cpp
@@ -198,7 +198,8 @@ void SampleGenerator::SaveSnapshot(BlockVector *U_snapshots, std::vector<BasisTa
       assert(addSample);
 
       /* save the column index in each snapshot matrix, for port data. */
-      col_idxs[s] = snapshot_generators[index]->getNumSamples();
+      /* 0-based index */
+      col_idxs[s] = snapshot_generators[index]->getNumSamples() - 1;
    }
 }
 

--- a/src/stokes_solver.cpp
+++ b/src/stokes_solver.cpp
@@ -1018,6 +1018,7 @@ void StokesSolver::ProjectOperatorOnReducedBasis()
    Array2D<Array<int> *> ioffsets(numSub, numSub), joffsets(numSub, numSub);
    tmp = NULL; ioffsets = NULL; joffsets = NULL;
 
+   int ui, pi, uj, pj;
    for (int i = 0; i < numSub; i++)
       for (int j = 0; j < numSub; j++)
       {
@@ -1026,9 +1027,14 @@ void StokesSolver::ProjectOperatorOnReducedBasis()
 
          if (separate_variable_basis)
          {
-            tmp(i * num_var, j * num_var) = m_mats(i, j);
-            tmp(i * num_var + 1, j * num_var) = b_mats(i, j);
-            tmp(i * num_var, j * num_var + 1) = bt_mats(i, j);
+            ui = rom_handler->GetBlockIndex(i, 0);
+            pi = rom_handler->GetBlockIndex(i, 1);
+            uj = rom_handler->GetBlockIndex(j, 0);
+            pj = rom_handler->GetBlockIndex(j, 1);
+
+            tmp(ui, uj) = m_mats(i, j);
+            tmp(pi, uj) = b_mats(i, j);
+            tmp(ui, pj) = bt_mats(i, j);
          }
          else
          {

--- a/src/unsteady_ns_solver.cpp
+++ b/src/unsteady_ns_solver.cpp
@@ -32,7 +32,7 @@ UnsteadyNSSolver::UnsteadyNSSolver()
    if (time_order != 1)
       mfem_error("UnsteadyNSSolver supports only first-order time integration for now!\n");
 
-   if (!separate_variable_basis)
+   if (use_rom && !separate_variable_basis)
       mfem_error("UnsteadyNSSolver does not allow unified basis for all variables!\n");
 }
 

--- a/src/unsteady_ns_solver.cpp
+++ b/src/unsteady_ns_solver.cpp
@@ -106,20 +106,24 @@ bool UnsteadyNSSolver::Solve(SampleGenerator *sample_generator)
 
       cfl = ComputeCFL(dt);
       SanityCheck(step);
-      if (((step+1) % report_interval) == 0)
+      if (report_interval &&
+          ((step+1) % report_interval) == 0)
          printf("Time step: %05d, CFL: %.3e\n", step+1, cfl);
 
-      if (((step+1) % visual.time_interval) == 0)
+      if (visual.time_interval &&
+          ((step+1) % visual.time_interval) == 0)
          SaveVisualization(step+1, time);
 
-      if ((save_sol) && (((step+1) % restart_interval) == 0))
+      if (save_sol && restart_interval &&
+          (((step+1) % restart_interval) == 0))
       {
          restart_file = string_format(file_fmt, sol_dir.c_str(), sol_prefix.c_str(), step+1);
          SaveSolutionWithTime(restart_file, step+1, time);
       }
 
       /* save solution if sample generator is provided */
-      if (sample_generator && ((step+1) > bootstrap) && (((step+1) % sample_interval) == 0))
+      if (sample_generator && sample_interval &&
+          ((step+1) > bootstrap) && (((step+1) % sample_interval) == 0))
          SaveSnapshots(sample_generator);
    }
 

--- a/src/unsteady_ns_solver.cpp
+++ b/src/unsteady_ns_solver.cpp
@@ -184,13 +184,12 @@ void UnsteadyNSSolver::SetupInitialCondition(int &initial_step, double &time)
    }
    else
    {
-      assert(u_ic && p_ic);
-
-      for (int m = 0; m < numSub; m++)
-      {
-         vels[m]->ProjectCoefficient(*u_ic);
-         ps[m]->ProjectCoefficient(*p_ic);
-      }
+      if (u_ic && p_ic)
+         for (int m = 0; m < numSub; m++)
+         {
+            vels[m]->ProjectCoefficient(*u_ic);
+            ps[m]->ProjectCoefficient(*p_ic);
+         }
 
       initial_step = 0;
       time = 0.0;

--- a/test/gmsh/CMakeLists.txt
+++ b/test/gmsh/CMakeLists.txt
@@ -12,6 +12,7 @@ file(COPY test.component.yml DESTINATION ${CMAKE_BINARY_DIR}/test/gmsh/)
 file(COPY stokes.component.yml DESTINATION ${CMAKE_BINARY_DIR}/test/gmsh/)
 file(COPY steadyns.lf.yml DESTINATION ${CMAKE_BINARY_DIR}/test/gmsh/)
 file(COPY steadyns.interface_eqp.yml DESTINATION ${CMAKE_BINARY_DIR}/test/gmsh/)
+file(COPY usns.periodic.yml DESTINATION ${CMAKE_BINARY_DIR}/test/gmsh/)
 
 ADD_CUSTOM_COMMAND(
     OUTPUT ${CMAKE_BINARY_DIR}/test/gmsh/square-circle.msh

--- a/test/gmsh/test_multi_comp_workflow.cpp
+++ b/test/gmsh/test_multi_comp_workflow.cpp
@@ -440,12 +440,14 @@ TEST(UnsteadyNS_Workflow, Periodic)
    config.dict_["main"]["mode"] = "build_rom";
    BuildROM(MPI_COMM_WORLD);
 
-   // config.dict_["main"]["mode"] = "single_run";
-   // double error = SingleRun(MPI_COMM_WORLD, "test_output.h5");
+   config.dict_["main"]["mode"] = "single_run";
+   config.dict_["solver"]["use_restart"] = true;
+   config.dict_["solver"]["restart_file"] = "usns_restart_00000000.h5";
+   double error = SingleRun(MPI_COMM_WORLD, "test_output.h5");
 
-   // // This reproductive case must have a very small error at the level of finite-precision.
-   // printf("Error: %.15E\n", error);
-   // EXPECT_TRUE(error < ns_threshold);
+   // This reproductive case must have a very small error at the level of finite-precision.
+   printf("Error: %.15E\n", error);
+   EXPECT_TRUE(error < ns_threshold);
 
    return;
 }

--- a/test/gmsh/test_multi_comp_workflow.cpp
+++ b/test/gmsh/test_multi_comp_workflow.cpp
@@ -441,8 +441,8 @@ TEST(UnsteadyNS_Workflow, Periodic)
    BuildROM(MPI_COMM_WORLD);
 
    config.dict_["main"]["mode"] = "single_run";
-   config.dict_["solver"]["use_restart"] = true;
-   config.dict_["solver"]["restart_file"] = "usns_restart_00000000.h5";
+   // config.dict_["solver"]["use_restart"] = true;
+   // config.dict_["solver"]["restart_file"] = "usns_restart_00000000.h5";
    double error = SingleRun(MPI_COMM_WORLD, "test_output.h5");
 
    // This reproductive case must have a very small error at the level of finite-precision.

--- a/test/gmsh/test_multi_comp_workflow.cpp
+++ b/test/gmsh/test_multi_comp_workflow.cpp
@@ -420,6 +420,36 @@ TEST(MultiComponentGlobalROM, SteadyNSTest_SeparateVariable)
    return;
 }
 
+TEST(UnsteadyNS_Workflow, Periodic)
+{
+   config = InputParser("usns.periodic.yml");
+
+   printf("\nSample Generation \n\n");
+   
+   config.dict_["main"]["mode"] = "sample_generation";
+   GenerateSamples(MPI_COMM_WORLD);
+
+   config.dict_["main"]["mode"] = "train_rom";
+   TrainROM(MPI_COMM_WORLD);
+
+   config.dict_["main"]["mode"] = "train_eqp";
+   TrainEQP(MPI_COMM_WORLD);
+
+   printf("\nBuild ROM \n\n");
+
+   config.dict_["main"]["mode"] = "build_rom";
+   BuildROM(MPI_COMM_WORLD);
+
+   // config.dict_["main"]["mode"] = "single_run";
+   // double error = SingleRun(MPI_COMM_WORLD, "test_output.h5");
+
+   // // This reproductive case must have a very small error at the level of finite-precision.
+   // printf("Error: %.15E\n", error);
+   // EXPECT_TRUE(error < ns_threshold);
+
+   return;
+}
+
 int main(int argc, char* argv[])
 {
    ::testing::InitGoogleTest(&argc, argv);

--- a/test/gmsh/usns.periodic.yml
+++ b/test/gmsh/usns.periodic.yml
@@ -31,6 +31,11 @@ time-integration:
   timestep_size: 0.01
   number_of_timesteps: 3
 
+save_solution:
+  enabled: true
+  file_path:
+    prefix: usns_restart
+
 visualization:
   enable: false
   output_dir: dd_mms_output
@@ -87,4 +92,4 @@ model_reduction:
   compare_solution:
     enabled: true
   linear_solver_type: direct
-  linear_system_type: us
+  linear_system_type: sid

--- a/test/gmsh/usns.periodic.yml
+++ b/test/gmsh/usns.periodic.yml
@@ -32,7 +32,7 @@ time-integration:
   number_of_timesteps: 3
 
 save_solution:
-  enabled: true
+  enabled: false
   file_path:
     prefix: usns_restart
 

--- a/test/gmsh/usns.periodic.yml
+++ b/test/gmsh/usns.periodic.yml
@@ -1,0 +1,90 @@
+main:
+#mode: run_example/sample_generation/build_rom/single_run
+  mode: single_run
+  use_rom: true
+  solver: unsteady-ns
+
+navier-stokes:
+  operator-type: lf
+
+mesh:
+  type: component-wise
+  component-wise:
+    global_config: "box-channel.2x2.periodic.h5"
+    components:
+      - name: "empty"
+        file: "square.tri.mesh"
+      - name: "square-circle"
+        file: "square-circle.msh.mfem"
+
+domain-decomposition:
+  type: interior_penalty
+
+discretization:
+  order: 1
+  full-discrete-galerkin: true
+
+solver:
+  direct_solve: true
+
+time-integration:
+  timestep_size: 0.01
+  number_of_timesteps: 3
+
+visualization:
+  enable: false
+  output_dir: dd_mms_output
+
+parameterized_problem:
+  name: periodic_flow_past_array
+
+single_run:
+  periodic_flow_past_array:
+    nu: 1.1
+    fx: 0.5
+    fy: -0.5
+
+sample_generation:
+  maximum_number_of_snapshots: 400
+  file_path:
+    prefix: "usns0"
+  parameters:
+    - key: single_run/periodic_flow_past_array/nu
+      type: double
+      sample_size: 1
+      minimum: 1.1
+      maximum: 1.1
+  time-integration:
+    sample_interval: 1
+    bootstrap: 0
+
+sample_collection:
+  mode: port
+  port_fileformat:
+    format: usns%d_sample.port.h5
+    minimum: 0
+    maximum: 0
+
+basis:
+  prefix: "usns"
+  number_of_basis: 6
+  svd:
+    save_spectrum: true
+    update_right_sv: false
+  visualization:
+    enabled: false
+
+model_reduction:
+  separate_variable_basis: true
+  ordering: variable
+  nonlinear_handling: eqp
+  eqp:
+    relative_tolerance: 1.0e-11
+    precompute: true
+  save_operator:
+    level: component
+    prefix: "test.rom_elem"
+  compare_solution:
+    enabled: true
+  linear_solver_type: direct
+  linear_system_type: us


### PR DESCRIPTION
# ROMHandler block ordering

Previously, the blocks in the ROM system matrix are ordered by domain, i.e. for `m`-th subdomain and `v`-th variable, the block index is `v + m * num_var`.

Now block indexing supports two modes, specified by `enum class ROMOrderBy`:
- `ROMOrderBy::DOMAIN`: `v + m * num_var`
- `ROMOrderBy::VARIABLE`: `m + v * numSub`

This helps manipulating ROM matrix/vectors in the same way of FOM. Two auxiliary functions are also provided:

- `ROMHandlerBase:: GetBlockIndex`: from a domain and variable to block index
- `ROMHandlerBase::GetDomainAndVariableIndex`: from a block index to domain and variable

# `ROMHandler::SetRomMat`

`ROMHandler::SetRomMat` now skips the LU factorization only when specified. Currently it does not skip anywhere.

# mass matrix added in ROMLinearElement

`ROMLinearElement` now has the additional Matrix blocks for mass matrix. It can be created and saved only if needed.

# Unsteady NS equation ROM solver

The ROM workflow for unsteady NS equation solver is implemented and verified:
- `UnsteadyNSSolver::BuildCompROMLinElems`
- `UnsteadyNSSolver::AssembleROMMat`
- `UnsteadyNSSolver::SolveROM`