### PR TITLE
Installation in LC Dane

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,10 +43,10 @@ scaleupROM is mainly built upon [MFEM](https://mfem.org/) and [libROM](https://w
 
 See the [wiki page](https://github.com/LLNL/scaleupROM/wiki/Installation) for the detailed instruction.
 
-For LC quartz, the installation script is provided. You can simply run:
+For LC dane, the installation script is provided. You can simply run:
 
 ```
-./script/install_quartz.bash
+./script/install_dane.bash
 ```
 
 # Using Docker container

--- a/install-helper/libROM/CMakeLists.txt
+++ b/install-helper/libROM/CMakeLists.txt
@@ -38,6 +38,7 @@ set(module_list
   algo/DMDc
   algo/AdaptiveDMD
   algo/NonuniformDMD
+  algo/SnapshotDMD
   algo/DifferentialEvolution
   algo/greedy/GreedyCustomSampler
   algo/greedy/GreedyRandomSampler
@@ -45,6 +46,7 @@ set(module_list
   algo/manifold_interp/Interpolator
   algo/manifold_interp/MatrixInterpolator
   algo/manifold_interp/VectorInterpolator
+  algo/manifold_interp/PCHIPInterpolator
   hyperreduction/DEIM
   hyperreduction/GNAT
   hyperreduction/QDEIM
@@ -61,7 +63,7 @@ set(module_list
   utils/mpi_utils)
 set(source_files)
 foreach(module IN LISTS module_list)
-  list(APPEND source_files ${module}.cpp)
+  list(APPEND source_files ${module}.cpp ${module}.h)
 endforeach(module) # IN LISTS module_list
 
 list(APPEND source_files
@@ -141,3 +143,24 @@ target_include_directories(ROM PUBLIC
   ${MPI_C_INCLUDE_DIRS}
   ${MFEM_C_INCLUDE_DIRS}
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
+
+# Find headers from the source file list that need to be installed
+set(HEADERS "")
+foreach(file IN LISTS source_files)
+  if(file MATCHES ".(hpp|h)$")
+    list(APPEND HEADERS ${file})
+  endif()
+endforeach(file)
+
+# Only install libROM.so if installing to a different directory. Otherwise, libROM.so is already in lib/
+if (NOT ${CMAKE_INSTALL_PREFIX} STREQUAL ${CMAKE_BINARY_DIR})
+  install(TARGETS ROM EXPORT ROM LIBRARY DESTINATION lib INCLUDES DESTINATION include)
+endif()
+
+# Install libROM headers
+install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/CAROM_config.h ${CMAKE_CURRENT_SOURCE_DIR}/FCMangle.h DESTINATION include)
+foreach(file IN LISTS HEADERS)
+  # get the directory component so the include directory structure is preserved
+  get_filename_component(dir ${file} DIRECTORY)
+  install(FILES ${file} DESTINATION include/${dir})
+endforeach(file)

--- a/script/install_dane.bash
+++ b/script/install_dane.bash
@@ -89,6 +89,7 @@ fi
 cd $LIB_DIR
 if [ ! -d "mumps" ]; then
     git clone https://github.com/scivision/mumps.git
+    check_result $? mumps-clone
     cd ./mumps
     git checkout v5.6.2.1
     export tempMKLROOT=$MKLROOT
@@ -106,6 +107,7 @@ fi
 cd $LIB_DIR
 if [ ! -d "mfem" ]; then
     git clone https://github.com/mfem/mfem.git
+    check_result $? mfem-clone
     cd mfem
     git checkout v4.6
     mkdir -p ./build && cd ./build
@@ -121,6 +123,7 @@ fi
 cd $LIB_DIR
 if [ ! -d "yaml-cpp" ]; then
     git clone https://github.com/jbeder/yaml-cpp.git
+    check_result $? yaml-cpp-clone
     mkdir -p ./yaml-cpp/lib && cd ./yaml-cpp/lib
     cmake .. -DYAML_BUILD_SHARED_LIBS=on -DCMAKE_INSTALL_PREFIX=$LIB_DIR
     check_result $? yaml-config
@@ -133,6 +136,7 @@ fi
 cd $LIB_DIR
 if [ ! -d "googletest" ]; then
     git clone https://github.com/google/googletest
+    check_result $? googletest-clone
     cd ./googletest
     git checkout tags/release-1.12.1 -b v1.12.1
     mkdir ./build && cd ./build


### PR DESCRIPTION
Updated installation script and auxiliary files.

libROM `CMakeLists.txt` is updated from the most recent `master` branch of libROM. In order to use manually compiled scalapack, libROM `lib/CMakeLists.txt` should comment `find_package(MKL COMPONENTS BLACS ScaLAPACK)`.