### PR TITLE
Squared singular values in calculation of variance

### DIFF
--- a/include/sample_generator.hpp
+++ b/include/sample_generator.hpp
@@ -57,6 +57,7 @@ protected:
    int max_num_snapshots = 100;
    bool save_sv = false;
    bool update_right_SV = false;
+   bool square_sv = true;
    const bool incremental = false;
    Array<CAROM::Options*> snapshot_options;
    Array<CAROM::BasisGenerator*> snapshot_generators;

--- a/src/sample_generator.cpp
+++ b/src/sample_generator.cpp
@@ -68,6 +68,7 @@ SampleGenerator::SampleGenerator(MPI_Comm comm)
    // BasisGenerator options.
    update_right_SV = config.GetOption<bool>("basis/svd/update_right_sv", false);
    save_sv = config.GetOption<bool>("basis/svd/save_spectrum", false);
+   square_sv = config.GetOption<bool>("basis/svd/square_sv", true);
 }
 
 SampleGenerator::~SampleGenerator()
@@ -573,7 +574,8 @@ void SampleGenerator::SaveSV(CAROM::BasisGenerator *basis_generator, const std::
    for (int d = 0; d < rom_sv->dim(); d++)
    {
       if (d == ref_num_basis) coverage = total;
-      total += rom_sv->item(d);
+      const double s = rom_sv->item(d);
+      total += square_sv ? s * s : s;
    }
    if (rom_sv->dim() == ref_num_basis) coverage = total;
    coverage /= total;


### PR DESCRIPTION
Hi @dreamer2368 , I'm back!

Similar to https://github.com/LLNL/libROM/pull/306 this PR is a fix so that we use the squared singular values for the energy fraction calculation.

Example:
```
cd examples/poisson
../../bin/main -i poisson.full.yml -f main/mode=sample_generation

nb=1 # Number of bases in ROM

# Previous behavior
../../bin/main -i poisson.full.yml -f main/mode=train_rom:basis/svd/square_sv=false:basis/tags/0/number_of_basis=$nb:basis/tags/1/number_of_basis=$nb:basis/tags/2/number_of_basis=$nb:basis/tags/3/number_of_basis=$nb

# Current behavior
../../bin/main -i poisson.full.yml -f main/mode=train_rom:basis/tags/0/number_of_basis=$nb:basis/tags/1/number_of_basis=$nb:basis/tags/2/number_of_basis=$nb:basis/tags/3/number_of_basis=$nb
```

On my local device, the first training prints:
```
Singular values: 2.103E-01      1.928E-01       3.835E-02       8.536E-03       5.104E-04
Energy fraction with 1 basis: 46.6832645%
Creating file: poisson0_square-circle.000000
Singular values: 2.858E-01      1.391E-01       2.535E-02       2.736E-03       1.710E-04
Energy fraction with 1 basis: 63.0686903%
Creating file: poisson0_square-square.000000
Singular values: 3.545E-01      3.122E-01       6.106E-02       1.244E-02       6.307E-04
Energy fraction with 1 basis: 47.8501513%
Creating file: poisson0_square-star.000000
Singular values: 3.396E-01      3.038E-01       8.137E-02       2.957E-02       1.826E-03
Energy fraction with 1 basis: 44.9135469%
```

And the second one prints:
```
Singular values: 2.103E-01      1.928E-01       3.835E-02       8.536E-03       5.104E-04
Energy fraction with 1 basis: 53.3251752%
Creating file: poisson0_square-circle.000000
Singular values: 2.858E-01      1.391E-01       2.535E-02       2.736E-03       1.710E-04
Energy fraction with 1 basis: 80.3314430%
Creating file: poisson0_square-square.000000
Singular values: 3.545E-01      3.122E-01       6.106E-02       1.244E-02       6.307E-04
Energy fraction with 1 basis: 55.3531120%
Creating file: poisson0_square-star.000000
Singular values: 3.396E-01      3.038E-01       8.137E-02       2.957E-02       1.826E-03
Energy fraction with 1 basis: 53.6178019%
```
Let me know if you have any comments!

Best,
Axel